### PR TITLE
Add :sanitize to IGNORE_METHODS_IN_SQL

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -540,7 +540,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     :sanitize_sql, :sanitize_sql_array, :sanitize_sql_for_assignment,
     :sanitize_sql_for_conditions, :sanitize_sql_hash,
     :sanitize_sql_hash_for_assignment, :sanitize_sql_hash_for_conditions,
-    :to_sql]
+    :to_sql, :sanitize]
 
   def safe_value? exp
     return true unless sexp? exp


### PR DESCRIPTION
`sanitize` delegates to `connection.quote`, so it seems like it should be included in IGNORE_METHODS_IN_SQL.
