### PR TITLE
Fix warning type for session settings

### DIFF
--- a/lib/brakeman/checks/check_session_settings.rb
+++ b/lib/brakeman/checks/check_session_settings.rb
@@ -106,7 +106,7 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
   end
 
   def warn_about_http_only value, file
-    warn :warning_type => "Session Setting",
+    warn :warning_type => "Session Settings",
       :message => "Session cookies should be set to HTTP only",
       :confidence => CONFIDENCE[:high],
       :line => value.line,
@@ -115,7 +115,7 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
   end
 
   def warn_about_secret_token value, file
-    warn :warning_type => "Session Setting",
+    warn :warning_type => "Session Settings",
       :message => "Session secret should not be included in version control",
       :confidence => CONFIDENCE[:high],
       :line => value.line,
@@ -123,7 +123,7 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
   end
 
   def warn_about_secure_only value, file
-    warn :warning_type => "Session Setting",
+    warn :warning_type => "Session Settings",
       :message => "Session cookie should be set to secure only",
       :confidence => CONFIDENCE[:high],
       :line => value.line,

--- a/test/tests/test_rails2.rb
+++ b/test/tests/test_rails2.rb
@@ -169,7 +169,7 @@ class Rails2Tests < Test::Unit::TestCase
 
   def test_session_secret
     assert_warning :type => :warning,
-      :warning_type => "Session Setting",
+      :warning_type => "Session Settings",
       :line => 9,
       :message => /^Session\ secret\ should\ not\ be\ included\ in/,
       :confidence => 0,
@@ -178,7 +178,7 @@ class Rails2Tests < Test::Unit::TestCase
 
   def test_session_cookies
     assert_warning :type => :warning,
-      :warning_type => "Session Setting",
+      :warning_type => "Session Settings",
       :line => 10,
       :message => /^Session cookies should be set to HTTP on/,
       :confidence => 0,

--- a/test/tests/test_rails3.rb
+++ b/test/tests/test_rails3.rb
@@ -824,7 +824,7 @@ class Rails3Tests < Test::Unit::TestCase
 
   def test_http_only_session_setting
     assert_warning :type => :warning,
-      :warning_type => "Session Setting",
+      :warning_type => "Session Settings",
       :line => 3,
       :message => /^Session\ cookies\ should\ be\ set\ to\ HTTP\ on/,
       :confidence => 0,
@@ -833,7 +833,7 @@ class Rails3Tests < Test::Unit::TestCase
 
   def test_secure_only_session_setting
     assert_warning :type => :warning,
-      :warning_type => "Session Setting",
+      :warning_type => "Session Settings",
       :line => 3,
       :message => /^Session\ cookie\ should\ be\ set\ to\ secure\ o/,
       :confidence => 0,
@@ -842,7 +842,7 @@ class Rails3Tests < Test::Unit::TestCase
 
   def test_session_secret_token
     assert_warning :type => :warning,
-      :warning_type => "Session Setting",
+      :warning_type => "Session Settings",
       :line => 7,
       :message => /^Session\ secret\ should\ not\ be\ included\ in/,
       :confidence => 0,

--- a/test/tests/test_rails31.rb
+++ b/test/tests/test_rails31.rb
@@ -784,7 +784,7 @@ class Rails31Tests < Test::Unit::TestCase
 
   def test_session_secret_token
     assert_warning :type => :warning,
-      :warning_type => "Session Setting",
+      :warning_type => "Session Settings",
       :line => 7,
       :message => /^Session\ secret\ should\ not\ be\ included\ in/,
       :confidence => 0,

--- a/test/tests/test_rails32.rb
+++ b/test/tests/test_rails32.rb
@@ -119,7 +119,7 @@ class Rails32Tests < Test::Unit::TestCase
 
   def test_session_secret_token
     assert_warning :type => :warning,
-      :warning_type => "Session Setting",
+      :warning_type => "Session Settings",
       :line => 7,
       :message => /^Session\ secret\ should\ not\ be\ included\ in/,
       :confidence => 0,

--- a/test/tests/test_rails_with_xss_plugin.rb
+++ b/test/tests/test_rails_with_xss_plugin.rb
@@ -277,7 +277,7 @@ class RailsWithXssPluginTests < Test::Unit::TestCase
 
   def test_session_secret_token
     assert_warning :type => :warning,
-      :warning_type => "Session Setting",
+      :warning_type => "Session Settings",
       :line => 9,
       :message => /^Session\ secret\ should\ not\ be\ included\ in/,
       :confidence => 0,


### PR DESCRIPTION
Because the link on the outputted report to reference URL is not found.
