### PR TITLE
add some consistency to the @ignore_methods in XSS checks

### DIFF
--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -35,13 +35,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
 
   #Run check
   def run_check
-    @ignore_methods = Set[:button_to, :check_box, :content_tag, :escapeHTML, :escape_once,
-                           :field_field, :fields_for, :h, :hidden_field,
-                           :hidden_field, :hidden_field_tag, :image_tag, :label,
-                           :link_to, :mail_to, :radio_button, :select,
-                           :submit_tag, :text_area, :text_field,
-                           :text_field_tag, :url_encode, :url_for,
-                           :will_paginate].merge tracker.options[:safe_methods]
+    @ignore_methods = ignore_methods(tracker.options[:safe_methods].merge(:link_to))
 
     @models = tracker.models.keys
     @inspect_arguments = tracker.options[:check_arguments]
@@ -292,5 +286,15 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
 
   def raw_call? exp
     exp.value.node_type == :call and exp.value.method == :raw
+  end
+
+  def ignore_methods extras
+    Set[:button_to, :check_box, :content_tag, :escapeHTML, :escape_once,
+      :field_field, :fields_for, :h, :hidden_field,
+      :hidden_field, :hidden_field_tag, :image_tag, :label,
+      :mail_to, :radio_button, :select,
+      :submit_tag, :text_area, :text_field,
+      :text_field_tag, :url_encode, :url_for,
+      :will_paginate].merge(extras)
   end
 end

--- a/lib/brakeman/checks/check_link_to.rb
+++ b/lib/brakeman/checks/check_link_to.rb
@@ -12,13 +12,7 @@ class Brakeman::CheckLinkTo < Brakeman::CheckCrossSiteScripting
   def run_check
     return unless version_between?("2.0.0", "2.9.9") and not tracker.config[:escape_html]
 
-    @ignore_methods = Set[:button_to, :check_box, :escapeHTML, :escape_once,
-                           :field_field, :fields_for, :h, :hidden_field,
-                           :hidden_field, :hidden_field_tag, :image_tag, :label,
-                           :mail_to, :radio_button, :select,
-                           :submit_tag, :text_area, :text_field,
-                           :text_field_tag, :url_encode, :url_for,
-                           :will_paginate].merge tracker.options[:safe_methods]
+    @ignore_methods = ignore_methods(tracker.options[:safe_methods])
 
     @known_dangerous = []
     #Ideally, I think this should also check to see if people are setting

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -12,13 +12,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
   @description = "Checks to see if values used for hrefs are sanitized using a :url_safe_method to protect against javascript:/data: XSS"
 
   def run_check
-    @ignore_methods = Set[:button_to, :check_box,
-                           :field_field, :fields_for, :hidden_field,
-                           :hidden_field, :hidden_field_tag, :image_tag, :label,
-                           :mail_to, :radio_button, :select,
-                           :submit_tag, :text_area, :text_field,
-                           :text_field_tag, :url_encode, :url_for,
-                           :will_paginate].merge(tracker.options[:url_safe_methods] || [])
+    @ignore_methods = Set[:url_encode, :url_for].merge(tracker.options[:url_safe_methods] || [])
 
     @models = tracker.models.keys
     @inspect_arguments = tracker.options[:check_arguments]


### PR DESCRIPTION
Thoughts:

link_to_href: putting buttons and stuff in there makes no sense, only URL encoding methods can surely be safe

link_to: almost identical, adds content_tag to the ignore list for this check.  Content tag method should catch it if it's dangerous?

cross_site_scripting: no change
