### PR TITLE
Don't warn when calling send on user input

### DIFF
--- a/lib/brakeman/checks/check_send.rb
+++ b/lib/brakeman/checks/check_send.rb
@@ -28,15 +28,5 @@ class Brakeman::CheckSend < Brakeman::BaseCheck
         :user_input => input.match,
         :confidence => CONFIDENCE[:high]
     end
-
-    if input = has_immediate_user_input?(target)
-      warn :result => result,
-        :warning_type => "Dangerous Send",
-        :warning_code => :dangerous_send,
-        :message => "User defined target of method invocation",
-        :code => result[:call],
-        :user_input => input.match,
-        :confidence => CONFIDENCE[:med]
-    end
   end
 end

--- a/test/tests/test_rails2.rb
+++ b/test/tests/test_rails2.rb
@@ -12,13 +12,13 @@ class Rails2Tests < Test::Unit::TestCase
         :controller => 1,
         :model => 3,
         :template => 41,
-        :warning => 42 }
+        :warning => 40 }
     else
       @expected ||= {
         :controller => 1,
         :model => 3,
         :template => 41,
-        :warning => 43 }
+        :warning => 41 }
     end
   end
 
@@ -753,7 +753,7 @@ class Rails2Tests < Test::Unit::TestCase
       :confidence => 0,
       :file => /home_controller\.rb/
 
-    assert_warning :type => :warning,
+    assert_no_warning :type => :warning,
       :warning_type => "Dangerous Send",
       :line => 90,
       :message => /\AUser defined target of method invocation/,
@@ -909,7 +909,7 @@ class Rails2Tests < Test::Unit::TestCase
   end
 
   def test_dangerous_try_on_user_input
-    assert_warning :type => :warning,
+    assert_no_warning :type => :warning,
       :warning_type => "Dangerous Send",
       :line => 160,
       :message => /^User\ defined\ target\ of\ method\ invocation/,


### PR DESCRIPTION
We have warnings for use of `constantize` and for using `send`/`try`/etc with user input for the method name. I don't think warning on user input as a target of these calls is helpful.
