### PR TITLE
No need to assign result Sexps in call indexing

### DIFF
--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -22,6 +22,10 @@ class Brakeman::FindAllCalls < Brakeman::BaseProcessor
     process exp
   end
 
+  def process_default exp
+    process_all exp
+  end
+
   #Process body of method
   def process_methdef exp
     process_all exp.body

--- a/lib/brakeman/processors/lib/find_call.rb
+++ b/lib/brakeman/processors/lib/find_call.rb
@@ -67,6 +67,10 @@ class Brakeman::FindCall < Brakeman::BaseProcessor
     process exp
   end
 
+  def process_default exp
+    process_all exp
+  end
+
   #Process body of method
   def process_methdef exp
     process_all exp.body


### PR DESCRIPTION
`process_default` in `BaseProcessor` assigns the results of processing back to the `Sexp` as it goes. But that's not always needed if the processor is just traversing but not changing the AST.

This change shaves a little bit of time off of call indexing.
