### PR TITLE
GitHub flavored markdown output

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -24,6 +24,7 @@ module Brakeman
   #  * :config_file - configuration file
   #  * :escape_html - escape HTML by default (automatic)
   #  * :exit_on_warn - return false if warnings found, true otherwise. Not recommended for library use (default: false)
+  #  * :github_repo - github repo to use for file links (user/repo[/path][@ref])
   #  * :highlight_user_input - highlight user input in reported warnings (default: true)
   #  * :html_style - path to CSS file
   #  * :ignore_model_output - consider models safe (default: false)
@@ -77,6 +78,7 @@ module Brakeman
 
     options[:app_path] = File.expand_path(options[:app_path])
     options[:output_formats] = get_output_formats options
+    options[:github_url] = get_github_url options
 
     options
   end
@@ -166,6 +168,8 @@ module Brakeman
       [:to_tabs]
     when :json, :to_json
       [:to_json]
+    when :markdown, :to_markdown
+      [:to_markdown]
     else
       [:to_s]
     end
@@ -185,12 +189,30 @@ module Brakeman
         :to_tabs
       when /\.json$/i
         :to_json
+      when /\.md$/i
+        :to_markdown
       else
         :to_s
       end
     end
   end
   private_class_method :get_formats_from_output_files
+
+  def self.get_github_url options
+    if github_repo = options[:github_repo]
+      full_repo, ref = github_repo.split '@', 2
+      name, repo, path = full_repo.split '/', 3
+      unless name && repo && !(name.empty? || repo.empty?)
+        raise ArgumentError, "Invalid GitHub repository format"
+      end
+      path.chomp '/' if path
+      ref ||= 'master'
+      ['https://github.com', name, repo, 'blob', ref, path].compact.join '/'
+    else
+      nil
+    end
+  end
+  private_class_method :get_github_url
 
   #Output list of checks (for `-k` option)
   def self.list_checks

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -142,7 +142,7 @@ module Brakeman::Options
 
         opts.on "-f",
           "--format TYPE",
-          [:pdf, :text, :html, :csv, :tabs, :json],
+          [:pdf, :text, :html, :csv, :tabs, :json, :markdown],
           "Specify output formats. Default is text" do |type|
 
           type = "s" if type == :text
@@ -158,7 +158,7 @@ module Brakeman::Options
         end
 
         opts.on "-I", "--interactive-ignore", "Interactively ignore warnings" do
-          options[:interactive_ignore] = true 
+          options[:interactive_ignore] = true
         end
 
         opts.on "-l", "--[no-]combine-locations", "Combine warning locations (Default)" do |combine|
@@ -196,6 +196,10 @@ module Brakeman::Options
 
         opts.on "--absolute-paths", "Output absolute file paths in reports" do
           options[:absolute_paths] = true
+        end
+
+        opts.on "--github-repo USER/REPO[/PATH][@REF]", "Output links to GitHub in markdown and HTML reports using specified repo" do |repo|
+          options[:github_repo] = repo
         end
 
         opts.on "-w",

--- a/lib/brakeman/report.rb
+++ b/lib/brakeman/report.rb
@@ -6,7 +6,7 @@ require 'brakeman/report/report_base'
 class Brakeman::Report
   attr_reader :tracker
 
-  VALID_FORMATS = [:to_html, :to_pdf, :to_csv, :to_json, :to_tabs, :to_hash, :to_s]
+  VALID_FORMATS = [:to_html, :to_pdf, :to_csv, :to_json, :to_tabs, :to_hash, :to_s, :to_markdown]
 
   def initialize app_tree, tracker
     @app_tree = app_tree
@@ -29,6 +29,8 @@ class Brakeman::Report
     when :to_hash
       require_report 'hash'
       Brakeman::Report::Hash
+    when :to_markdown
+      return self.to_markdown
     when :to_s
       return self.to_s
     when :to_pdf
@@ -60,6 +62,11 @@ class Brakeman::Report
   def to_s
     require_report 'table'
     generate Brakeman::Report::Table
+  end
+
+  def to_markdown
+    require_report 'markdown'
+    generate Brakeman::Report::Markdown
   end
 
   def generate reporter

--- a/lib/brakeman/report/report_html.rb
+++ b/lib/brakeman/report/report_html.rb
@@ -139,7 +139,7 @@ class Brakeman::Report::HTML < Brakeman::Report::Base
       message
     end <<
     "<table id='#{code_id}' class='context' style='display:none'>" <<
-    "<caption>#{warning_file(warning) || ''}</caption>"
+    "<caption>#{CGI.escapeHTML warning_file(warning) || ''}</caption>"
 
     unless context.empty?
       if warning.line - 1 == 1 or warning.line + 1 == 1
