### PR TITLE
Add support for Rails LTS 2.3.17 and 2.3.18

### DIFF
--- a/lib/brakeman/checks/check_number_to_currency.rb
+++ b/lib/brakeman/checks/check_number_to_currency.rb
@@ -10,6 +10,8 @@ class Brakeman::CheckNumberToCurrency < Brakeman::BaseCheck
       version_between? "3.0.0", "3.2.16" or
       version_between? "4.0.0", "4.0.2"
 
+      return if lts_version? "2.3.18.8"
+
       check_number_helper_usage
       generic_warning unless @found_any
     end

--- a/lib/brakeman/checks/check_select_vulnerability.rb
+++ b/lib/brakeman/checks/check_select_vulnerability.rb
@@ -9,7 +9,9 @@ class Brakeman::CheckSelectVulnerability < Brakeman::BaseCheck
 
   def run_check
 
-    if version_between? "3.0.0", "3.0.11"
+    if lts_version? "2.3.18.7"
+      return
+    elsif version_between? "3.0.0", "3.0.11"
       suggested_version = "3.0.12"
     elsif version_between? "3.1.0", "3.1.3"
       suggested_version = "3.1.4"

--- a/test/apps/rails_with_xss_plugin/app/views/users/index.html.erb
+++ b/test/apps/rails_with_xss_plugin/app/views/users/index.html.erb
@@ -15,3 +15,5 @@
 <br />
 
 <%= link_to 'New user', new_user_path %>
+
+<%= select('post', 'author_id', "<option value='#{params[:id]}'>#{params[:name]}</option>") %>

--- a/test/tests/rails_lts.rb
+++ b/test/tests/rails_lts.rb
@@ -1,0 +1,50 @@
+require 'brakeman/rescanner'
+
+class RailsLTSTests < Test::Unit::TestCase
+  include BrakemanTester::RescanTestHelper
+
+  def test_gemfile_lock_rails_lts
+    gemfile = "Gemfile.lock"
+
+    before_rescan_of gemfile, "rails_with_xss_plugin" do
+      append gemfile, "railslts-version (2.3.18.6)"
+    end
+
+    #@original is actually modified
+    assert @original.config[:gems][:"railslts-version"], "2.3.18.6"
+    assert_reindex :none
+    assert_changes
+    assert_new 0
+    assert_fixed 2
+  end
+
+  def test_rails_lts_CVE_2012_1099
+    gemfile = "Gemfile.lock"
+
+    before_rescan_of gemfile, "rails_with_xss_plugin" do
+      append gemfile, "railslts-version (2.3.18.7)"
+    end
+
+    #@original is actually modified
+    assert @original.config[:gems][:"railslts-version"], "2.3.18.7"
+    assert_reindex :none
+    assert_changes
+    assert_new 0
+    assert_fixed 3 # 2 + CVE-2012-1099
+  end
+
+  def test_rails_lts_CVE_2014_0081
+    gemfile = "Gemfile.lock"
+
+    before_rescan_of gemfile, "rails_with_xss_plugin" do
+      append gemfile, "railslts-version (2.3.18.8)"
+    end
+
+    #@original is actually modified
+    assert @original.config[:gems][:"railslts-version"], "2.3.18.8"
+    assert_reindex :none
+    assert_changes
+    assert_new 0
+    assert_fixed 4 # 2 + CVE-2012-1099 + CVE_2014_0081
+  end
+end

--- a/test/tests/rails_with_xss_plugin.rb
+++ b/test/tests/rails_with_xss_plugin.rb
@@ -10,7 +10,7 @@ class RailsWithXssPluginTests < Test::Unit::TestCase
     @expected ||= {
       :controller => 1,
       :model => 3,
-      :template => 3,
+      :template => 4,
       :generic => 23 }
   end
 
@@ -320,6 +320,18 @@ class RailsWithXssPluginTests < Test::Unit::TestCase
 
   def test_absolute_paths
     assert report[:generic_warnings].all? { |w| w.file.start_with? "/" }
+  end
+
+  def test_cross_site_scripting_CVE_2012_1099
+    assert_warning :type => :template,
+      :warning_code => 22,
+      :fingerprint => "d54bacec90be92ad8ca58164cdfd505114eae34db2fb5b03f7bc2a8fd93f1edb",
+      :warning_type => "Cross Site Scripting",
+      :line => 18,
+      :message => /^Upgrade\ to\ Rails\ 3\ or\ use\ options_for_se/,
+      :confidence => 1,
+      :relative_path => "app/views/users/index.html.erb",
+      :user_input => nil
   end
 
   def test_sql_injection_CVE_2013_0155

--- a/test/tests/rescanner.rb
+++ b/test/tests/rescanner.rb
@@ -253,21 +253,6 @@ class RescannerTests < Test::Unit::TestCase
     assert_fixed 0
   end
 
-  def test_gemfile_lock_rails_lts
-    gemfile = "Gemfile.lock"
-
-    before_rescan_of gemfile, "rails_with_xss_plugin" do
-      append gemfile, "railslts-version (2.3.18.6)"
-    end
-
-    #@original is actually modified
-    assert @original.config[:gems][:"railslts-version"], "2.3.18.6"
-    assert_reindex :none
-    assert_changes
-    assert_new 0
-    assert_fixed 2
-  end
-
   def test_gemfile_rails_version_fix_CVE_2014_0082
     gemfile = "Gemfile.lock"
 


### PR DESCRIPTION
Avoid warning about CVE-2012-1099 and CVE-2014-0081 when using appropriate versions of RailsLTS.
