### PR TITLE
Allow OutputProcessor to load before ruby_parser

### DIFF
--- a/lib/brakeman/processors/output_processor.rb
+++ b/lib/brakeman/processors/output_processor.rb
@@ -1,7 +1,7 @@
 #Temporary fix for https://github.com/seattlerb/ruby_parser/issues/154
 class Regexp
   [:ENC_NONE, :ENC_EUC, :ENC_SJIS, :ENC_UTF8].each do |enc|
-    remove_const enc
+    remove_const enc if const_defined? enc
   end
 end
 


### PR DESCRIPTION
as reported by @mastahyeti in #459.
