### PR TITLE
Refactor of check_link_to to improve code quality

### DIFF
--- a/lib/brakeman/checks/check_link_to.rb
+++ b/lib/brakeman/checks/check_link_to.rb
@@ -26,7 +26,7 @@ class Brakeman::CheckLinkTo < Brakeman::CheckCrossSiteScripting
     @models = tracker.models.keys
     @inspect_arguments = tracker.options[:check_arguments]
 
-    tracker.find_call(:target => false, :method => :link_to).map {|call| process_result call}
+    tracker.find_call(:target => false, :method => :link_to).each {|call| process_result call}
   end
 
   def process_result result


### PR DESCRIPTION
Hi, 

I really love Brakeman (tried to build one myself a couple of years ago, but unfortunately stopped because of time issues), but I saw you where having some code quality issues: https://codeclimate.com/github/presidentbeef/brakeman/Brakeman::CheckLinkTo#duplication . I'd be more then willing to help with this. I've started by reformatting one of the worst offenders (F).

All tests succeed and I tried not to change _any_ business logic while refactoring.
- Broke check_argument into smaller functions
- Removed warning code duplication
- Added some one liners to clarify logic
