### PR TITLE
Add check for unsafe symbol creation

### DIFF
--- a/lib/brakeman/checks/check_symbol_dos.rb
+++ b/lib/brakeman/checks/check_symbol_dos.rb
@@ -3,7 +3,7 @@ require 'brakeman/checks/base_check'
 class Brakeman::CheckSymbolDoS < Brakeman::BaseCheck
   Brakeman::Checks.add self
 
-  @description = "Checks for versions with ActiveRecord symbol denial of service" 
+  @description = "Checks for versions with ActiveRecord symbol denial of service, or code with a similar vulnerability"
 
   def run_check
     fix_version = case
@@ -14,10 +14,10 @@ class Brakeman::CheckSymbolDoS < Brakeman::BaseCheck
       when version_between?('3.2.0', '3.2.12')
         '3.2.13'
       else
-        return
+        nil
       end
 
-    unless active_record_models.empty?
+    if fix_version && active_record_models.any?
       warn :warning_type => "Denial of Service",
         :warning_code => :CVE_2013_1854,
         :message => "Rails #{tracker.config[:rails_version]} has a denial of service vulnerability in ActiveRecord: upgrade to #{fix_version} or patch",
@@ -25,5 +25,52 @@ class Brakeman::CheckSymbolDoS < Brakeman::BaseCheck
         :file => gemfile_or_environment,
         :link => "https://groups.google.com/d/msg/rubyonrails-security/jgJ4cjjS8FE/BGbHRxnDRTIJ"
     end
+
+    tracker.find_call(:methods => [:to_sym, :literal_to_sym], :nested => true).each do |result|
+      check_unsafe_symbol_creation(result)
+    end
+
   end
+
+  def check_unsafe_symbol_creation result
+
+    call = result[:call]
+    if result[:method] == :to_sym
+      args = [call.target]
+    else
+      args = call
+    end
+
+    if input = args.map{ |arg| has_immediate_user_input?(arg) }.compact.first
+      confidence = CONFIDENCE[:high]
+    elsif input = args.map{ |arg| include_user_input?(arg) }.compact.first
+      confidence = CONFIDENCE[:med]
+    end
+
+    if confidence
+      input_type = case input.type
+                   when :params
+                     "parameter value"
+                   when :cookies
+                     "cookies value"
+                   when :request
+                     "request value"
+                   when :model
+                     "model attribute"
+                   else
+                     "user input"
+                   end
+
+      message = "Symbol conversion from unsafe string (#{input_type})"
+
+      warn :result => result,
+        :warning_type => "Denial of Service",
+        :warning_code => :unsafe_symbol_creation,
+        :message => message,
+        :user_input => input.match,
+        :confidence => confidence
+    end
+
+  end
+
 end

--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -97,6 +97,23 @@ class Brakeman::FindAllCalls < Brakeman::BaseProcessor
     exp
   end
 
+  #:"string" is equivalent to "string".to_sym
+  def process_dsym exp
+    exp.each { |arg| process arg if sexp? arg }
+
+    call = { :target => nil, :method => :literal_to_sym, :call => exp, :nested => false }
+
+    if @current_template
+      call[:location] = [:template, @current_template]
+    else
+      call[:location] = [:class, @current_class, @current_method]
+    end
+
+    @calls << call
+
+    exp
+  end
+
   #Process an assignment like a call
   def process_attrasgn exp
     process_call exp

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -59,6 +59,7 @@ module Brakeman::WarningCodes
     :CVE_2013_1855 => 56,
     :CVE_2013_1856 => 57,
     :CVE_2013_1857 => 58,
+    :unsafe_symbol_creation => 59
   }
 
   def self.code name

--- a/test/apps/rails2/app/controllers/application_controller.rb
+++ b/test/apps/rails2/app/controllers/application_controller.rb
@@ -35,4 +35,11 @@ class ApplicationController < ActionController::Base
 
     return true
   end
+
+  def decent
+    if params[:thang] && self.respond_to?(params[:thang].to_sym)
+      :"really_#{params[:thang]}"
+    end
+  end
+
 end

--- a/test/tests/test_rails2.rb
+++ b/test/tests/test_rails2.rb
@@ -12,13 +12,13 @@ class Rails2Tests < Test::Unit::TestCase
         :controller => 1,
         :model => 3,
         :template => 43,
-        :warning => 41 }
+        :warning => 45 }
     else
       @expected ||= {
         :controller => 1,
         :model => 3,
         :template => 43,
-        :warning => 42 }
+        :warning => 46 }
     end
   end
 
@@ -961,4 +961,34 @@ class Rails2Tests < Test::Unit::TestCase
       :confidence => 0,
       :file => /home_controller\.rb/
   end
+
+  def test_unsafe_symbol_creation
+    [40,41].each do |line|
+      assert_warning :type => :warning,
+        :warning_type => "Denial of Service",
+        :line => line,
+        :message => /^Symbol\ conversion\ from\ unsafe\ string/,
+        :confidence => 0,
+        :file => /application_controller\.rb/
+     end
+  end
+
+  def test_unsafe_symbol_creation_2
+    assert_warning :type => :warning,
+      :warning_type => "Denial of Service",
+      :line => 83,
+      :message => /^Symbol\ conversion\ from\ unsafe\ string/,
+      :confidence => 0,
+      :file => /home_controller\.rb/
+  end
+
+  def test_unsafe_symbol_creation_3
+    assert_warning :type => :warning,
+      :warning_type => "Denial of Service",
+      :line => 29,
+      :message => /^Symbol\ conversion\ from\ unsafe\ string/,
+      :confidence => 1,
+      :file => /application_controller\.rb/
+  end
+
 end


### PR DESCRIPTION
Closes https://github.com/presidentbeef/brakeman/issues/293.

As suggested, I modified the parser so that it considers `:"foo_#{bar}_#{baz}"` to be a method call with `"foo"`, `bar`, and `baz` as arguments. To test I added both this form and `to_sym` to the Rails2 app, and checked that there was a warning for each error. Two additional (legitimate) warnings are generated by other code calling `to_sym` on user data.

Tested with ruby-1.8.7-p358 and ruby-1.9.3-p194.
