### PR TITLE
Remove method_missing functionality from Sexp

### DIFF
--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -5,6 +5,11 @@ class Sexp
   attr_reader :paren
 
   def method_missing name, *args
+    #Brakeman does not use this functionality,
+    #so overriding it to raise a NoMethodError.
+    #
+    #The original functionality calls find_node and optionally
+    #deletes the node if found.
     raise NoMethodError.new("No method '#{name}' for Sexp", name, args)
   end
 
@@ -19,6 +24,12 @@ class Sexp
 
   def to_sym
     self.value.to_sym
+  end
+
+ def resbody delete = false
+    #RubyParser relies on method_missing for this, but since we don't want to use
+    #method_missing, here's a real method.
+    find_node :resbody, delete
   end
 
   alias :node_type :sexp_type


### PR DESCRIPTION
The original `Sexp` class has a "feature" where `method_missing` ends up being a call to `find_node`. `find_node` also has the "feature" of being able to delete nodes when they are found.

Brakeman does not use this feature, and the use of `method_missing` hides bugs since any method can be called on a `Sexp` instance without raising an exception. It's also super-confusing.

It appears that RubyParser uses this feature for calling exactly one method, `Sexp#resbody`, so I've just made that a regular method.