@@ -192,6 +192,11 @@ class Brakeman::Report::HTML < Brakeman::Report::Base
   #Escape warning message and highlight user input in HTML output
   def html_message warning, message
     message = CGI.escapeHTML(message)
+
+    if warning.file
+      github_url = github_url warning.file, warning.line
+      message.gsub!(/(near line \d+)/, "<a href='#{URI.escape github_url, /'/}' target='_blank'>\\1</a>") if github_url
+    end
 
     if @highlight_user_input and warning.user_input
       user_input = CGI.escapeHTML(warning.format_user_input)

--- a/lib/brakeman/report/report_markdown.rb
+++ b/lib/brakeman/report/report_markdown.rb
@@ -1,0 +1,158 @@
+Brakeman.load_brakeman_dependency 'terminal-table'
+
+class Brakeman::Report::Markdown < Brakeman::Report::Base
+
+  class MarkdownTable < Terminal::Table
+
+    def initialize options = {}, &block
+      options[:style] ||= {}
+      options[:style].merge!({
+          :border_x => '-',
+          :border_y => '|',
+          :border_i => '|'
+      })
+      super options, &block
+    end
+
+    def render
+      super.split("\n")[1...-1].join("\n")
+    end
+    alias :to_s :render
+
+  end
+
+  def generate_report
+    out = "# BRAKEMAN REPORT\n\n" <<
+    generate_metadata.to_s << "\n\n" <<
+    generate_checks.to_s << "\n\n" <<
+    "### SUMMARY\n\n" <<
+    generate_overview.to_s << "\n\n" <<
+    generate_warning_overview.to_s << "\n\n"
+
+    #Return output early if only summarizing
+    return out if tracker.options[:summary_only]
+
+    if tracker.options[:report_routes] or tracker.options[:debug]
+      out << "### CONTROLLERS"  << "\n\n" <<
+      generate_controllers.to_s << "\n\n"
+    end
+
+    if tracker.options[:debug]
+      out << "### TEMPLATES\n\n" <<
+      generate_templates.to_s << "\n\n"
+    end
+
+    res = generate_errors
+    out << "### Errors\n\n" << res.to_s << "\n\n" if res
+
+    res = generate_warnings
+    out << "### SECURITY WARNINGS\n\n" << res.to_s << "\n\n" if res
+
+    res = generate_controller_warnings
+    out << "### Controller Warnings:\n\n" << res.to_s << "\n\n" if res
+
+    res = generate_model_warnings
+    out << "### Model Warnings:\n\n" << res.to_s << "\n\n" if res
+
+    res = generate_template_warnings
+    out << "### View Warnings:\n\n" << res.to_s << "\n\n" if res
+
+    out
+  end
+
+  def generate_metadata
+    MarkdownTable.new(
+      :headings =>
+        ['Application path', 'Rails version', 'Brakeman version', 'Started at', 'Duration']
+    ) do |t|
+      t.add_row([
+        File.expand_path(tracker.options[:app_path]),
+        rails_version,
+        Brakeman::Version,
+        tracker.start_time,
+        "#{tracker.duration} seconds",
+      ])
+    end
+  end
+
+  def generate_checks
+    MarkdownTable.new(:headings => ['Checks performed']) do |t|
+      t.add_row([checks.checks_run.sort.join(", ")])
+    end
+  end
+
+  def generate_overview
+    num_warnings = all_warnings.length
+
+    MarkdownTable.new(:headings => ['Scanned/Reported', 'Total']) do |t|
+      t.add_row ['Controllers', tracker.controllers.length]
+      t.add_row ['Models', tracker.models.length - 1]
+      t.add_row ['Templates', number_of_templates(@tracker)]
+      t.add_row ['Errors', tracker.errors.length]
+      t.add_row ['Security Warnings', "#{num_warnings} (#{warnings_summary[:high_confidence]})"]
+      t.add_row ['Ignored Warnings', ignored_warnings.length] unless ignored_warnings.empty?
+    end
+  end
+
+  #Generate listings of templates and their output
+  def generate_templates
+    out_processor = Brakeman::OutputProcessor.new
+    template_rows = {}
+    tracker.templates.each do |name, template|
+      unless template[:outputs].empty?
+        template[:outputs].each do |out|
+          out = out_processor.format out
+          template_rows[name] ||= []
+          template_rows[name] << out.gsub("\n", ";").gsub(/\s+/, " ")
+        end
+      end
+    end
+
+    template_rows = template_rows.sort_by{|name, value| name.to_s}
+
+    output = ''
+    template_rows.each do |template|
+      output << template.first.to_s << "\n\n"
+      table = MarkdownTable.new(:headings => ['Output']) do |t|
+        # template[1] is an array of calls
+        template[1].each do |v|
+          t.add_row [v]
+        end
+      end
+
+      output << table.to_s << "\n\n"
+    end
+
+    output
+  end
+
+  def render_array template, headings, value_array, locals
+    return if value_array.empty?
+
+    MarkdownTable.new(:headings => headings) do |t|
+      value_array.each { |value_row| t.add_row value_row }
+    end
+  end
+
+  def convert_warning warning, original
+    warning["Confidence"] = TEXT_CONFIDENCE[warning["Confidence"]]
+    warning["Message"] = markdown_message original, warning["Message"]
+    warning["Warning Type"] = "[#{warning['Warning Type']}](#{original.link})" if original.link
+    warning
+  end
+
+  # Escape and code format warning message
+  def markdown_message warning, message
+    if warning.file
+      github_url = github_url warning.file, warning.line
+      message.gsub!(/(near line \d+)/, "[\\1](#{github_url})") if github_url
+    end
+    if warning.code
+      code = warning.format_code
+      message.gsub(code, "`#{code.gsub('`','``').gsub(/\A``|``\z/, '` `')}`")
+    else
+      message
+    end
+  end
+
+end

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -383,6 +383,15 @@ module Brakeman::Util
     end
   end
 
