### PR TITLE
Always have tracker.config[:rails] by default

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -165,7 +165,6 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
     @mass_assign_disabled = false
 
     if version_between?("3.1.0", "3.9.9") and
-      tracker.config[:rails] and
       tracker.config[:rails][:active_record] and
       tracker.config[:rails][:active_record][:whitelist_attributes] == Sexp.new(:true)
 

--- a/lib/brakeman/checks/check_forgery_setting.rb
+++ b/lib/brakeman/checks/check_forgery_setting.rb
@@ -11,8 +11,7 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
 
   def run_check
     app_controller = tracker.controllers[:ApplicationController]
-    if tracker.config[:rails] and
-      tracker.config[:rails][:action_controller] and
+    if tracker.config[:rails][:action_controller] and
       tracker.config[:rails][:action_controller][:allow_forgery_protection] == Sexp.new(:false)
 
       warn :controller => :ApplicationController,

--- a/lib/brakeman/checks/check_session_settings.rb
+++ b/lib/brakeman/checks/check_session_settings.rb
@@ -17,9 +17,8 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
   end
 
   def run_check
-    settings = tracker.config[:rails] and
-                tracker.config[:rails][:action_controller] and
-                tracker.config[:rails][:action_controller][:session]
+    settings = tracker.config[:rails][:action_controller] &&
+               tracker.config[:rails][:action_controller][:session]
 
     check_for_issues settings, "#{tracker.options[:app_path]}/config/environment.rb"
 

--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -25,7 +25,7 @@ class Brakeman::Tracker
     @processor = processor
     @options = options
 
-    @config = {}
+    @config = { :rails => {} }
     @templates = {}
     @controllers = {}
     #Initialize models with the unknown model so


### PR DESCRIPTION
to avoid having to check for it and forgetting to.
