### PR TITLE
Avoid warning on redirects when :host is specified

### DIFF
--- a/lib/brakeman/checks/check_redirect.rb
+++ b/lib/brakeman/checks/check_redirect.rb
@@ -31,7 +31,11 @@ class Brakeman::CheckRedirect < Brakeman::BaseCheck
 
     method = call.method
 
-    if method == :redirect_to and not only_path?(call) and res = include_user_input?(call)
+    if method == :redirect_to and
+        not only_path?(call) and
+        not explicit_host?(call) and
+        res = include_user_input?(call)
+
       add_result result
 
       if res.type == :immediate
@@ -104,6 +108,16 @@ class Brakeman::CheckRedirect < Brakeman::BaseCheck
       end
     elsif call? arg and arg.method == :url_for
       return check_url_for(arg)
+    end
+
+    false
+  end
+
+  def explicit_host? call
+    arg = call.first_arg
+
+    if hash? arg and value = hash_access(arg, :host)
+      return !has_immediate_user_input?(value)
     end
 
     false

--- a/test/apps/rails4/app/controllers/friendly_controller.rb
+++ b/test/apps/rails4/app/controllers/friendly_controller.rb
@@ -53,4 +53,14 @@ class FriendlyController
                                      join thing_entries dohe on do.id = dohe.data_object_id
                                      where do.published=#{params[:published]} and dohe.visibility_id=#{something.id} group by toc.id")
   end
+
+  def redirect_to_some_places
+    if something
+      redirect_to params.merge(:host => "example.com") # Should not warn
+    elsif something_else
+      redirect_to params.merge(:host => User.canonical_url) # Should not warn
+    else
+      redirect_to params.merge(:host => params[:host]) # Should warn
+    end
+  end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 1,
       :template => 2,
-      :generic => 19
+      :generic => 20
     }
   end
 
@@ -39,6 +39,38 @@ class Rails4Tests < Test::Unit::TestCase
       :confidence => 0,
       :relative_path => "app/controllers/application_controller.rb",
       :user_input => s(:call, s(:const, :User), :create!)
+  end
+
+  def test_redirects_with_explicit_host_do_not_warn
+    assert_no_warning :type => :warning,
+      :warning_code => 18,
+      :fingerprint => "b5a1bf2d1634564c82436e569c9ea874e355d4538cdc4dc4a8e6010dc9a7c11e",
+      :warning_type => "Redirect",
+      :line => 55,
+      :message => /^Possible\ unprotected\ redirect/,
+      :confidence => 0,
+      :relative_path => "app/controllers/friendly_controller.rb",
+      :user_input => s(:params, s(:lit, :host), s(:str, "example.com"))
+
+    assert_no_warning :type => :warning,
+      :warning_code => 18,
+      :fingerprint => "d04df9716ee4c8cadcb5f046e73ee06c3f1606e8b522f6e3130ac0a33fbc4d73",
+      :warning_type => "Redirect",
+      :line => 57,
+      :message => /^Possible\ unprotected\ redirect/,
+      :confidence => 0,
+      :relative_path => "app/controllers/friendly_controller.rb",
+      :user_input => s(:params, s(:lit, :host), s(:call, s(:const, :User), :canonical_url))
+
+    assert_warning :type => :warning,
+      :warning_code => 18,
+      :fingerprint => "25846ea0cd5178f2af4423a9fc1d7212983ee7f7ba4ca9f35f890e7ef00d9bf9",
+      :warning_type => "Redirect",
+      :line => 59,
+      :message => /^Possible\ unprotected\ redirect/,
+      :confidence => 0,
+      :relative_path => "app/controllers/friendly_controller.rb",
+      :user_input => s(:params, s(:lit, :host), s(:call, s(:params), :[], s(:lit, :host)))
   end
 
   def test_session_secret_token


### PR DESCRIPTION
unless that host is a param in which case still warn about it.

Fixes #464.
