### PR TITLE
Fix CVE for CVE-2011-2932

### DIFF
--- a/lib/brakeman/checks/check_escape_function.rb
+++ b/lib/brakeman/checks/check_escape_function.rb
@@ -11,8 +11,8 @@ class Brakeman::CheckEscapeFunction < Brakeman::BaseCheck
     if version_between?('2.0.0', '2.3.13') and RUBY_VERSION < '1.9.0' 
 
       warn :warning_type => 'Cross Site Scripting',
-        :warning_code => :CVE_2011_2931,
-        :message => 'Versions before 2.3.14 have a vulnerability in escape method when used with Ruby 1.8: CVE-2011-2931',
+        :warning_code => :CVE_2011_2932,
+        :message => 'Versions before 2.3.14 have a vulnerability in escape method when used with Ruby 1.8: CVE-2011-2932',
         :confidence => CONFIDENCE[:high],
         :gem_info => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/topic/rubyonrails-security/Vr_7WSOrEZU/discussion"

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -84,6 +84,7 @@ module Brakeman::WarningCodes
     :CVE_2014_3514 => 80,
     :CVE_2014_3514_call => 81,
     :unscoped_find => 82,
+    :CVE_2011_2932 => 83,
   }
 
   def self.code name

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -207,6 +207,20 @@ class Rails2Tests < Test::Unit::TestCase
       :relative_path => "config/initializers/session_store.rb"
   end
 
+  def test_rails_cve_2011_2932
+    unless Brakeman::Scanner::RUBY_1_9
+      assert_warning :type => :warning,
+        :warning_code => 83,
+        :fingerprint => "19e0b7ab34bebe1c887bc388a195a8619136abe5875d62010628958f0792479c",
+        :warning_type => "Cross Site Scripting",
+        :line => nil,
+        :message => /^Versions\ before\ 2\.3\.14\ have\ a\ vulnerabil/,
+        :confidence => 0,
+        :relative_path => "config/environment.rb",
+        :user_input => nil
+    end
+  end
+
   def test_rails_cve_2012_2660
     assert_warning :type => :warning,
       :warning_type => "SQL Injection",


### PR DESCRIPTION
I'm sure this affects no one at all, but Brakeman had two different checks which warned about CVE-2011-2931...which wasn't right. In my defense, the mistake was in [the CVE assignment email](https://groups.google.com/forum/#!topic/rubyonrails-security/-HijMVmsmWc).
