### PR TITLE
Update ruby_parser to the lastest version (3.1.1)

### DIFF
--- a/brakeman.gemspec
+++ b/brakeman.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.add_dependency "activesupport"
   s.add_dependency "i18n"
-  s.add_dependency "ruby_parser", "~>3.0.4"
+  s.add_dependency "ruby_parser", "~>3.1.1"
   s.add_dependency "ruby2ruby", "~>2.0"
   s.add_dependency "terminal-table", "~>1.4"
   s.add_dependency "fastercsv", "~>1.5"


### PR DESCRIPTION
This fixes a conflict with the 'tomdoc' gem.
