### PR TITLE
Whitelist `exists` arel method from sqli

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -549,7 +549,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     :sanitize_sql, :sanitize_sql_array, :sanitize_sql_for_assignment,
     :sanitize_sql_for_conditions, :sanitize_sql_hash,
     :sanitize_sql_hash_for_assignment, :sanitize_sql_hash_for_conditions,
-    :to_sql, :sanitize]
+    :to_sql, :sanitize, :exists]
 
   def safe_value? exp
     return true unless sexp? exp

--- a/test/apps/rails4/app/models/user.rb
+++ b/test/apps/rails4/app/models/user.rb
@@ -4,4 +4,8 @@ class User < ActiveRecord::Base
   end
 
   scope :hits_by_ip, ->(ip,col="*") { select("#{col}").order("id DESC") }
+
+  def arel_exists
+    where(User.where(User.arel_table[:object_id].eq(arel_table[:id])).exists)
+  end
 end


### PR DESCRIPTION
per comments in #378 where `exists` is called on the results of `where`.
