### PR TITLE
Ignore report file generated by tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+test/apps/rails3.2/report.json


### PR DESCRIPTION
Simple commit updating .gitignore. The file listed was the only file generated by `bundle exec rake` that then showed up as "new" in Git.
