### PR TITLE
Ignore non-string gem names in Gemfile

### DIFF
--- a/lib/brakeman/processors/gem_processor.rb
+++ b/lib/brakeman/processors/gem_processor.rb
@@ -35,6 +35,8 @@ class Brakeman::GemProcessor < Brakeman::BaseProcessor
   def process_call exp
     if exp.target == nil and exp.method == :gem
       gem_name = exp.first_arg
+      return exp unless string? gem_name
+
       gem_version = exp.second_arg
 
       if string? gem_version

--- a/test/apps/rails4/Gemfile
+++ b/test/apps/rails4/Gemfile
@@ -25,6 +25,9 @@ gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.0.1'
 
+gem people do
+  strange things
+end
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 


### PR DESCRIPTION
Also, I found a repo that actually redefines Bundler's `gem` method. Awesome.
