### PR TITLE
CVE_2013_6415 and CVE_2013_6415_call commented out

### DIFF
--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -65,8 +65,9 @@ module Brakeman::WarningCodes
     :detailed_exceptions => 62,
     :CVE_2013_4491 => 63,
     :CVE_2013_6414 => 64,
-    :CVE_2013_6415 => 65,
-    :CVE_2013_6415_call => 66,
+    # Replaced by CVE_2014_0081
+    #:CVE_2013_6415 => 65,
+    #:CVE_2013_6415_call => 66,
     :CVE_2013_6416 => 67,
     :CVE_2013_6416_call => 68,
     :CVE_2013_6417 => 69,


### PR DESCRIPTION
CVE_2013_6415 and CVE_2013_6415_call were replaced by CVE_2014_0081 and CVE_2014_0081_call respectively. Neither are used any longer.
