### PR TITLE
Use an older version of RubyGems on Travis to fix 1.8.x issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ rvm:
   - "2.0.0"
   - "jruby-18mode"
   - "jruby-19mode"
+
+before_install:
+  - gem update --system 2.1.11
+  - gem --version


### PR DESCRIPTION
The Travis build is currently erroring due to an issue with RubyGems and 1.8.x/JRuby 1.8.x compat mode

https://github.com/bundler/bundler/issues/2784

This moves back to a version of RubyGems that works until a new version is released. Everything is back to green on my fork now

https://travis-ci.org/abedra/brakeman
