### PR TITLE
Clarify 2.x warning for CVE-2013-0155

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -138,9 +138,15 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
   end
 
   def check_rails_version_for_cve_2013_0155
-    if version_between?("2.0.0", "2.3.15") || version_between?("3.0.0", "3.0.18") || version_between?("3.1.0", "3.1.9") || version_between?("3.2.0", "3.2.10")
+    if version_between?("3.0.0", "3.0.18") || version_between?("3.1.0", "3.1.9") || version_between?("3.2.0", "3.2.10")
+      message = 'All versions of Rails before 3.0.19, 3.1.10, and 3.2.11 contain a SQL Injection Vulnerability: CVE-2013-0155; Upgrade to 3.2.11, 3.1.10, 3.0.19'
+    elsif version_between?("2.0.0", "2.3.15")
+      message = "Rails #{@rails_version} contains a SQL Injection Vulnerability: CVE-2013-0155; Upgrade to 2.3.16"
+    end
+
+    if message
       warn :warning_type => 'SQL Injection',
-        :message => 'All versions of Rails before 3.0.19, 3.1.10, and 3.2.11 contain a SQL Injection Vulnerability: CVE-2013-0155; Upgrade to 3.2.11, 3.1.10, 3.0.19',
+        :message => message,
         :confidence => CONFIDENCE[:high],
         :file => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/topic/rubyonrails-security/c7jT-EeN9eI/discussion"

--- a/test/tests/test_rails2.rb
+++ b/test/tests/test_rails2.rb
@@ -789,7 +789,7 @@ class Rails2Tests < Test::Unit::TestCase
   def test_sql_injection_CVE_2013_0155
     assert_warning :type => :warning,
       :warning_type => "SQL Injection",
-      :message => /^All\ versions\ of\ Rails\ before\ 3\.0\.19,\ 3\.1/,
+      :message => /^Rails\ 2\.3\.11\ contains\ a\ SQL\ Injection\ Vu/,
       :confidence => 0,
       :file => /environment\.rb/
   end

--- a/test/tests/test_rails_with_xss_plugin.rb
+++ b/test/tests/test_rails_with_xss_plugin.rb
@@ -287,7 +287,7 @@ class RailsWithXssPluginTests < Test::Unit::TestCase
   def test_sql_injection_CVE_2013_0155
     assert_warning :type => :warning,
       :warning_type => "SQL Injection",
-      :message => /^All\ versions\ of\ Rails\ before\ 3\.0\.19,\ 3\.1/,
+      :message => /^Rails\ 2\.3\.14\ contains\ a\ SQL\ Injection\ Vu/,
       :confidence => 0,
       :file => /Gemfile/
   end


### PR DESCRIPTION
This will break anyone relying on the wording of the warning message, but it will affect at most one warning, so hopefully not too big of a problem.

This should help avoid issues like #251.
