### PR TITLE
Output JSON diff to file if -o option is used

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -59,7 +59,16 @@ end
 begin
   if options[:previous_results_json]
     vulns = Brakeman.compare options.merge(:quiet => options[:quiet])
-    puts MultiJson.dump(vulns, :pretty => true)
+
+    if options[:comparison_output_file]
+      File.open options[:comparison_output_file], "w" do |f|
+        f.puts MultiJson.dump(vulns, :pretty => true)
+      end
+
+      Brakeman.notify "Comparison saved in '#{options[:comparison_output_file]}'"
+    else
+      puts MultiJson.dump(vulns, :pretty => true)
+    end
 
     if options[:exit_on_warn] and (vulns[:new].count + vulns[:fixed].count > 0)
       exit Brakeman::Warnings_Found_Exit_Code

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -238,6 +238,10 @@ module Brakeman::Options
         parser.parse args
       end
 
+      if options[:previous_results_json] and options[:output_files]
+        options[:comparison_output_file] = options[:output_files].shift
+      end
+
       return options, parser
     end
   end


### PR DESCRIPTION
and also output regular reports if multiple -o options are given. But the first `-o` will always be used for the JSON diff output.
