### PR TITLE
Avoid rescanning deleted templates

### DIFF
--- a/lib/brakeman/rescanner.rb
+++ b/lib/brakeman/rescanner.rb
@@ -127,7 +127,7 @@ class Brakeman::Rescanner < Brakeman::Scanner
   end
 
   def rescan_template path
-    return unless path.match KNOWN_TEMPLATE_EXTENSIONS
+    return unless path.match KNOWN_TEMPLATE_EXTENSIONS and File.exist? path
 
     template_name = template_path_to_name(path)
 


### PR DESCRIPTION
In the case where
- A partial was rendered from a view
- The partial was changed
- The view where it was rendered was deleted
- The partial and the deleted view were supplied to Brakeman for rescanning

Then Brakeman attempted to rescan the delete view and failed.

So let's just check the file exists before rescanning a template - if the template was deleted as part of the changed files then it will be rescanned separately.
