### PR TITLE
Add some OutputProcessor resilience

### DIFF
--- a/lib/brakeman/processors/output_processor.rb
+++ b/lib/brakeman/processors/output_processor.rb
@@ -10,7 +10,7 @@ class Brakeman::OutputProcessor < Ruby2Ruby
 
   #Copies +exp+ and then formats it.
   def format exp
-    process(exp.deep_clone) || ""
+    process(exp.deep_clone) || "[Format Error]"
   end
 
   alias process_safely format

--- a/test/tests/test_output_processor.rb
+++ b/test/tests/test_output_processor.rb
@@ -6,19 +6,19 @@ class OutputProcessorTests < Test::Unit::TestCase
   end
 
   def test_output_nil
-    assert_output "", nil
+    assert_output "[Format Error]", nil
   end
 
   def test_output_empty_sexp
-    assert_output "", Sexp.new
+    assert_output "[Format Error]", Sexp.new
   end
 
   def test_output_missing_node_type
-    assert_output "", Sexp.new(Sexp.new(:str, 'x'))
+    assert_output "[Format Error]", Sexp.new(Sexp.new(:str, 'x'))
   end
 
   def test_output_bad_node_type
-    assert_output "", Sexp.new(:bad_node_type)
+    assert_output "[Format Error]", Sexp.new(:bad_node_type)
   end
 
   def test_output_local_variable


### PR DESCRIPTION
While this is kind of putting a bandaid on issues like #53, Brakeman should recover properly from errors while formatting code (especially since the error is already being rescued...)

Instead of `OutputProcessor#format` returning `nil` when an error occurs or a `Sexp` is empty, it will now return an empty string. That way when the result of the call is used (e.g. in [warnings](https://github.com/presidentbeef/brakeman/blob/master/lib/brakeman/warning.rb#L77)) it will be safe to expect a string.

Also, tests! 
:joy_cat:

(While no one is probably wondering, `OutputProcessor#process_call` will likely be removed very soon in another pull request).
