### PR TITLE
Support keyword arguments in blocks

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -180,6 +180,8 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
         #Force block arg(s) to be local
         if node_type? e, :lasgn
           env.current[Sexp.new(:lvar, e.lhs)] = e.rhs
+        elsif node_type? e, :kwarg
+          env.current[Sexp.new(:lvar, e[1])] = e[2]
         elsif node_type? e, :masgn
           e[1..-1].each do |var|
             local = Sexp.new(:lvar, var)

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -587,4 +587,16 @@ class AliasProcessorTests < Test::Unit::TestCase
       x
     INPUT
   end
+
+  def test_keywords_in_blocks
+    assert_output <<-'INPUT', <<-'OUTPUT'
+    x do |y: 1, z: "2"|
+      puts y, z
+    end
+    INPUT
+    x do |y: 1, z: "2"|
+      puts 1, "2"
+    end
+    OUTPUT
+  end
 end


### PR DESCRIPTION
Treat keyword arguments as local to block.

fixes #511
