### PR TITLE
Do not process appending to HAML template variable

### DIFF
--- a/lib/brakeman/processors/haml_template_processor.rb
+++ b/lib/brakeman/processors/haml_template_processor.rb
@@ -74,7 +74,8 @@ class Brakeman::HamlTemplateProcessor < Brakeman::TemplateProcessor
       res
 
       #_hamlout.buffer <<
-      #This seems to be used rarely, but directly appends args to output buffer
+      #This seems to be used rarely, but directly appends args to output buffer.
+      #Has something to do with values of blocks?
     elsif sexp? target and method == :<< and is_buffer_target? target
       @inside_concat = true
       out = exp.arglist[1] = process(exp.arglist[1])

--- a/lib/brakeman/processors/template_alias_processor.rb
+++ b/lib/brakeman/processors/template_alias_processor.rb
@@ -96,11 +96,17 @@ class Brakeman::TemplateAliasProcessor < Brakeman::AliasProcessor
     false
   end
 
+  #Ignore `<<` calls on template variables which are used by the templating
+  #library (HAML, ERB, etc.)
   def find_push_target exp
     if sexp? exp
       if exp.node_type == :lvar and (exp.value == :_buf or exp.value == :_erbout)
         return nil
       elsif exp.node_type == :ivar and exp.value == :@output_buffer
+        return nil
+      elsif exp.node_type == :call and exp.target.node_type == :call and
+        exp.target.method == :_hamlout and exp.method == :buffer
+
         return nil
       end
     end


### PR DESCRIPTION
When Brakeman processes a call to `<<`, it treats the target like an array, if possible. We were already ignoring some variables used in the templates, but not one used by HAML. This was causing problems with some templates.

For example, some HAML will end up like this:

``` ruby
_hamlout.buffer << _hamlout.format_script_false_false_false_true_false_false_false(haml_temp);
```

This appears to happen when the return value of a block is output (just a guess). In any case, we should not treat `_hamlout.buffer` like an array (or string) when doing the alias processing. Just leave it alone.

This is for #168.
