### PR TITLE
Fixes for CheckModelAttrAccessible: consistency in Ruby 1.8 and new warning code

### DIFF
--- a/lib/brakeman/checks/check_model_attr_accessible.rb
+++ b/lib/brakeman/checks/check_model_attr_accessible.rb
@@ -27,6 +27,7 @@ class Brakeman::CheckModelAttrAccessible < Brakeman::BaseCheck
             warn :model => name,
               :file => model[:file],
               :warning_type => "Mass Assignment",
+              :warning_code => :dangerous_attr_accessible,
               :message => "Potentially dangerous attribute #{attribute} available for mass assignment.",
               :confidence => confidence
             break # Prevent from matching single attr multiple times

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -59,7 +59,8 @@ module Brakeman::WarningCodes
     :CVE_2013_1855 => 56,
     :CVE_2013_1856 => 57,
     :CVE_2013_1857 => 58,
-    :unsafe_symbol_creation => 59
+    :unsafe_symbol_creation => 59,
+    :dangerous_attr_accessible => 60
   }
 
   def self.code name

--- a/test/tests/rails32.rb
+++ b/test/tests/rails32.rb
@@ -215,6 +215,7 @@ class Rails32Tests < Test::Unit::TestCase
 
   def test_model_attr_accessible_admin
     assert_warning :type => :model,
+      :warning_code => 60,
       :warning_type => "Mass Assignment",
       :message => /^Potentially\ dangerous\ attribute\ admin/,
       :confidence => 0, #HIGH
@@ -223,14 +224,17 @@ class Rails32Tests < Test::Unit::TestCase
 
   def test_model_attr_accessible_account_id
     assert_warning :type => :model,
+      :warning_code => 60,
+      :fingerprint => "1d6615676c39afae6d749891e45d7351423542b3fe71a6eaf088bf7573e5c4b0",
       :warning_type => "Mass Assignment",
-      :message => /^Potentially\ dangerous\ attribute\ account_id/,
-      :confidence => 0, 
-      :file => /user\.rb/
+      :message => /^Potentially\ dangerous\ attribute\ account_/,
+      :confidence => 0,
+      :relative_path => "app/models/user.rb"
   end 
 
   def test_model_attr_accessible_account_banned
     assert_warning :type => :model,
+      :warning_code => 60,
       :warning_type => "Mass Assignment",
       :message => /^Potentially\ dangerous\ attribute\ banned/,
       :confidence => 1, #MED
@@ -239,6 +243,7 @@ class Rails32Tests < Test::Unit::TestCase
 
   def test_model_attr_accessible_status_id
     assert_warning :type => :model,
+      :warning_code => 60,
       :warning_type => "Mass Assignment",
       :message => /^Potentially\ dangerous\ attribute\ status_id/,
       :confidence => 2, #LOW


### PR DESCRIPTION
My mistake here. `CheckModelAttrAccessible` warnings should have used a new warning code when it was added.

Also, the comparisons are order-dependent, which is not guaranteed with Ruby 1.8 hashes and was causes build failures.
