### PR TITLE
uninitialized constant Brakeman::RenderHelper

### DIFF
--- a/lib/brakeman/processors/slim_template_processor.rb
+++ b/lib/brakeman/processors/slim_template_processor.rb
@@ -1,4 +1,5 @@
 require 'brakeman/processors/template_processor'
+require 'brakeman/processors/lib/render_helper'
 
 class Brakeman::SlimTemplateProcessor < Brakeman::TemplateProcessor
   include Brakeman::RenderHelper


### PR DESCRIPTION
I have an error when launch brakeman :

```
/usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/lib/brakeman/processors/slim_template_processor.rb:4:in `<class:SlimTemplateProcessor>': uninitialized constant Brakeman::RenderHelper (NameError)
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/lib/brakeman/processors/slim_template_processor.rb:3:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/lib/brakeman/processor.rb:2:in `require'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/lib/brakeman/processor.rb:2:in `block in <top (required)>'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/lib/brakeman/processor.rb:2:in `each'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/lib/brakeman/processor.rb:2:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/lib/brakeman/scanner.rb:12:in `require'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/lib/brakeman/scanner.rb:12:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/lib/brakeman.rb:247:in `require'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/lib/brakeman.rb:247:in `scan'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/lib/brakeman.rb:57:in `run'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bundler/gems/brakeman-8edaba37e8e2/bin/brakeman:64:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bin/brakeman:19:in `load'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bin/brakeman:19:in `<main>'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bin/ruby_noexec_wrapper:14:in `eval'
    from /usr/local/rvm/gems/ruby-2.0.0-p0@xxx/bin/ruby_noexec_wrapper:14:in `<main>'
```

After this, I discovered that the way to require processors in lib/processor.rb is 

```
Dir.glob("#{File.expand_path(File.dirname(__FILE__))}/processors/*.rb")
```

and which cause my issue, because "render_helper" seems not required in some files which include it, so for now i just add 

```
require 'brakeman/processors/lib/render_helper'
```

to lib/brakeman/processors/slim_template_processor.rb

for a temperate fix, maybe there are some better ways to require it ?
