### PR TITLE
rails 4 no warning for friendly model in redirect_to (friendly_id gem compatibility)

### DIFF
--- a/lib/brakeman/checks/check_redirect.rb
+++ b/lib/brakeman/checks/check_redirect.rb
@@ -128,7 +128,7 @@ class Brakeman::CheckRedirect < Brakeman::BaseCheck
     if node_type? exp, :or
       model_instance? exp.lhs or model_instance? exp.rhs
     elsif call? exp
-      if model_name? exp.target and
+      if model_name? exp.target or friendly_model? exp.target and
         (@model_find_calls.include? exp.method or exp.method.to_s.match(/^find_by_/))
         true
       else
@@ -137,6 +137,12 @@ class Brakeman::CheckRedirect < Brakeman::BaseCheck
     end
   end
 
+  #Returns true if exp is (probably) a friendly model instance
+  #using the FriendlyId gem
+  def friendly_model? exp
+    call? exp and model_name? exp.target and exp.method == :friendly
+  end
+  
   #Returns true if exp is (probably) a decorated model instance
   #using the Draper gem
   def decorated_model? exp

--- a/test/apps/rails4/app/controllers/friendly_controller.rb
+++ b/test/apps/rails4/app/controllers/friendly_controller.rb
@@ -1,0 +1,8 @@
+class FriendlyController
+ 
+  def find
+    @user = User.friendly.find(params[:id])
+    redirect_to @user
+  end
+  
+end


### PR DESCRIPTION
Fixes https://github.com/presidentbeef/brakeman/issues/399

Only Rails 4 app is affected. `Model.friendly` is treated like `Model` for determining if it is a model in `redirect_to` calls. 

Pretty codebase, btw!
