### PR TITLE
Avoid warning about symbolizing safe parameters

### DIFF
--- a/lib/brakeman/checks/check_symbol_dos.rb
+++ b/lib/brakeman/checks/check_symbol_dos.rb
@@ -54,6 +54,8 @@ class Brakeman::CheckSymbolDoS < Brakeman::BaseCheck
     end
 
     if confidence
+      return if safe_parameter? input.match
+
       message = "Symbol conversion from unsafe string (#{friendly_type_of input})"
 
       warn :result => result,
@@ -63,7 +65,14 @@ class Brakeman::CheckSymbolDoS < Brakeman::BaseCheck
         :user_input => input.match,
         :confidence => confidence
     end
-
   end
 
+  def safe_parameter? input
+    return unless params? input
+
+    call? input and
+    input.method == :[] and
+    symbol? input.first_arg and
+    [:controller, :action].include? input.first_arg.value
+  end
 end

--- a/test/apps/rails4/app/controllers/users_controller.rb
+++ b/test/apps/rails4/app/controllers/users_controller.rb
@@ -47,4 +47,9 @@ class UsersController < ApplicationController
     User.find_by "age > #{params[:age_limit]}"
     User.find_by! params[:user_search]
   end
+
+  def symbolize_safe_parameters
+    params[:controller].to_sym
+    params[:action].intern
+  end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -387,6 +387,28 @@ class Rails4Tests < Test::Unit::TestCase
       :user_input => s(:call, s(:call, s(:const, :User), :where, s(:hash, s(:lit, :stuff), s(:lit, 1))), :take)
   end
 
+  def test_symbol_dos_with_safe_parameters
+    assert_no_warning :type => :warning,
+      :warning_code => 59,
+      :fingerprint => "53a74ac0c23e934a1d439e0b53ce818a22db6b23a696a61cd7dfb5b19175240a",
+      :warning_type => "Denial of Service",
+      :line => 52,
+      :message => /^Symbol\ conversion\ from\ unsafe\ string\ \(pa/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :controller))
+
+    assert_no_warning :type => :warning,
+      :warning_code => 59,
+      :fingerprint => "d569b240f71e4fc4cc6e91559923baea941a1341d1d70fd6c1c36813947e369d",
+      :warning_type => "Denial of Service",
+      :line => 53,
+      :message => /^Symbol\ conversion\ from\ unsafe\ string\ \(pa/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :action))
+  end
+
   def test_i18n_xss_CVE_2013_4491_workaround
     assert_no_warning :type => :warning,
       :warning_code => 63,


### PR DESCRIPTION
As reported in #536, `params[:controller]` and `params[:action]` are hard if not impossible to manipulate for DoS via symbol creation.
