### PR TITLE
Fix block statement endings in erubis

### DIFF
--- a/lib/brakeman/parsers/rails3_erubis.rb
+++ b/lib/brakeman/parsers/rails3_erubis.rb
@@ -39,14 +39,6 @@ class Brakeman::Rails3Erubis < ::Erubis::Eruby
     end
   end
 
-  def add_stmt(src, code)
-    if code =~ BLOCK_EXPR
-      src << '@output_buffer.append_if_string= ' << code
-    else
-      super
-    end
-  end
-
   def add_expr_escaped(src, code)
     if code =~ BLOCK_EXPR
       src << "@output_buffer.safe_append= " << code


### PR DESCRIPTION
Partial fix for #518

Tested with erubis 2.6.0 which is the oldest supported as well as the latest..
