### PR TITLE
Use old ruby_parser (2.3.1) for Ruby 1.8 parsing

### DIFF
--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -1,7 +1,11 @@
 require 'rubygems'
 begin
-  #Load our own version of ruby_parser :'(
-  require 'ruby_parser/ruby_parser.rb'
+  if RUBY_VERSION =~ /^1\.9/
+    #Load our own version of ruby_parser :'(
+    require 'ruby_parser/ruby_parser.rb'
+  else
+    require 'ruby_parser'
+  end
 
   require 'haml'
   require 'sass'
@@ -47,7 +51,7 @@ class Brakeman::Scanner
     if RUBY_1_9
       @ruby_parser = ::Ruby19Parser
     else
-      @ruby_parser = ::Ruby18Parser
+      @ruby_parser = ::RubyParser
     end
   end
 

--- a/test/tests/test_brakeman.rb
+++ b/test/tests/test_brakeman.rb
@@ -1,13 +1,21 @@
 class UtilTests < Test::Unit::TestCase
+  def setup
+    if RUBY_VERSION =~ /^1\.9/
+      @ruby_parser = Ruby19Parser
+    else
+      @ruby_parser = RubyParser
+    end
+  end
+
   def util
     Class.new.extend Brakeman::Util
   end
 
   def test_cookies?
-    assert util.cookies?(Ruby18Parser.new.parse 'cookies[:x][:y][:z]')
+    assert util.cookies?(@ruby_parser.new.parse 'cookies[:x][:y][:z]')
   end
 
   def test_params?
-    assert util.params?(Ruby18Parser.new.parse 'params[:x][:y][:z]')
+    assert util.params?(@ruby_parser.new.parse 'params[:x][:y][:z]')
   end
 end


### PR DESCRIPTION
Confusingly, 1.8 support in ruby_parser has a bunch of regressions on the master branch.

This changes Brakeman so it uses the regular ruby_parser gem for Ruby 1.8 apps, but will still use the "vendored" ruby_parser for 1.9, since it has better support for 1.9 syntax.

This should fix a number of parsing issues people are seeing.
