### PR TITLE
Use exit code of "1" when path is not a Rails app

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -75,4 +75,5 @@ begin
   end
 rescue Brakeman::Scanner::NoApplication => e
   $stderr.puts e.message
+  exit 1
 end


### PR DESCRIPTION
This was accidentally changed when switching away from using `abort` and towards using exceptions.

@noahd1, does this look okay?
