### PR TITLE
Make TemplateAliasProcessor work with top-level partials

### DIFF
--- a/lib/brakeman/processors/template_alias_processor.rb
+++ b/lib/brakeman/processors/template_alias_processor.rb
@@ -32,7 +32,7 @@ class Brakeman::TemplateAliasProcessor < Brakeman::AliasProcessor
 
   #Determine template name
   def template_name name
-    unless name.to_s.include? "/"
+    if !name.to_s.include?('/') && @template[:name].to_s.include?('/')
       name = "#{@template[:name].to_s.match(/^(.*\/).*$/)[1]}#{name}"
     end
     name

--- a/test/apps/rails4/app/views/_global_partial.html.erb
+++ b/test/apps/rails4/app/views/_global_partial.html.erb
@@ -1,0 +1,1 @@
+<%= render 'something' %>


### PR DESCRIPTION
For some reason the `template_name` method assumes that there is a slash in each partial's path, while it is perfectly valid to have global partials that are not contained in a sub directory. For those the expression won't match and the method would fail due to a call to `nil.[]`.
