### PR TITLE
Read/parse files up front

### DIFF
--- a/lib/brakeman/file_parser.rb
+++ b/lib/brakeman/file_parser.rb
@@ -1,0 +1,49 @@
+module Brakeman
+  ASTFile = Struct.new(:path, :ast)
+
+  # This class handles reading and parsing files.
+  class FileParser
+    attr_reader :file_list
+
+    def initialize tracker, app_tree
+      @tracker = tracker
+      @app_tree = app_tree
+      @file_list = {}
+    end
+
+    def parse_files list, type
+      read_files list, type do |path, contents|
+        if ast = parse_ruby(contents, path)
+          ASTFile.new(path, ast)
+        end
+      end
+    end
+
+    def read_files list, type
+      @file_list[type] ||= []
+
+      list.each do |path|
+        result = yield path, read_path(path)
+        if result
+          @file_list[type] << result
+        end
+      end
+    end
+
+    def parse_ruby input, path
+      begin
+        RubyParser.new.parse input, path
+      rescue Racc::ParseError => e
+        @tracker.error e, "Could not parse #{path}"
+        nil
+      rescue => e
+        @tracker.error e.exception(e.message + "\nWhile processing #{path}"), e.backtrace
+        nil
+      end
+    end
+
+    def read_path path
+      @app_tree.read_path path
+    end
+  end
+end

--- a/lib/brakeman/parsers/template_parser.rb
+++ b/lib/brakeman/parsers/template_parser.rb
@@ -1,0 +1,88 @@
+module Brakeman
+  class TemplateParser
+    include Brakeman::Util
+    attr_reader :tracker
+    KNOWN_TEMPLATE_EXTENSIONS = /.*\.(erb|haml|rhtml|slim)$/
+
+    TemplateFile = Struct.new(:path, :ast, :name, :type)
+
+    def initialize tracker, file_parser
+      @tracker = tracker
+      @file_parser = file_parser
+      @file_parser.file_list[:templates] ||= []
+    end
+
+    def parse_template path, text
+      type = path.match(KNOWN_TEMPLATE_EXTENSIONS)[1].to_sym
+      type = :erb if type == :rhtml
+      name = template_path_to_name path
+
+      begin
+        src = case type
+              when :erb
+                type = :erubis if erubis?
+                parse_erb text
+              when :haml
+                parse_haml text
+              when :slim
+                parse_slim text
+              else
+                tracker.error "Unkown template type in #{path}"
+                nil
+              end
+
+        if src and ast = @file_parser.parse_ruby(src, path)
+          @file_parser.file_list[:templates] << TemplateFile.new(path, ast, name, type)
+        end
+      rescue Racc::ParseError => e
+        tracker.error e, "could not parse #{path}"
+      rescue Haml::Error => e
+        tracker.error e, ["While compiling HAML in #{path}"] << e.backtrace
+      rescue StandardError, LoadError => e
+        tracker.error e.exception(e.message + "\nWhile processing #{path}"), e.backtrace
+      end
+
+      nil
+    end
+
+    def parse_erb text
+      if tracker.config[:escape_html]
+        if tracker.options[:rails3]
+          require 'brakeman/parsers/rails3_erubis'
+          Brakeman::Rails3Erubis.new(text).src
+        else
+          require 'brakeman/parsers/rails2_xss_plugin_erubis'
+          Brakeman::Rails2XSSPluginErubis.new(text).src
+        end
+      elsif tracker.config[:erubis]
+        require 'brakeman/parsers/rails2_erubis'
+        Brakeman::ScannerErubis.new(text).src
+      else
+        require 'erb'
+        src = ERB.new(text, nil, "-").src
+        src.sub!(/^#.*\n/, '') if Brakeman::Scanner::RUBY_1_9
+        src
+      end
+    end
+
+    def erubis?
+      tracker.config[:escape_html] or
+      tracker.config[:erubis]
+    end
+
+    def parse_haml text
+      Brakeman.load_brakeman_dependency 'haml'
+      Brakeman.load_brakeman_dependency 'sass'
+
+      Haml::Engine.new(text,
+                       :escape_html => !!tracker.config[:escape_html]).precompiled
+    end
+
+    def parse_slim text
+      Brakeman.load_brakeman_dependency 'slim'
+
+      Slim::Template.new(:disable_capture => true,
+                         :generator => Temple::Generators::RailsOutputBuffer) { text }.precompiled_template
+    end
+  end
+end

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -383,6 +383,15 @@ module Brakeman::Util
     end
   end
 
+  #Convert path/filename to view name
+  #
+  # views/test/something.html.erb -> test/something
+  def template_path_to_name path
+    names = path.split("/")
+    names.last.gsub!(/(\.(html|js)\..*|\.rhtml)$/, '')
+    names[(names.index("views") + 1)..-1].join("/").to_sym
+  end
+
   def github_url file, line=nil
     if repo_url = @tracker.options[:github_url] and file and not file.empty? and file.start_with? '/'
       url = "#{repo_url}/#{relative_path(file)}"


### PR DESCRIPTION
and cleanup reading/parsing files in general.

This will change some warnings, as sorting of files when processing has been fixed.

Also parse error message have changed a little bit, from something like

``` json
{"error"=>"(string):11 :: parse error on value \"}\" (tRCURLY)",
 "location"=>
  "could not parse /storage/repos/canvas-lms/app/views/terms/_timespan.html.erb"}
```

to

``` json
{"error"=>
  "/storage/repos/canvas-lms/app/views/terms/_timespan.html.erb:11 :: parse error on value \"}\" (tRCURLY)",
 "location"=>
  "Could not parse /storage/repos/canvas-lms/app/views/terms/_timespan.html.erb"}
```
