### PR TITLE
Adds a check for OpenSSL::SSL::VERIFY_NONE.

### DIFF
--- a/lib/brakeman/checks/check_ssl_verify.rb
+++ b/lib/brakeman/checks/check_ssl_verify.rb
@@ -1,0 +1,31 @@
+require 'brakeman/checks/base_check'
+
+# Checks if verify_mode= is called with OpenSSL::SSL::VERIFY_NONE
+
+class Brakeman::CheckSSLVerify < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  SSL_VERIFY_NONE = s(:colon2, s(:colon2, s(:const, :OpenSSL), :SSL), :VERIFY_NONE)
+
+  @description = "Checks for OpenSSL::SSL::VERIFY_NONE"
+
+  def run_check
+    check_open_ssl_verify_none
+  end
+
+  def check_open_ssl_verify_none
+    tracker.find_call(:method => :verify_mode=).each {|call| process_result(call)}
+  end
+
+  def process_result(result)
+    return if duplicate?(result)
+    if result[:call].last_arg == SSL_VERIFY_NONE
+      add_result result
+      warn :result => result,
+        :warning_type => "SSL Verification Bypass",
+        :warning_code => :ssl_verification_bypass,
+        :message => "SSL certificate verification was bypassed",
+        :confidence => CONFIDENCE[:high]
+    end
+  end
+end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -71,6 +71,7 @@ module Brakeman::WarningCodes
     :CVE_2013_6416_call => 68,
     :CVE_2013_6417 => 69,
     :mass_assign_permit! => 70,
+    :ssl_verification_bypass => 71
   }
 
   def self.code name

--- a/test/apps/rails4/app/controllers/application_controller.rb
+++ b/test/apps/rails4/app/controllers/application_controller.rb
@@ -18,4 +18,9 @@ class ApplicationController < ActionController::Base
       redirect_to @model
     end
   end
+
+  def bypass_ssl_check
+    # Should warn on self.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    self.verify_mode = OpenSSL::SSL::VERIFY_NONE
+  end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 1,
       :template => 1,
-      :generic => 12
+      :generic => 13
     }
   end
 
@@ -257,5 +257,16 @@ class Rails4Tests < Test::Unit::TestCase
       :warning_code => 60,
       :message => "Potentially dangerous attribute available for mass assignment: :admin",
       :relative_path => "app/models/account.rb"
+  end
+
+  def test_ssl_verification_bypass
+    assert_warning :type => :warning,
+      :warning_code => 71,
+      :warning_type => "SSL Verification Bypass",
+      :line => 24,
+      :message => /^SSL\ certificate\ verification\ was\ bypassed/,
+      :confidence => 0,
+      :relative_path => "app/controllers/application_controller.rb",
+      :user_input => nil
   end
 end


### PR DESCRIPTION
This commit introduces a new check that creates a warning when it
detects a call to verify_mode= when the right hand of the assignment is
OpenSSL::SSL::VERIFY_NONE.

This addresses issue #250.
