### PR TITLE
Ignore identically rendered templates

### DIFF
--- a/lib/brakeman/processors/lib/render_helper.rb
+++ b/lib/brakeman/processors/lib/render_helper.rb
@@ -129,6 +129,14 @@ module Brakeman::RenderHelper
       #TODO: Add in :locals => { ... } to environment
       src = Brakeman::TemplateAliasProcessor.new(@tracker, template, called_from).process_safely(template[:src], template_env)
 
+      digest = Digest::SHA1.new.update(name + src.to_s).to_s.to_sym
+
+      if @tracker.template_cache.include? digest
+        return
+      else
+        @tracker.template_cache << digest
+      end
+
       #Run alias-processed src through the template processor to pull out
       #information and outputs.
       #This information will be stored in tracker.templates, but with a name


### PR DESCRIPTION
A given template (view) can be rendered many times, especially layouts and partials. But many times the rendered templates are identical. There's no need to store/process identically rendered templates.

This can greatly reduce memory usage and improve speed since Brakeman is no longer storing or processing duplicate templates once they are rendered.

A similar optimization has been in place for a long time to avoid rendering templates with the same values over and over, but this change is to not store templates that end up rendered the same, even with different values/environments.
