### PR TITLE
Avoid warning about Symbol DoS on safe params

### DIFF
--- a/lib/brakeman/checks/check_symbol_dos.rb
+++ b/lib/brakeman/checks/check_symbol_dos.rb
@@ -68,11 +68,16 @@ class Brakeman::CheckSymbolDoS < Brakeman::BaseCheck
   end
 
   def safe_parameter? input
-    return unless params? input
-
-    call? input and
-    input.method == :[] and
-    symbol? input.first_arg and
-    [:controller, :action].include? input.first_arg.value
+    if call? input
+      if node_type? input.target, :params
+        input.method == :[] and
+        symbol? input.first_arg and
+        [:controller, :action].include? input.first_arg.value
+      else
+        safe_parameter? input.target
+      end
+    else
+      false
+    end
   end
 end

--- a/test/apps/rails4/app/controllers/users_controller.rb
+++ b/test/apps/rails4/app/controllers/users_controller.rb
@@ -50,7 +50,7 @@ class UsersController < ApplicationController
 
   def symbolize_safe_parameters
     params[:controller].to_sym
-    params[:action].intern
+    params[:action].intern && params[:controller][/([^\/]+)$/].try(:to_sym)
   end
 
   def mass_assignment_bypass


### PR DESCRIPTION
This is the promised follow-up to #538 in order to ignore symbolizing of `params[:controller]` and `params[:action]`.

I don't plan to make any further reductions to false positives of this kind. Instead, `CheckSymbolDoS` will be an optional check starting in Brakeman 3.0.
