### PR TITLE
Use SVG for status badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 ![Brakeman Logo](http://brakemanscanner.org/images/logo_medium.png)
 
-[![Travis CI
-Status](https://secure.travis-ci.org/presidentbeef/brakeman.png)](https://travis-ci.org/presidentbeef/brakeman)
-[![Code
-Climate](https://codeclimate.com/github/presidentbeef/brakeman.png)](https://codeclimate.com/github/presidentbeef/brakeman)
+[![Travis CI Status](https://img.shields.io/travis/presidentbeef/brakeman.svg)](https://travis-ci.org/presidentbeef/brakeman)
+[![Code Climate](https://img.shields.io/codeclimate/github/presidentbeef/brakeman.svg)](https://codeclimate.com/github/presidentbeef/brakeman)
 
 # Brakeman
 


### PR DESCRIPTION
http://shields.io/ provides many standardized badges for OSS. The PNG versions provided by Shields are similar to the images currently used, but the SVG versions added here are more legible on high pixel density displays.
