### PR TITLE
Add Gemfile.lock for sane development

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,42 @@
+PATH
+  remote: .
+  specs:
+    brakeman (1.8.3)
+      activesupport
+      erubis (~> 2.6)
+      fastercsv (~> 1.5)
+      haml (~> 3.0)
+      highline (~> 1.6)
+      i18n
+      multi_json (~> 1.3)
+      ruby2ruby (~> 1.2)
+      ruby_parser (= 2.3.1)
+      sass (~> 3.0)
+      terminal-table (~> 1.4)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activesupport (3.2.9)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
+    erubis (2.7.0)
+    fastercsv (1.5.4)
+    haml (3.1.7)
+    highline (1.6.15)
+    i18n (0.6.1)
+    multi_json (1.3.7)
+    ruby2ruby (1.3.1)
+      ruby_parser (~> 2.0)
+      sexp_processor (~> 3.0)
+    ruby_parser (2.3.1)
+      sexp_processor (~> 3.0)
+    sass (3.2.1)
+    sexp_processor (3.2.0)
+    terminal-table (1.4.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  brakeman!


### PR DESCRIPTION
some people argue it should not be checked in to get more error reports,
but as a maintainer I do not want to get stuck in a place where tests are failing and I do not know why -> always have a set of know good dependencies

alternatively: add Gemfile.lock to .gitignore
