### PR TITLE
Fix processing of production.rb in Rails 3

### DIFF
--- a/lib/brakeman/processors/lib/rails3_config_processor.rb
+++ b/lib/brakeman/processors/lib/rails3_config_processor.rb
@@ -29,9 +29,14 @@ class Brakeman::Rails3ConfigProcessor < Brakeman::BaseProcessor
 
   #Look for MyApp::Application.configure do ... end
   def process_iter exp
-    if node_type?(exp.block_call.target, :colon2) and exp.block_call.method == :Application
+    call = exp.block_call
+
+    if node_type?(call.target, :colon2) and
+      call.target.rhs == :Application and
+      call.method == :configure
+
       @inside_config = true
-      process_all exp.body if sexp? exp.body
+      process exp.block if sexp? exp.block
       @inside_config = false
     end
 

--- a/test/apps/rails3.2/config/application.rb
+++ b/test/apps/rails3.2/config/application.rb
@@ -51,7 +51,7 @@ module Rails32
     # This will create an empty whitelist of attributes available for mass-assignment for all models
     # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
     # parameters by using an attr_accessible or attr_protected declaration.
-    config.active_record.whitelist_attributes = true
+    config.active_record.whitelist_attributes = false
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/test/apps/rails3.2/config/environments/production.rb
+++ b/test/apps/rails3.2/config/environments/production.rb
@@ -64,4 +64,5 @@ Rails32::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
+  config.active_record.whitelist_attributes = true
 end

--- a/test/tests/test_mass_assign_disable.rb
+++ b/test/tests/test_mass_assign_disable.rb
@@ -40,7 +40,7 @@ class MassAssignDisableTest < Test::Unit::TestCase
   def test_strong_parameters_in_initializer
     init = "config/initializers/mass_assign.rb"
     gemfile = "Gemfile"
-    config = "config/application.rb"
+    config = "config/environments/production.rb"
 
     before_rescan_of [init, gemfile, config], "rails3.2" do
       write_file init, <<-RUBY

--- a/test/tests/test_rescanner.rb
+++ b/test/tests/test_rescanner.rb
@@ -172,7 +172,7 @@ class RescannerTests < Test::Unit::TestCase
   end
 
   def test_change_config
-    config = "config/application.rb"
+    config = "config/environments/production.rb"
 
     before_rescan_of config do
       replace config, "config.active_record.whitelist_attributes = true",


### PR DESCRIPTION
Bad test coverage meant a bug in processing of `config/environments/production.rb` was totally broken. Fixed now.