+  def github_url file, line=nil
+    if repo_url = @tracker.options[:github_url] and file and not file.empty? and file.start_with? '/'
+      url = "#{repo_url}/#{relative_path(file)}"
+      url << "#L#{line}" if line
+    else
+      nil
+    end
+  end
+
   def truncate_table str
     @terminal_width ||= if @tracker.options[:table_width]
                           @tracker.options[:table_width]

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -75,11 +75,11 @@ class BaseCheckTests < Test::Unit::TestCase
 end
 
 class ConfigTests < Test::Unit::TestCase
-  
+
   def setup
     Brakeman.instance_variable_set(:@quiet, false)
   end
-  
+
   # method from test-unit: http://test-unit.rubyforge.org/test-unit/en/Test/Unit/Util/Output.html#capture_output-instance_method
   def capture_output
     require 'stringio'
@@ -95,7 +95,7 @@ class ConfigTests < Test::Unit::TestCase
       $stdout, $stderr = stdout_save, stderr_save
     end
   end
-  
+
   def test_quiet_option_from_file
     config = Tempfile.new("config")
 
@@ -119,7 +119,7 @@ class ConfigTests < Test::Unit::TestCase
       assert final_options[:quiet], "Expected quiet option to be true, but was #{final_options[:quiet]}"
     }[1]
   end
-  
+
   def test_quiet_option_from_commandline
     config = Tempfile.new("config")
 
@@ -135,7 +135,7 @@ class ConfigTests < Test::Unit::TestCase
       :quiet => true,
       :app_path => "/tmp" #doesn't need to be real
     }
-    
+
     assert_equal "", capture_output {
       final_options = Brakeman.set_options(options)
     }[1]
@@ -184,13 +184,13 @@ class ConfigTests < Test::Unit::TestCase
       config.unlink
     }[1]
   end
-  
+
   def output_format_tester options, expected_options
     output_formats = Brakeman.get_output_formats(options)
-    
+
     assert_equal expected_options, output_formats
   end
-  
+
   def test_output_format
     output_format_tester({}, [:to_s])
     output_format_tester({:output_format => :html}, [:to_html])
@@ -203,15 +203,18 @@ class ConfigTests < Test::Unit::TestCase
     output_format_tester({:output_format => :to_json}, [:to_json])
     output_format_tester({:output_format => :tabs}, [:to_tabs])
     output_format_tester({:output_format => :to_tabs}, [:to_tabs])
+    output_format_tester({:output_format => :markdown}, [:to_markdown])
+    output_format_tester({:output_format => :to_markdown}, [:to_markdown])
     output_format_tester({:output_format => :others}, [:to_s])
-    
+
     output_format_tester({:output_files => ['xx.html', 'xx.pdf']}, [:to_html, :to_pdf])
     output_format_tester({:output_files => ['xx.pdf', 'xx.json']}, [:to_pdf, :to_json])
     output_format_tester({:output_files => ['xx.json', 'xx.tabs']}, [:to_json, :to_tabs])
     output_format_tester({:output_files => ['xx.tabs', 'xx.csv']}, [:to_tabs, :to_csv])
     output_format_tester({:output_files => ['xx.csv', 'xx.xxx']}, [:to_csv, :to_s])
+    output_format_tester({:output_files => ['xx.md', 'xx.xxx']}, [:to_markdown, :to_s])
     output_format_tester({:output_files => ['xx.xx', 'xx.xx']}, [:to_s, :to_s])
