### PR TITLE
Fix CSRF spelling inconsistency

### DIFF
--- a/lib/brakeman/checks/check_forgery_setting.rb
+++ b/lib/brakeman/checks/check_forgery_setting.rb
@@ -16,21 +16,21 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
       tracker.config[:rails][:action_controller][:allow_forgery_protection] == Sexp.new(:false)
 
       warn :controller => :ApplicationController,
-        :warning_type => "Cross-Site Request Forgery",
+        :warning_type => "Cross Site Request Forgery",
         :message => "Forgery protection is disabled", 
         :confidence => CONFIDENCE[:high]
 
     elsif app_controller and not app_controller[:options][:protect_from_forgery]
 
       warn :controller => :ApplicationController, 
-        :warning_type => "Cross-Site Request Forgery", 
+        :warning_type => "Cross Site Request Forgery", 
         :message => "'protect_from_forgery' should be called in ApplicationController", 
         :confidence => CONFIDENCE[:high]
 
     elsif version_between? "2.1.0", "2.3.10"
       
       warn :controller => :ApplicationController, 
-        :warning_type => "Cross-Site Request Forgery",
+        :warning_type => "Cross Site Request Forgery",
         :message => "CSRF protection is flawed in unpatched versions of Rails #{tracker.config[:rails_version]} (CVE-2011-0447). Upgrade to 2.3.11 or apply patches as needed",
         :confidence => CONFIDENCE[:high],
         :file => gemfile_or_environment,
@@ -39,7 +39,7 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
     elsif version_between? "3.0.0", "3.0.3"
 
       warn :controller => :ApplicationController, 
-        :warning_type => "Cross-Site Request Forgery",
+        :warning_type => "Cross Site Request Forgery",
         :message => "CSRF protection is flawed in unpatched versions of Rails #{tracker.config[:rails_version]} (CVE-2011-0447). Upgrade to 3.0.4 or apply patches as needed",
         :confidence => CONFIDENCE[:high],
         :file => gemfile_or_environment,


### PR DESCRIPTION
Being named Cross-Site Request Forgery (note the dash) is not consistent with Cross Site Scripting and the URL naming scheme at http://brakemanscanner.org/docs/warning_types/

Currently, CSRF warnings in an HTML report link to this broken URL: http://brakemanscanner.org/docs/warning_types/cross-site_request_forgery/ 
