### PR TITLE
Remove "timestamp" field from JSON report

### DIFF
--- a/lib/brakeman/report.rb
+++ b/lib/brakeman/report.rb
@@ -629,7 +629,6 @@ HEADER
       :security_warnings => all_warnings.length,
       :start_time => tracker.start_time.to_s,
       :end_time => tracker.end_time.to_s,
-      :timestamp => tracker.end_time.to_s,
       :duration => tracker.duration,
       :checks_performed => checks.checks_run.sort,
       :number_of_controllers =>tracker.controllers.length,

--- a/test/tests/test_json_output.rb
+++ b/test/tests/test_json_output.rb
@@ -16,6 +16,14 @@ class JSONOutputTests < Test::Unit::TestCase
     assert (@json.keys - ["warnings", "scan_info", "errors"]).empty?
   end
 
+  def test_for_scan_info_keys
+    info_keys = ["app_path", "rails_version", "security_warnings", "start_time", "end_time", "duration",
+                 "checks_performed", "number_of_controllers", "number_of_models", "number_of_templates",
+                 "ruby_version", "brakeman_version"]
+
+    assert (@json["scan_info"].keys - info_keys).empty?
+  end
+
   def test_for_expected_warning_keys
     expected = ["warning_type", "message", "file", "link", "code", "location",
       "render_path", "user_input", "confidence", "line", "warning_code", "fingerprint"]


### PR DESCRIPTION
It is the same as "end_time"
