### PR TITLE
Fix get version gemfile regexp and add tests

### DIFF
--- a/lib/brakeman/processors/gem_processor.rb
+++ b/lib/brakeman/processors/gem_processor.rb
@@ -40,11 +40,12 @@ class Brakeman::GemProcessor < Brakeman::BaseProcessor
 
     exp
   end
-
-  #Need to implement generic gem version check
+  
+  # Supports .rc2 but not ~>, >=, or <=
   def get_version name, gem_lock
-    match = gem_lock.match(/\s#{name} \((\d+.\d+.\d+.*)\)$/)
-    match[1] if match
+    if gem_lock =~ /\s#{name} \((\w(\.\w+)*)\)(?:\n|\r\n)/ 
+      $1
+    end 
   end
 
   def get_rails_version gem_lock


### PR DESCRIPTION
This hopefully fixes #359 by matching both end of line characters `\r\n` and `\n`.  Also added a fix for  matching variable length version numbers like `1.2` instead of just ones of length three like `1.2.3`.  

Do we need to support formats like these? 

```
haml (>= 3.0, < 5.0)
mime-types (>= 1.16)
ruby_parser (~> 3.1)
```
