### PR TITLE
Fix CheckExecute treating all string interps same

### DIFF
--- a/lib/brakeman/checks/check_execute.rb
+++ b/lib/brakeman/checks/check_execute.rb
@@ -43,7 +43,7 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
     if failure and not duplicate? result
       add_result result
 
-      if @string_interp
+      if failure.type == :interp #Not from user input
         confidence = CONFIDENCE[:med]
       else
         confidence = CONFIDENCE[:high]


### PR DESCRIPTION
and making user input medium confidence. Oops. Sorry, Travis. It was my fault, this time.
