### PR TITLE
Add right value to results in XSS check

### DIFF
--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -120,7 +120,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
                end
 
       unless IGNORE_MODEL_METHODS.include? method
-        add_result out
+        add_result exp
 
         if MODEL_METHODS.include? method or method.to_s =~ /^find_by/
           confidence = CONFIDENCE[:high]


### PR DESCRIPTION
This fixes the Travis test failures with 1.8.7.

The real root cause, though, is something more mysterious...which may forever remain a mystery because something as little as changing a variable name caused it to go away, so I'm not digging into it any further.
