### PR TITLE
Drop faster csv

### DIFF
--- a/brakeman.gemspec
+++ b/brakeman.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency "ruby_parser", "~>3.5.0"
   s.add_dependency "ruby2ruby", "~>2.0.5"
   s.add_dependency "terminal-table", "~>1.4"
-  s.add_dependency "fastercsv", "~>1.5"
   s.add_dependency "highline", "~>1.6.20"
   s.add_dependency "erubis", "~>2.6"
   s.add_dependency "haml", ">=3.0", "<5.0"

--- a/lib/brakeman/report/initializers/faster_csv.rb
+++ b/lib/brakeman/report/initializers/faster_csv.rb
@@ -1,7 +1,0 @@
-# Ruby 1.8 compatible
-if CSV.const_defined? :Reader
-  require 'fastercsv'
-  Object.send(:remove_const, :CSV)
-  CSV = FasterCSV
-end
-

--- a/lib/brakeman/report/report_csv.rb
+++ b/lib/brakeman/report/report_csv.rb
@@ -1,5 +1,4 @@
-Brakeman.load_brakeman_dependency 'csv'
-require "brakeman/report/initializers/faster_csv"
+require 'csv'
 require "brakeman/report/report_table"
 
 class Brakeman::Report::CSV < Brakeman::Report::Table


### PR DESCRIPTION
It save a gem download for ruby 1.9+ and will just be slightly slower for 1.8 users.

And 1.8 is EOL anyway.

Regards.
