### PR TITLE
Add find_by/find_by! to SQL check for Rails 4

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -19,6 +19,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     @sql_targets = [:all, :average, :calculate, :count, :count_by_sql, :exists?, :delete_all, :destroy_all,
       :find, :find_by_sql, :first, :last, :maximum, :minimum, :pluck, :sum, :update_all]
     @sql_targets.concat [:from, :group, :having, :joins, :lock, :order, :reorder, :select, :where] if tracker.options[:rails3]
+    @sql_targets << :find_by << :find_by! if version_between? "4.0.0", "9.9.9"
 
     @connection_calls = [:delete, :execute, :insert, :select_all, :select_one,
       :select_rows, :select_value, :select_values]
@@ -172,7 +173,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
                         else
                           check_find_arguments call.last_arg
                         end
-                      when :where, :having
+                      when :where, :having, :find_by, :find_by!
                         check_query_arguments call.arglist
                       when :order, :group, :reorder
                         check_order_arguments call.arglist

--- a/test/apps/rails4/app/controllers/users_controller.rb
+++ b/test/apps/rails4/app/controllers/users_controller.rb
@@ -42,4 +42,9 @@ class UsersController < ApplicationController
       redirect_to User.where(:stuff => 1).take
     end
   end
+
+  def find_by_stuff
+    User.find_by "age > #{params[:age_limit]}"
+    User.find_by! params[:user_search]
+  end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 1,
       :template => 2,
-      :generic => 25
+      :generic => 27
     }
   end
 
@@ -280,6 +280,30 @@ class Rails4Tests < Test::Unit::TestCase
       :confidence => 1,
       :relative_path => "app/models/user.rb",
       :user_input => s(:lvar, :col)
+  end
+
+  def test_sql_injection_in_find_by
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "ca9d658a7215099a35b3b3ec3867ffb8fb7ad497d31307ba8952d7dcb85e8ac9",
+      :warning_type => "SQL Injection",
+      :line => 47,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :age_limit))
+  end
+
+  def test_sql_injection_in_find_by!
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "6f743b0a084c132d3bd074a0d22e197d6c81018028f6166324de1970616c4cbd",
+      :warning_type => "SQL Injection",
+      :line => 48,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :user_search))
   end
 
   def test_dynamic_render_path_with_before_action


### PR DESCRIPTION
`find_by`/`find_by!` just call `where(*args).take`, so they are just as vulnerable as `where`.
