### PR TITLE
Reuse call locations in CallIndex

### DIFF
--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -9,6 +9,7 @@ class Brakeman::FindAllCalls < Brakeman::BaseProcessor
     @current_method = nil
     @in_target = false
     @calls = []
+    @cache = {}
   end
 
   #Process the given source. Provide either class and method being searched
@@ -145,11 +146,18 @@ class Brakeman::FindAllCalls < Brakeman::BaseProcessor
 
   def make_location
     if @current_template
-      { :type => :template,
+      key = [@current_template, @current_file]
+      cached = @cache[key]
+      return cached if cached
+
+      @cache[key] = { :type => :template,
         :template => @current_template,
         :file => @current_file }
     else
-      { :type => :class,
+      key = [@current_class, @current_method, @current_file]
+      cached = @cache[key]
+      return cached if cached
+      @cache[key] = { :type => :class,
         :class => @current_class,
         :method => @current_method,
         :file => @current_file }


### PR DESCRIPTION
For a large application many method calls will be in the same location (template or class+method), but each one will get a shiny new location hash even though they are identical. To shave off some memory usage, they will now have to share instead.
