### PR TITLE
Make CheckSymbolDoS an optional check

### DIFF
--- a/lib/brakeman/checks/check_symbol_dos.rb
+++ b/lib/brakeman/checks/check_symbol_dos.rb
@@ -1,37 +1,16 @@
 require 'brakeman/checks/base_check'
 
 class Brakeman::CheckSymbolDoS < Brakeman::BaseCheck
-  Brakeman::Checks.add self
+  Brakeman::Checks.add_optional self
 
   UNSAFE_METHODS = [:to_sym, :literal_to_sym, :intern, :symbolize_keys, :symbolize_keys!]
 
-  @description = "Checks for versions with ActiveRecord symbol denial of service, or code with a similar vulnerability"
+  @description = "Checks for symbol denial of service"
 
   def run_check
-    fix_version = case
-      when version_between?('2.0.0', '2.3.17')
-        '2.3.18'
-      when version_between?('3.1.0', '3.1.11')
-        '3.1.12'
-      when version_between?('3.2.0', '3.2.12')
-        '3.2.13'
-      else
-        nil
-      end
-
-    if fix_version && active_record_models.any?
-      warn :warning_type => "Denial of Service",
-        :warning_code => :CVE_2013_1854,
-        :message => "Rails #{tracker.config[:rails_version]} has a denial of service vulnerability in ActiveRecord: upgrade to #{fix_version} or patch",
-        :confidence => CONFIDENCE[:med],
-        :gem_info => gemfile_or_environment,
-        :link => "https://groups.google.com/d/msg/rubyonrails-security/jgJ4cjjS8FE/BGbHRxnDRTIJ"
-    end
-
     tracker.find_call(:methods => UNSAFE_METHODS, :nested => true).each do |result|
       check_unsafe_symbol_creation(result)
     end
-
   end
 
   def check_unsafe_symbol_creation result

--- a/lib/brakeman/checks/check_symbol_dos_cve.rb
+++ b/lib/brakeman/checks/check_symbol_dos_cve.rb
@@ -1,0 +1,30 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckSymbolDoSCVE < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = "Checks for versions with ActiveRecord symbol denial of service vulnerability"
+
+  def run_check
+    fix_version = case
+      when version_between?('2.0.0', '2.3.17')
+        '2.3.18'
+      when version_between?('3.1.0', '3.1.11')
+        '3.1.12'
+      when version_between?('3.2.0', '3.2.12')
+        '3.2.13'
+      else
+        nil
+      end
+
+    if fix_version && active_record_models.any?
+      warn :warning_type => "Denial of Service",
+        :warning_code => :CVE_2013_1854,
+        :message => "Rails #{tracker.config[:rails_version]} has a denial of service vulnerability in ActiveRecord: upgrade to #{fix_version} or patch",
+        :confidence => CONFIDENCE[:med],
+        :gem_info => gemfile_or_environment,
+        :link => "https://groups.google.com/d/msg/rubyonrails-security/jgJ4cjjS8FE/BGbHRxnDRTIJ"
+    end
+  end
+end
+

--- a/test/apps/rails3.2/app/controllers/users_controller.rb
+++ b/test/apps/rails3.2/app/controllers/users_controller.rb
@@ -96,4 +96,8 @@ class UsersController < ApplicationController
   def render_text
     render :text => "oh noes my service"
   end
+
+  def test_symbol_dos
+    params[:x].to_sym # no warning because this is an optional check
+  end
 end


### PR DESCRIPTION
but keep check for CVE-2013-1854 on by default.

I did some very simple benchmarking creating symbols (with ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-linux]). After creating 10 million symbols, the memory usage was ~2.3GB. Assuming a single-threaded, single-process Rails app with 100ms response times creating one new symbol per request, that would take ~11.5 days (late at night, math might be wrong). I don't think this is a very effective DoS attack. If you have multiple Rails processes, then one falling over and restarting once every few weeks is not a huge deal.

Additionally, Ruby 2.2 will garbage collect symbols, so eventually this will be a problem of the past.

I'm curious if people think this is a serious enough security issue to warrant these kinds of warnings, or if it is okay to make this an optional check which people can run if they are worried about memory leaks.

Alternatively, the confidence/severity of these warnings could be set to low.
