### PR TITLE
use --message-limit in table output

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -41,7 +41,6 @@ module Brakeman
   #  * :safe_methods - array of methods to consider safe
   #  * :skip_libs - do not process lib/ directory (default: false)
   #  * :skip_checks - checks not to run (run all if not specified)
-  #  * :table_width - limit width of table in text report
   #  * :absolute_paths - show absolute path of each file (default: false)
   #  * :summary_only - only output summary section of report
   #                    (does not apply to tabs format)
@@ -127,7 +126,6 @@ module Brakeman
       :ignore_redirect_to_model => true,
       :ignore_model_output => false,
       :message_limit => 100,
-      :table_width => 80,
       :parallel_checks => true,
       :relative_path => false,
       :report_progress => true,

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -384,11 +384,13 @@ module Brakeman::Util
   end
 
   def truncate_table str
-    @terminal_width ||= if $stdin && $stdin.tty?
+    @terminal_width ||= if @tracker.options[:table_width]
+                          @tracker.options[:table_width]
+                        elsif $stdin && $stdin.tty?
                           Brakeman.load_brakeman_dependency 'highline'
                           ::HighLine.new.terminal_size[0]
                         else
-                          @tracker.options[:table_width]
+                          80
                         end
     lines = str.lines
 


### PR DESCRIPTION
this also changes the default width from 80 to 100 which might be undesirable, if it is a new option --table-width could be introduced or the default set to 80 which would affect the html renderer.