-    output_format_tester({:output_files => ['xx.html', 'xx.pdf', 'xx.csv', 'xx.tabs', 'xx.json']}, [:to_html, :to_pdf, :to_csv, :to_tabs, :to_json])
+    output_format_tester({:output_files => ['xx.html', 'xx.pdf', 'xx.csv', 'xx.tabs', 'xx.json', 'xx.md']}, [:to_html, :to_pdf, :to_csv, :to_tabs, :to_json, :to_markdown])
   end
 end
 
@@ -222,22 +225,22 @@ class GemProcessorTests < Test::Unit::TestCase
     assert_equal version, @tracker[:config][:gems][name], msg
   end
 
-  def setup 
+  def setup
     @tracker = FakeTracker.new({}, {})
-    @gem_processor = Brakeman::GemProcessor.new @tracker 
-    @eol_representations = ["\r\n", "\n"] 
-    @gem_locks = @eol_representations.inject({}) {|h, eol| 
-      h[eol] = "    paperclip (3.2.1)#    erubis (4.3.1)#     rails (3.2.1.rc2)#    simplecov (1.1)#".gsub('#', eol); h 
+    @gem_processor = Brakeman::GemProcessor.new @tracker
+    @eol_representations = ["\r\n", "\n"]
+    @gem_locks = @eol_representations.inject({}) {|h, eol|
+      h[eol] = "    paperclip (3.2.1)#    erubis (4.3.1)#     rails (3.2.1.rc2)#    simplecov (1.1)#".gsub('#', eol); h
     }
-  end 
+  end
 
   def test_gem_lock_parsing
     @gem_locks.each do |eol, gem_lock|
       @gem_processor.process_gems Sexp.new(:block), gem_lock
       assert_version "4.3.1", :erubis, "Couldn't match gemlock with eol: #{eol}"
       assert_version "3.2.1", :paperclip, "Couldn't match gemlock with eol: #{eol}"
-      assert_version "3.2.1.rc2", :rails, "Couldn't match gemlock with eol: #{eol}"  
+      assert_version "3.2.1.rc2", :rails, "Couldn't match gemlock with eol: #{eol}"
       assert_version "1.1", :simplecov, "Couldn't match gemlock with eol: #{eol}"
-    end 
-  end 
-end 
+    end
+  end
+end

--- a/test/tests/markdown_output.rb
+++ b/test/tests/markdown_output.rb
@@ -1,0 +1,11 @@
+class TestMarkdownOutput < Test::Unit::TestCase
+  Report = Brakeman.run(:app_path => "#{TEST_PATH}/apps/rails2", :quiet => true).report.to_markdown
+
+  def test_reported_warnings
+    if Brakeman::Scanner::RUBY_1_9
+      assert_equal 164, Report.lines.to_a.count
+    else
+      assert_equal 165, Report.lines.to_a.count
+    end
+  end
+end

--- a/test/tests/report_generation.rb
+++ b/test/tests/report_generation.rb
@@ -40,6 +40,12 @@ class TestReportGeneration < Test::Unit::TestCase
     assert report.is_a? String
   end
 
+  def test_markdown_sanity
+    report = Report.to_markdown
+
+    assert report.is_a? String
+  end
+
   def test_bad_format_type
     assert_raises RuntimeError do
       Report.format(:to_something_else)
@@ -48,7 +54,7 @@ class TestReportGeneration < Test::Unit::TestCase
 
   def test_controller_output
     text_report = Report.to_s
-    
+
     assert text_report.include? "+CONTROLLERS+"
 
     html_report = Report.to_html


### PR DESCRIPTION
This adds GFM output format for reports (closes https://github.com/presidentbeef/brakeman/issues/435). This can be triggered with `-f markdown` or `-o file.md` flags or programmatically with `Brakeman::Report#to_markdown`.

Additionally, the `github-repo` flag / option has been added. 

```
--github-repo USER/REPO[/PATH][@REF]
               Output links to GitHub in markdown and HTML reports using specified repo
```

This allows a user to set the app's GitHub repository (user/repo) and optionally, application path within the repo and git ref (sha, tag, branch). This is used to generate links within the GFM and HTML reports to the file and line on GitHub for each warning with file info.

As an example, `brakeman -o test.md test/apps/rails3 --github-repo github/brakeman/test/apps/rails3` yields the report at https://gist.github.com/gregose/e7f1cc43263054bccd6d.

https://github.com/github/brakeman/commit/e2d3781ad58d2c1f81d45498ae3e012b7bd6e620 also closes a potential existing XSS in the HTML report by escaping the filename.

/cc @mastahyeti 
