### PR TITLE
Make sure file paths are absolute in AppTree

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -5,7 +5,7 @@ module Brakeman
     attr_reader :root
 
     def self.from_options(options)
-      root = options[:app_path]
+      root = File.expand_path options[:app_path]
 
       # Convert files into Regexp for matching
       init_options = {}

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -6,6 +6,19 @@ class BrakemanTests < Test::Unit::TestCase
       Brakeman.run "/tmp#{rand}" #better not exist
     end
   end
+
+  def test_app_tree_root_is_absolute
+    require 'brakeman/options'
+    relative_path = Pathname.new(File.dirname(__FILE__)).relative_path_from(Pathname.getwd)
+    absolute_path = relative_path.realpath.to_s
+    input = ["-p", relative_path.to_s]
+    options, _ = Brakeman::Options.parse input
+    at = Brakeman::AppTree.from_options options
+
+    assert !options[:app_path].start_with?("/")
+    assert_equal absolute_path, at.root
+    assert_equal File.join(absolute_path, "Gemfile"), at.expand_path("Gemfile")
+  end
 end
 
 class UtilTests < Test::Unit::TestCase


### PR DESCRIPTION
After changes in #534, relative file names were a bit off when running Brakeman against something other than the current directory, like

```
$ brakeman ./some_dir
```

@jeffrafter I believe this is a little ironic :stuck_out_tongue_winking_eye: 
