### PR TITLE
Stop raising exception in ProcessorHelper#class_name

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -432,13 +432,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
     if exp.is_a? Symbol
       @models.include? exp
     elsif sexp? exp
-      klass = nil
-      begin
-        klass = class_name exp
-      rescue StandardError
-      end
-
-      klass and @models.include? klass
+      @models.include? class_name(exp)
     else
       false
     end

--- a/lib/brakeman/processors/controller_processor.rb
+++ b/lib/brakeman/processors/controller_processor.rb
@@ -23,13 +23,7 @@ class Brakeman::ControllerProcessor < Brakeman::BaseProcessor
   #s(:class, NAME, PARENT, s(:scope ...))
   def process_class exp
     name = class_name(exp.class_name)
-
-    begin
-      parent = class_name exp.parent_name
-    rescue StandardError => e
-      Brakeman.debug e
-      parent = nil
-    end
+    parent = class_name(exp.parent_name)
 
     #If inside a real controller, treat any other classes as libraries.
     #But if not inside a controller already, then the class may include

--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -122,11 +122,7 @@ class Brakeman::FindAllCalls < Brakeman::BaseProcessor
       when :true, :false
         exp[0]
       when :colon2
-        begin
-          class_name exp
-        rescue StandardError
-          exp
-        end
+        class_name exp
       when :self
         @current_class || @current_module || nil
       else

--- a/lib/brakeman/processors/lib/processor_helper.rb
+++ b/lib/brakeman/processors/lib/processor_helper.rb
@@ -52,6 +52,7 @@ module Brakeman::ProcessorHelper
   end
 
   #Returns a class name as a Symbol.
+  #If class name cannot be determined, returns _exp_.
   def class_name exp
     case exp
     when Sexp
@@ -69,14 +70,14 @@ module Brakeman::ProcessorHelper
       when :self
         @current_class || @current_module || nil
       else
-        raise "Error: Cannot get class name from #{exp}"
+        exp
       end
     when Symbol
       exp
     when nil
       nil
     else
-      raise "Error: Cannot get class name from #{exp}"
+      exp
     end
   end
 end

--- a/lib/brakeman/processors/lib/render_helper.rb
+++ b/lib/brakeman/processors/lib/render_helper.rb
@@ -161,9 +161,10 @@ module Brakeman::RenderHelper
     if call? sexp
       get_class_target sexp.target
     else
-      begin
-        class_name sexp
-      rescue
+      klass = class_name sexp
+      if klass.is_a? Symbol
+        klass
+      else
         nil
       end
     end

--- a/lib/brakeman/processors/library_processor.rb
+++ b/lib/brakeman/processors/library_processor.rb
@@ -30,12 +30,7 @@ class Brakeman::LibraryProcessor < Brakeman::BaseProcessor
     if @tracker.libs[name]
       @current_class = @tracker.libs[name]
     else
-      begin
-        parent = class_name exp.parent_name
-      rescue StandardError => e
-        Brakeman.debug e
-        parent = nil
-      end
+      parent = class_name exp.parent_name
 
       @current_class = { :name => name,
                     :parent => parent,

--- a/lib/brakeman/processors/model_processor.rb
+++ b/lib/brakeman/processors/model_processor.rb
@@ -27,12 +27,7 @@ class Brakeman::ModelProcessor < Brakeman::BaseProcessor
       Brakeman.debug "[Notice] Skipping inner class: #{name}"
       ignore
     else
-      begin
-        parent = class_name exp.parent_name
-      rescue StandardError => e
-        Brakeman.debug e
-        parent = nil
-      end
+      parent = class_name exp.parent_name
 
       @model = { :name => name,
         :parent => parent,

--- a/lib/brakeman/processors/template_alias_processor.rb
+++ b/lib/brakeman/processors/template_alias_processor.rb
@@ -85,13 +85,8 @@ class Brakeman::TemplateAliasProcessor < Brakeman::AliasProcessor
 
       if exp.method == :all or exp.method.to_s[0,4] == "find"
         models = Set.new @tracker.models.keys
-
-        begin
-          name = class_name target
-          return target if models.include?(name)
-        rescue StandardError
-        end
-
+        name = class_name target
+        return target if models.include?(name)
       end
 
       return get_model_target(target)


### PR DESCRIPTION
Shouldn't affect much except there should be no more `Error: Cannot get class name from...` errors.
