### PR TITLE
Bug fix: `format_code': undefined method `gsub' for nil:NilClass (NoMeth...

### DIFF
--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -75,13 +75,13 @@ class Brakeman::Warning
   #Return String of the code output from the OutputProcessor and
   #stripped of newlines and tabs.
   def format_code
-    Brakeman::OutputProcessor.new.format(self.code).gsub(/(\t|\r|\n)+/, " ")
+    Brakeman::OutputProcessor.new.format(self.code).to_s.gsub(/(\t|\r|\n)+/, " ")
   end
 
   #Return String of the user input formatted and
   #stripped of newlines and tabs.
   def format_user_input
-    Brakeman::OutputProcessor.new.format(self.user_input).gsub(/(\t|\r|\n)+/, " ")
+    Brakeman::OutputProcessor.new.format(self.user_input).to_s.gsub(/(\t|\r|\n)+/, " ")
   end
 
   #Return formatted warning message


### PR DESCRIPTION
```
# brakeman .
Loading scanner...
[Notice] Using Ruby 1.9.3. Please make sure this matches the one used to run your Rails application.

...

 - CheckSQL
 - CheckStripTags
 - CheckTranslateBug
 - CheckValidationRegex
 - CheckWithoutProtection
Checks finished, collecting results...
Generating report...
/Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/lib/brakeman/warning.rb:78:in `format_code': undefined method `gsub' for nil:NilClass (NoMethodError)
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/lib/brakeman/warning.rb:98:in `format_message'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/lib/brakeman/warning.rb:125:in `to_row'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/lib/brakeman/report.rb:95:in `block in generate_warnings'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/lib/brakeman/report.rb:94:in `each'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/lib/brakeman/report.rb:94:in `generate_warnings'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/lib/brakeman/report.rb:379:in `to_s'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/lib/brakeman.rb:280:in `block in scan'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/lib/brakeman.rb:279:in `each'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/lib/brakeman.rb:279:in `scan'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/lib/brakeman.rb:56:in `run'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/gems/brakeman-1.8.0/bin/brakeman:63:in `<top (required)>'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/bin/brakeman:19:in `load'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/bin/brakeman:19:in `<main>'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/marocchino/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in `<main>'
brakeman .  35.33s user 0.43s system 98% cpu 36.397 total
```
