### PR TITLE
Only store original template outputs

### DIFF
--- a/lib/brakeman/processors/template_processor.rb
+++ b/lib/brakeman/processors/template_processor.rb
@@ -48,7 +48,7 @@ class Brakeman::TemplateProcessor < Brakeman::BaseProcessor
   #Adds output to the list of outputs.
   def process_output exp
     exp.value = process exp.value
-    @current_template[:outputs] << exp
+    @current_template[:outputs] << exp unless exp.original_line
     exp
   end
 


### PR DESCRIPTION
When storing outputs from templates, don't store outputs which are just interpolated values from alias processing. They are just duplicates taking up time and space.
