### PR TITLE
Call indexing performance improvement

### DIFF
--- a/lib/brakeman/call_index.rb
+++ b/lib/brakeman/call_index.rb
@@ -106,7 +106,7 @@ class Brakeman::CallIndex
   def index_calls calls
     calls.each do |call|
       @methods << call[:method].to_s
-      @targets << call[:target].to_s
+      @targets << call[:target].to_s if call[:target].is_a? Symbol
       @calls_by_method[call[:method]] << call
       @calls_by_target[call[:target]] << call
     end


### PR DESCRIPTION
When generating the CallIndex, call targets are converted to strings. This is to allow matching of known call targets against regexes. However, Brakeman was converting _all_ call targets (including huge Sexps) to strings. This was taking up time and memory (I saw a big garbage collector improvement with this change) and it was pointless.

Should help with issue #171

One app I tested this on, which was taking a long time to index call sites, went from ~3.5 minutes to ~2 minutes.
