### PR TITLE
Ignore more Rails 2 route options

### DIFF
--- a/lib/brakeman/processors/lib/rails2_route_processor.rb
+++ b/lib/brakeman/processors/lib/rails2_route_processor.rb
@@ -112,7 +112,8 @@ class Brakeman::Rails2RoutesProcessor < Brakeman::BaseProcessor
     hash_iterate(exp) do |option, value|
       case option[1]
       when :controller, :requirements, :singular, :path_prefix, :as,
-        :path_names, :shallow, :name_prefix, :member_path, :nested_member_path
+        :path_names, :shallow, :name_prefix, :member_path, :nested_member_path,
+        :belongs_to, :conditions, :active_scaffold
         #should be able to skip
       when :collection, :member, :new
         process_collection value
@@ -129,7 +130,7 @@ class Brakeman::Rails2RoutesProcessor < Brakeman::BaseProcessor
       when :except
         process_option_except value
       else
-        Brakeman.notify "[Notice] Unhandled resource option: #{option}"
+        Brakeman.notice "[Notice] Unhandled resource option, please report: #{option}"
       end
     end
   end


### PR DESCRIPTION
Most route options do not affect Brakeman, but I'll keep the message just in case.
