### PR TITLE
Expand Haml dependency to 4.x

### DIFF
--- a/brakeman.gemspec
+++ b/brakeman.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "fastercsv", "~>1.5"
   s.add_dependency "highline", "~>1.6"
   s.add_dependency "erubis", "~>2.6"
-  s.add_dependency "haml", "~>3.0"
+  s.add_dependency "haml", ">=3.0", "<5.0"
   s.add_dependency "sass", "~>3.0"
   s.add_dependency "multi_json", "~>1.2"
 end


### PR DESCRIPTION
closes #263 

As far as I can tell, Haml 4 doesn't break anything with Brakeman.
