### PR TITLE
Check all arguments in Model.select for SQLi

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -179,13 +179,13 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
                         check_order_arguments call.arglist
                       when :joins
                         check_joins_arguments call.first_arg
-                      when :from, :select
+                      when :from
                         unsafe_sql? call.first_arg
                       when :lock
                         check_lock_arguments call.first_arg
                       when :pluck
                         unsafe_sql? call.first_arg
-                      when :update_all
+                      when :update_all, :select
                         check_update_all_arguments call.args
                       when *@connection_calls
                         check_by_sql_arguments call.first_arg

--- a/test/apps/rails4/app/controllers/friendly_controller.rb
+++ b/test/apps/rails4/app/controllers/friendly_controller.rb
@@ -63,4 +63,8 @@ class FriendlyController
       redirect_to params.merge(:host => params[:host]) # Should warn
     end
   end
+
+  def select_some_stuff
+    User.select(:name, params[:x])
+  end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 1,
       :template => 2,
-      :generic => 20
+      :generic => 21
     }
   end
 
@@ -234,6 +234,18 @@ class Rails4Tests < Test::Unit::TestCase
       :confidence => 1,
       :relative_path => "app/models/account.rb",
       :user_input => s(:call, s(:self), :type)
+  end
+
+  def test_sql_injection_in_select_args
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "bd8c539a645aa417d538cbe7b658cc1c9743f61d1e90c948afacc7e023b30a62",
+      :warning_type => "SQL Injection",
+      :line => 64,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/controllers/friendly_controller.rb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :x))
   end
 
   def test_i18n_xss_CVE_2013_4491_workaround


### PR DESCRIPTION
As pointed out by @forced-request, Brakeman was only checking the first argument.
