### PR TITLE
Relax slim dependency for Slim 2.0.0

### DIFF
--- a/brakeman.gemspec
+++ b/brakeman.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency "erubis", "~>2.6"
   s.add_dependency "haml", ">=3.0", "<5.0"
   s.add_dependency "sass", "~>3.0"
-  s.add_dependency "slim", "~>1.3.6"
+  s.add_dependency "slim", ">=1.3.6", "<3.0"
   s.add_dependency "multi_json", "~>1.2"
 end


### PR DESCRIPTION
Currently, if a project is using Slim 2.0.0, bundle update brakeman will not update to brakeman 2.0 because it's locked to 1.3.x.

This adjusts that to match the haml dependency.

Thanks,
Ian.
