### PR TITLE
Check for protected_attributes gem in Rails 4 apps

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -177,7 +177,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
       tracker.config[:rails][:active_record][:whitelist_attributes] == Sexp.new(:true)
 
       @mass_assign_disabled = true
-    elsif version_between?("4.0.0", "4.9.9")
+    elsif version_between?("4.0.0", "4.9.9") and not tracker.config[:gems][:protected_attributes]
       #May need to revisit dependng on what Rails 4 actually does/has
       @mass_assign_disabled = true
     else

--- a/test/tests/mass_assign_disable.rb
+++ b/test/tests/mass_assign_disable.rb
@@ -63,6 +63,17 @@ class MassAssignDisableTest < Test::Unit::TestCase
     assert_new 0
   end
 
+  def test_protected_attributes_gem
+    before_rescan_of "Gemfile", "rails4_with_engines" do
+      append "Gemfile", "gem 'protected_attributes'"
+    end
+
+    assert_reindex :none
+    assert_changes
+    assert_fixed 0
+    assert_new 1
+  end
+
   def test_strong_parameters_with_send
     init = "config/initializers/mass_assign.rb"
     gemfile = "Gemfile"


### PR DESCRIPTION
and treat mass assignment as if it is allowed instead of using strong parameters.

Fixes #475
