### PR TITLE
February 18th CVEs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+# 2.4.1
+
+ * Add check for CVE-2014-0082
+ * Add check for CVE-2014-0081, replaces CVE-2013-6415
+ * Add check for CVE-2014-0080
+
 # 2.4.0 
 
  * Detect Rails LTS versions

--- a/lib/brakeman/version.rb
+++ b/lib/brakeman/version.rb
@@ -1,3 +1,3 @@
 module Brakeman
-  Version = "2.4.0"
+  Version = "2.4.1"
 end


### PR DESCRIPTION
Brakeman 2.4.1 was branched directly from 2.4.0 and only includes CVE checks. Need to merge back into master.
