### PR TITLE
Suggestion (update included): include file name with warnings

### DIFF
--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -92,13 +92,9 @@ class Brakeman::Warning
 
     @format_message = self.message.dup
 
-    if self.line
-      @format_message << " near line #{self.line}"
-    end
-
-    if self.code
-      @format_message << ": #{format_code}"
-    end
+    @format_message << " near line #{self.line}" if self.line
+    @format_message << " in file #{self.file}" if self.file
+    @format_message << ": #{format_code}" if self.code
 
     @format_message
   end


### PR DESCRIPTION
I was getting a security warning like this:

Session secret should not be included in version control near line 7 

-- which begged the question: in which file? Usually it would be config/initializers/secret_token.rb, of course, but I am a sporadic Rails developer, and don't always remember where everything is. I think it would help a lot to have the file named in the warning.
