### PR TITLE
Move NoApplication exception to Brakeman namespace

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -73,7 +73,7 @@ begin
       exit Brakeman::Warnings_Found_Exit_Code
     end
   end
-rescue Brakeman::Scanner::NoApplication => e
+rescue Brakeman::NoApplication => e
   $stderr.puts e.message
   exit 1
 end

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -368,4 +368,5 @@ module Brakeman
 
   class RakeInstallError < RuntimeError; end
   class NoBrakemanError < RuntimeError; end
+  class NoApplication < RuntimeError; end
 end

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -33,7 +33,7 @@ class Brakeman::Scanner
     @app_tree = Brakeman::AppTree.from_options(options)
 
     if !@app_tree.root || !@app_tree.exists?("app")
-      raise NoApplication, "Please supply the path to a Rails application."
+      raise Brakeman::NoApplication, "Please supply the path to a Rails application."
     end
 
     if @app_tree.exists?("script/rails")
@@ -355,6 +355,4 @@ class Brakeman::Scanner
   def parse_ruby input
     @ruby_parser.new.parse input
   end
-
-  class NoApplication < RuntimeError; end
 end

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -2,7 +2,7 @@ require 'tempfile'
 
 class BrakemanTests < Test::Unit::TestCase
   def test_exception_on_no_application
-    assert_raise Brakeman::Scanner::NoApplication do
+    assert_raise Brakeman::NoApplication do
       Brakeman.run "/tmp#{rand}" #better not exist
     end
   end


### PR DESCRIPTION
because it is masking some errors when the scanner has not been loaded yet and `bin/brakeman` tries to rescue an exception that has not been defined.
