### PR TITLE
Fix redirect false positive with chained call

### DIFF
--- a/test/apps/rails3.1/app/controllers/users_controller.rb
+++ b/test/apps/rails3.1/app/controllers/users_controller.rb
@@ -180,4 +180,8 @@ class UsersController < ApplicationController
   include UserMixin
 
   before_filter :assign_if, :only => :test_assign_if
+
+  def redirect_merge
+    redirect_to params.merge(host: 'http://app.webthing.com/stuff', port: '80').except(:action, :controller, :auth_token)
+  end
 end

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -99,6 +99,18 @@ class Rails31Tests < Test::Unit::TestCase
       :file => /users_controller\.rb/
   end
 
+  def test_redirect_false_positive_chained_call
+    assert_no_warning :type => :warning,
+      :warning_code => 18,
+      :fingerprint => "287308589926edfd6463a04b3eb5b39b67b3bf6de6da9c380f1507f377c5a333",
+      :warning_type => "Redirect",
+      :line => 185,
+      :message => /^Possible\ unprotected\ redirect/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :user_input => s(:call, s(:params, s(:lit, :host), s(:str, "http://app.webthing.com/stuff"), s(:lit, :port), s(:str, "80")), :except, s(:lit, :action), s(:lit, :controller), s(:lit, :auth_token))
+  end
+
   def test_whitelist_attributes
     assert_no_warning :type => :model,
       :warning_type => "Attribute Restriction",


### PR DESCRIPTION
This should fix #506 by checking target of call arguments in `redirect_to`.
