### PR TITLE
Lowercase "reflection" in unsafe reflection warning

### DIFF
--- a/lib/brakeman/checks/check_unsafe_reflection.rb
+++ b/lib/brakeman/checks/check_unsafe_reflection.rb
@@ -7,7 +7,7 @@ require 'brakeman/checks/base_check'
 class Brakeman::CheckUnsafeReflection < Brakeman::BaseCheck
   Brakeman::Checks.add self
 
-  @description = "Checks for Unsafe Reflection"
+  @description = "Checks for unsafe reflection"
 
   def run_check
     reflection_methods = [:constantize, :safe_constantize, :const_get, :qualified_const_get]
@@ -38,7 +38,7 @@ class Brakeman::CheckUnsafeReflection < Brakeman::BaseCheck
     end
 
     if confidence
-      message = "Unsafe Reflection method #{method} called with #{friendly_type_of input}"
+      message = "Unsafe reflection method #{method} called with #{friendly_type_of input}"
 
       warn :result => result,
         :warning_type => "Remote Code Execution",

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -1105,7 +1105,7 @@ class Rails2Tests < Test::Unit::TestCase
     assert_warning :type => :warning,
       :warning_type => "Remote Code Execution",
       :line => 89,
-      :message => /^Unsafe\ Reflection\ method\ constantize\ cal/,
+      :message => /^Unsafe\ reflection\ method\ constantize\ cal/,
       :confidence => 0,
       :file => /home_controller\.rb/,
       :relative_path => "app/controllers/home_controller.rb"
@@ -1115,7 +1115,7 @@ class Rails2Tests < Test::Unit::TestCase
       :warning_code => 24,
       :warning_type => "Remote Code Execution",
       :line => 1,
-      :message => /^Unsafe\ Reflection\ method\ constantize\ cal/,
+      :message => /^Unsafe\ reflection\ method\ constantize\ cal/,
       :confidence => 0,
       :relative_path => "app/views/home/test_send_target.html.erb"
   end
@@ -1124,7 +1124,7 @@ class Rails2Tests < Test::Unit::TestCase
     assert_warning :type => :warning,
       :warning_type => "Remote Code Execution",
       :line => 160,
-      :message => /^Unsafe\ Reflection\ method\ constantize\ cal/,
+      :message => /^Unsafe\ reflection\ method\ constantize\ cal/,
       :confidence => 0,
       :file => /home_controller\.rb/,
       :relative_path => "app/controllers/home_controller.rb"

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -958,7 +958,7 @@ class Rails31Tests < Test::Unit::TestCase
     assert_warning :type => :warning,
       :warning_type => "Remote Code Execution",
       :line => 9,
-      :message => /^Unsafe\ Reflection\ method\ constantize\ cal/,
+      :message => /^Unsafe\ reflection\ method\ constantize\ cal/,
       :confidence => 0,
       :file => /admin_controller\.rb/
   end
@@ -968,7 +968,7 @@ class Rails31Tests < Test::Unit::TestCase
     assert_warning :type => :warning,
       :warning_type => "Remote Code Execution",
       :line => 12,
-      :message => /^Unsafe\ Reflection\ method\ safe_constantiz/,
+      :message => /^Unsafe\ reflection\ method\ safe_constantiz/,
       :confidence => 0,
       :file => /admin_controller\.rb/
   end
@@ -977,7 +977,7 @@ class Rails31Tests < Test::Unit::TestCase
     assert_warning :type => :warning,
       :warning_type => "Remote Code Execution",
       :line => 14,
-      :message => /^Unsafe\ Reflection\ method\ qualified_const/,
+      :message => /^Unsafe\ reflection\ method\ qualified_const/,
       :confidence => 0,
       :file => /admin_controller\.rb/
   end
@@ -987,7 +987,7 @@ class Rails31Tests < Test::Unit::TestCase
     assert_warning :type => :warning,
       :warning_type => "Remote Code Execution",
       :line => 16,
-      :message => /^Unsafe\ Reflection\ method\ const_get\ calle/,
+      :message => /^Unsafe\ reflection\ method\ const_get\ calle/,
       :confidence => 0,
       :file => /admin_controller\.rb/
   end
@@ -996,7 +996,7 @@ class Rails31Tests < Test::Unit::TestCase
     assert_warning :type => :warning,
       :warning_type => "Remote Code Execution",
       :line => 18,
-      :message => /^Unsafe\ Reflection\ method\ constantize\ cal/,
+      :message => /^Unsafe\ reflection\ method\ constantize\ cal/,
       :confidence => 1,
       :file => /admin_controller\.rb/
   end


### PR DESCRIPTION
"Unsafe Reflection" -> "Unsafe reflection"
