### PR TITLE
Perfmon

### DIFF
--- a/conductor.rb
+++ b/conductor.rb
@@ -46,6 +46,16 @@ class Conductor
   #    }
   #
   def run_scans
+    @done = false
+    watcher = Thread.new do
+      until @done do
+        ps = "ps -p #{Process.pid} -opcpu | sed '1 d'"
+        ps_out = `#{ps}`
+        puts "\n#{Time.now} #{Process.times} #{Thread.list.count} threads #{ps_out}"
+        sleep 1
+      end
+    end
+
     @results[:start_time] = Time.now
 
     @results[:total_time] = Benchmark.measure do
@@ -74,7 +84,9 @@ class Conductor
       end
     end
 
+    @done = true
     @results[:end_time] = Time.now
+    watcher.join
 
     self
   end


### PR DESCRIPTION
Every second, print out the CPU usage and number of threads.  We could make this configurable, but its not for end users.  I've setup jobs to start monitoring the performance of brakeman against all rails apps on my box.  Will add more to this queue.
