### PR TITLE
Update to Ruby2Ruby 2.0.5 and override process_defn

### DIFF
--- a/brakeman.gemspec
+++ b/brakeman.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.executables = ["brakeman"]
   s.license = "MIT"
   s.add_dependency "ruby_parser", "~>3.1.1"
-  s.add_dependency "ruby2ruby", "2.0.3"
+  s.add_dependency "ruby2ruby", "~>2.0.5"
   s.add_dependency "terminal-table", "~>1.4"
   s.add_dependency "fastercsv", "~>1.5"
   s.add_dependency "highline", "~>1.6.19"

--- a/test/test.rb
+++ b/test/test.rb
@@ -191,7 +191,7 @@ module BrakemanTester::RescanTestHelper
     output = yield parsed
 
     File.open path, "w" do |f|
-      f.puts Ruby2Ruby.new.process output
+      f.puts Brakeman::OutputProcessor.new.process output
     end
   end
 

--- a/test/tests/test_output_processor.rb
+++ b/test/tests/test_output_processor.rb
@@ -144,4 +144,21 @@ class OutputProcessorTests < Test::Unit::TestCase
                Sexp.new(:args),
                Sexp.new(:call, nil, :y))
   end
+
+  # Ruby2Ruby tries to convert some methods to attr_* calls,
+  # but it breaks some stuff because of how it accesses nodes.
+  # So we overwrite it.
+  def test_output_defn_not_attr
+    assert_output "def x\n  @x\nend",
+      Sexp.new(:defn,
+               :x,
+               Sexp.new(:args),
+               Sexp.new(:ivar, :@x))
+
+    assert_output "def x(y)\n  @x = (local y)\nend",
+      Sexp.new(:methdef,
+               :x,
+               Sexp.new(:args, :y),
+               Sexp.new(:iasgn, :@x, Sexp.new(:lvar, :y)))
+  end
 end


### PR DESCRIPTION
Brakeman was pinned to Ruby2Ruby 2.0.3 because [code introduced in 2.0.4](https://github.com/seattlerb/ruby2ruby/commit/1e001e3a2728925b998425b031a655eb104a5261#L0R338) uses `Sexp#args` (via `method_missing`) and that really conflicts with Brakeman's `Sexp#args` in a way that is not easily fixable.

However, since this behavior of Ruby2Ruby (converting methods that look like attr_\* methods _into_ attr_\* methods) is not terribly useful for Brakeman, I've copied `process_defn` from Ruby2Ruby modulo the converting part and now we can use the latest Ruby2Ruby.
