### PR TITLE
more intuitive config locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Brakeman options can stored and read from YAML files. To simplify the process of
 
 Options passed in on the commandline have priority over configuration files.
 
-The default config locations are `./config.yaml`, `~/.brakeman/`, and `/etc/brakeman/config.yaml`
+The default config locations are `./config/brakeman.yml`, `~/.brakeman/config.yml`, and `/etc/brakeman/config.yml`
 
 The `-c` option can be used to specify a configuration file to use.
 


### PR DESCRIPTION
having a config.yaml in my project root tells me nothing about what it configures.

->  more standard `./config/brakeman.yml`

also renamed all configs from .yaml to .yml, which is the standard extension  afaik + extension used by rails

removed the ../lib/config.yaml since it was not there -> was not used

old configs will raise a descriptive error.
