### PR TITLE
Shaves 3 seconds off a large project, cleans up some code, review for si...

### DIFF
--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -71,6 +71,8 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
   end
 
   def check_for_immediate_xss exp
+    return if duplicate? exp
+
     if exp[0] == :output
       out = exp[1]
     elsif exp[0] == :escaped_output and raw_call? exp
@@ -79,7 +81,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
 
     type, match = has_immediate_user_input? out
 
-    if type and not duplicate? exp
+    if type
       add_result exp
       case type
       when :params
@@ -102,7 +104,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
     elsif not tracker.options[:ignore_model_output] and match = has_immediate_model?(out)
       method = match[2]
 
-      unless duplicate? out or IGNORE_MODEL_METHODS.include? method
+      unless IGNORE_MODEL_METHODS.include? method
         add_result out
 
         if MODEL_METHODS.include? method or method.to_s =~ /^find_by/

--- a/lib/brakeman/checks/check_link_to.rb
+++ b/lib/brakeman/checks/check_link_to.rb
@@ -34,6 +34,8 @@ class Brakeman::CheckLinkTo < Brakeman::CheckCrossSiteScripting
   end
 
   def process_result result
+    return if duplicate? result
+
     #Have to make a copy of this, otherwise it will be changed to
     #an ignored method call by the code above.
     call = result[:call] = result[:call].dup
@@ -58,19 +60,15 @@ class Brakeman::CheckLinkTo < Brakeman::CheckCrossSiteScripting
         message = "Unescaped user input value in link_to"
       end
 
-      unless duplicate? result
-        add_result result
-
-        warn :result => result,
-          :warning_type => "Cross Site Scripting", 
-          :message => message,
-          :confidence => CONFIDENCE[:high]
-      end
-
+      add_result result
+      warn :result => result,
+        :warning_type => "Cross Site Scripting", 
+        :message => message,
+        :confidence => CONFIDENCE[:high]
     elsif not tracker.options[:ignore_model_output] and match = has_immediate_model?(first_arg)
       method = match[2]
 
-      unless duplicate? result or IGNORE_MODEL_METHODS.include? method
+      unless IGNORE_MODEL_METHODS.include? method
         add_result result
 
         if MODEL_METHODS.include? method or method.to_s =~ /^find_by/
@@ -92,7 +90,7 @@ class Brakeman::CheckLinkTo < Brakeman::CheckCrossSiteScripting
         message = "Unescaped parameter value in link_to"
       end
 
-      if message and not duplicate? result
+      if message
         add_result result
 
         warn :result => result, 


### PR DESCRIPTION
...de effects

It seems like if the result is a duplicate, there's no reason to do any processing on it.  However, in applying the same logic to check_cross_site_scripting, I saw a case where it looked like changing the flow of the process_call method might have side effects.  

This saves 1-2 seconds on a large project, negligible on others 
