### PR TITLE
Add option to exit with nonzero exit code when warnings found

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -12,7 +12,7 @@ trap("INT") do
   exit!
 end
 
-Warnings_Found_Exit_Code = 3
+Brakeman::Warnings_Found_Exit_Code = 3
 
 #Parse command line options
 options = {}
@@ -149,7 +149,7 @@ OptionParser.new do |opts|
     end
   end
 
-  opts.on( "-s", "--exit-on-warn", "Exit code is non-zero if warnings found.") do |s|
+  opts.on( "-z", "--exit-on-warn", "Exit code is non-zero if warnings found.") do |s|
     options[:exit_on_warn] = s
   end
 
@@ -173,6 +173,6 @@ end.parse!(ARGV)
 clean = Brakeman.run options
 
 if options[:exit_on_warn] && !clean
-  exit Warnings_Found_Exit_Code
+  exit Brakeman::Warnings_Found_Exit_Code
 end
 

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -186,7 +186,7 @@ module Brakeman
     end
 
     if options[:exit_on_warn]
-      tracker.checks.warnings.each do |warning|
+      tracker.checks.all_warnings.each do |warning|
         next if warning.confidence > options[:min_confidence]
         return false
       end


### PR DESCRIPTION
We would like to be able to tell if brakeman ran cleanly, as in had no warnings above the specified warning thresh hold, or not by checking its exit code.

If this implementation is too invasive please let me know how you would prefer to see this implemented!

Thanks!
