### PR TITLE
Reduce Slim-template XSS false positives

### DIFF
--- a/lib/brakeman/processors/slim_template_processor.rb
+++ b/lib/brakeman/processors/slim_template_processor.rb
@@ -96,7 +96,7 @@ class Brakeman::SlimTemplateProcessor < Brakeman::TemplateProcessor
   def is_escaped? exp
     call? exp and
     exp.target == TEMPLE_UTILS and
-    exp.method == :escape_html
+    (exp.method == :escape_html or exp.method == :escape_html_safe)
   end
 
   def render? exp


### PR DESCRIPTION
Recognize how slim sometimes outputs safe html (with `escape_html_safe`)

Reduces slim XSS false positives in cases where brakeman is run in the context of an app that includes active support.

Templates compile down to Template::Utils.escape_html_utils if Active Support's `html_safe?` method is defined.

See:

https://github.com/judofyr/temple/blob/master/lib/temple/filters/escapable.rb#L12
