### PR TITLE
make sure ruby_parser is loaded before removing Regexp constants

### DIFF
--- a/lib/brakeman/processors/output_processor.rb
+++ b/lib/brakeman/processors/output_processor.rb
@@ -1,4 +1,5 @@
 #Temporary fix for https://github.com/seattlerb/ruby_parser/issues/154
+require 'ruby_parser'
 class Regexp
   [:ENC_NONE, :ENC_EUC, :ENC_SJIS, :ENC_UTF8].each do |enc|
     remove_const enc


### PR DESCRIPTION
The tool that runs brakeman for us requires `brakeman/checks` directly. Since `ruby_parser` isn't required yet when `processors/output_processor.rb` is required we get an error when the constants are being removed from `Regexp` because they aren't defined. This PR ensures that `ruby_parser` is required before trying to remove the constants from `Regexp.`
