### PR TITLE
Add String#intern and Hash#symbolize_keys DoS check

### DIFF
--- a/test/apps/rails2/app/controllers/application_controller.rb
+++ b/test/apps/rails2/app/controllers/application_controller.rb
@@ -37,9 +37,11 @@ class ApplicationController < ActionController::Base
   end
 
   def decent
+    p = params
     if params[:thang] && self.respond_to?(params[:thang].to_sym)
       :"really_#{params[:thang]}"
     end
+    p.symbolize_keys[:custom]
   end
 
 end

--- a/test/apps/rails2/app/controllers/other_controller.rb
+++ b/test/apps/rails2/app/controllers/other_controller.rb
@@ -81,4 +81,15 @@ class OtherController < ApplicationController
   def test_unescaped_regex
     /#{Rack::Utils.escape_html(params[:regex])}/
   end
+
+  def test_intern
+    x = params[:x].intern
+
+    params.symbolize_keys!
+
+    #Checking that the code below does not warn about to_sym again
+    call_something_with x
+
+    x.cool_thing?
+  end
 end

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -12,13 +12,13 @@ class Rails2Tests < Test::Unit::TestCase
         :controller => 1,
         :model => 3,
         :template => 47,
-        :generic => 51 }
+        :generic => 54 }
     else
       @expected ||= {
         :controller => 1,
         :model => 3,
         :template => 47,
-        :generic => 52 }
+        :generic => 55 }
     end
   end
 
@@ -1215,7 +1215,7 @@ class Rails2Tests < Test::Unit::TestCase
   end
 
   def test_unsafe_symbol_creation
-    [40,41].each do |line|
+    [41,42].each do |line|
       assert_warning :type => :warning,
         :warning_type => "Denial of Service",
         :line => line,
@@ -1241,6 +1241,36 @@ class Rails2Tests < Test::Unit::TestCase
       :warning_type => "Denial of Service",
       :line => 29,
       :message => /^Symbol\ conversion\ from\ unsafe\ string/,
+      :confidence => 1,
+      :file => /application_controller\.rb/,
+      :relative_path => "app/controllers/application_controller.rb"
+  end
+
+  def test_unsafe_symbol_creation_4
+    assert_warning :type => :warning,
+      :warning_type => "Denial of Service",
+      :line => 86,
+      :message => /^Symbol\ conversion\ from\ unsafe\ string\ \(pa/,
+      :confidence => 0,
+      :file => /other_controller\.rb/,
+      :relative_path => "app/controllers/other_controller.rb"
+  end
+
+  def test_unsafe_symbol_creation_5
+    assert_warning :type => :warning,
+      :warning_type => "Denial of Service",
+      :line => 88,
+      :message => /^Symbol\ conversion\ from\ unsafe\ string\ \(pa/,
+      :confidence => 1,
+      :file => /other_controller\.rb/,
+      :relative_path => "app/controllers/other_controller.rb"
+  end
+
+  def test_unsafe_symbol_creation_6
+    assert_warning :type => :warning,
+      :warning_type => "Denial of Service",
+      :line => 44,
+      :message => /^Symbol\ conversion\ from\ unsafe\ string\ \(pa/,
       :confidence => 1,
       :file => /application_controller\.rb/,
       :relative_path => "app/controllers/application_controller.rb"
@@ -1338,13 +1368,13 @@ class Rails2WithOptionsTests < Test::Unit::TestCase
         :controller => 1,
         :model => 4,
         :template => 47,
-        :generic => 51 }
+        :generic => 54 }
     else
       @expected ||= {
         :controller => 1,
         :model => 4,
         :template => 47,
-        :generic => 52 }
+        :generic => 55 }
     end
   end
 

--- a/test/tests/tabs_output.rb
+++ b/test/tests/tabs_output.rb
@@ -3,9 +3,9 @@ class TestTabsOutput < Test::Unit::TestCase
 
   def test_reported_warnings
     if Brakeman::Scanner::RUBY_1_9
-      assert_equal 103, Report.lines.to_a.count
+      assert_equal 106, Report.lines.to_a.count
     else
-      assert_equal 104, Report.lines.to_a.count
+      assert_equal 107, Report.lines.to_a.count
     end
   end
 end


### PR DESCRIPTION
Currently CheckSymbolDoS looks for the unsafe usage of String#to_sym method. Except for this method, there is also synonymous String#intern method. Another possibility to turn user-supplied strings to new symbols is Hash#symbolize_keys method, which converts all keys to symbols as long as they respond to to_sym method.

This PR adds checks for String#intern, Hash#symbolize_keys and Hash#symbolize_keys! along with tests.
