### PR TITLE
Ignore generators

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -71,7 +71,7 @@ module Brakeman
     end
 
     def lib_paths
-      @lib_files ||= find_paths("lib")
+      @lib_files ||= find_paths("lib").reject { |path| path.include? "/generators/" }
     end
 
   private

--- a/test/apps/rails2/lib/generators/test_generator/templates/model.rb
+++ b/test/apps/rails2/lib/generators/test_generator/templates/model.rb
@@ -1,0 +1,2 @@
+class <%= file_name.camelize %> < ActiveRecord::Base
+end


### PR DESCRIPTION
Especially since they are often ERB, not Ruby files even though they have an .rb extension, causing parse errors. Kind of surprised no one has ever complained about this.
