### PR TITLE
Use custom deep_clone for Sexp

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -63,7 +63,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
 
     #Generic replace
     if replacement = env[exp] and not duplicate? replacement
-      result = set_line replacement.deep_clone, exp.line
+      result = replacement.deep_clone(exp.line)
     else
       result = exp
     end
@@ -578,20 +578,6 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     end
 
     meth_env
-  end
-
-  #Set line nunber for +exp+ and every Sexp it contains. Used when replacing
-  #expressions, so warnings indicate the correct line.
-  def set_line exp, line_number
-    if sexp? exp
-      exp.original_line(exp.original_line || exp.line)
-      exp.line line_number
-      exp.each do |e|
-        set_line e, line_number
-      end
-    end
-
-    exp
   end
 
   #Finds the inner most call target which is not the target of a call to <<

--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -14,6 +14,30 @@ class Sexp
     raise NoMethodError.new("No method '#{name}' for Sexp", name, args)
   end
 
+  #Create clone of Sexp and nested Sexps but not their non-Sexp contents.
+  #If a line number is provided, also sets line/original_line on all Sexps.
+  def deep_clone line = nil
+    s = Sexp.new
+
+    self.each do |e|
+      if e.is_a? Sexp
+        s << e.deep_clone(line)
+      else
+        s << e
+      end
+    end
+
+    if line
+      s.original_line(self.original_line || self.line)
+      s.line(line)
+    else
+      s.original_line(self.original_line)
+      s.line(self.line)
+    end
+
+    s
+  end
+
   def paren
     @paren ||= false
   end


### PR DESCRIPTION
I've been wanting to get rid of `Marshal.dump/load` for a while now. We don't really need full deep clones of Sexps, since the non-Sexp values should not change. But we do need clones of all the Sexps, if only to have correct line numbers.

This change also allows Brakeman to set the line numbers at the same time as cloning the Sexps, which avoids a second recursive trip through.

This approach is slightly faster (~10% in my testing).
