### PR TITLE
Rescanning of templates doesn't pass through the same "filter" as the in...

### DIFF
--- a/lib/brakeman/rescanner.rb
+++ b/lib/brakeman/rescanner.rb
@@ -117,6 +117,8 @@ class Brakeman::Rescanner < Brakeman::Scanner
   end
 
   def rescan_template path
+    return unless path.match KNOWN_TEMPLATE_EXTENSIONS
+
     template_name = template_path_to_name(path)
 
     tracker.reset_template template_name

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -33,6 +33,7 @@ class Brakeman::Scanner
   attr_reader :options
 
   RUBY_1_9 = !!(RUBY_VERSION =~ /^1\.9/)
+  KNOWN_TEMPLATE_EXTENSIONS = /.*\.(erb|haml|rhtml)$/
 
   #Pass in path to the root of the Rails application
   def initialize options, processor = nil
@@ -298,7 +299,7 @@ class Brakeman::Scanner
   end
 
   def process_template path
-    type = path.match(/.*\.(erb|haml|rhtml)$/)[1].to_sym
+    type = path.match(KNOWN_TEMPLATE_EXTENSIONS)[1].to_sym
     type = :erb if type == :rhtml
     name = template_path_to_name path
     text = File.read path


### PR DESCRIPTION
...itial scan

/Users/neilm/workspace/brakeman/lib/brakeman/scanner.rb:302:in `process_template': undefined method`[]' for nil:NilClass (NoMethodError)

Debated between filtering this in the process_template method, decided to filter BEFORE calling process_template, decided to leave it here to bypass the other login in rescan_template
