### PR TITLE
Add BasicProcessor for non-mutating processing

### DIFF
--- a/lib/brakeman/processors/base_processor.rb
+++ b/lib/brakeman/processors/base_processor.rb
@@ -20,14 +20,6 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
     IGNORE
   end
 
-  def process_class exp
-    current_class = @current_class
-    @current_class = class_name exp[1]
-    process_all exp.body
-    @current_class = current_class
-    exp
-  end
-
   #Process a new scope. Removes expressions that are set to nil.
   def process_scope exp
     #NOPE?

--- a/lib/brakeman/processors/gem_processor.rb
+++ b/lib/brakeman/processors/gem_processor.rb
@@ -1,7 +1,7 @@
-require 'brakeman/processors/base_processor'
+require 'brakeman/processors/lib/basic_processor'
 
 #Processes Gemfile and Gemfile.lock
-class Brakeman::GemProcessor < Brakeman::BaseProcessor
+class Brakeman::GemProcessor < Brakeman::BasicProcessor
 
   def initialize *args
     super

--- a/lib/brakeman/processors/lib/basic_processor.rb
+++ b/lib/brakeman/processors/lib/basic_processor.rb
@@ -1,0 +1,17 @@
+require 'brakeman/processors/lib/processor_helper'
+require 'brakeman/util'
+
+class Brakeman::BasicProcessor < Brakeman::SexpProcessor
+  include Brakeman::ProcessorHelper
+  include Brakeman::Util
+
+  def initialize tracker
+    super()
+    @tracker = tracker
+    @current_template = @current_module = @current_class = @current_method = nil
+  end
+
+  def process_default exp
+    process_all exp
+  end
+end

--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -1,6 +1,6 @@
-require 'brakeman/processors/base_processor'
+require 'brakeman/processors/lib/basic_processor'
 
-class Brakeman::FindAllCalls < Brakeman::BaseProcessor
+class Brakeman::FindAllCalls < Brakeman::BasicProcessor
   attr_reader :calls
 
   def initialize tracker

--- a/lib/brakeman/processors/lib/find_call.rb
+++ b/lib/brakeman/processors/lib/find_call.rb
@@ -1,4 +1,4 @@
-require 'brakeman/processors/base_processor'
+require 'brakeman/processors/lib/basic_processor'
 
 #Finds method calls matching the given target(s).
 #   #-- This should be deprecated --#
@@ -31,7 +31,7 @@ require 'brakeman/processors/base_processor'
 #
 # #Find all calls to sub, sub!, gsub, or gsub!
 # FindCall.new nil, /^g?sub!?$/
-class Brakeman::FindCall < Brakeman::BaseProcessor
+class Brakeman::FindCall < Brakeman::BasicProcessor
 
   def initialize targets, methods, tracker, in_depth = false
     super tracker

--- a/lib/brakeman/processors/lib/processor_helper.rb
+++ b/lib/brakeman/processors/lib/processor_helper.rb
@@ -29,6 +29,15 @@ module Brakeman::ProcessorHelper
 
     exp
   end
+
+  def process_class exp
+    current_class = @current_class
+    @current_class = class_name exp[1]
+    process_all exp.body
+    @current_class = current_class
+    exp
+  end
+
   #Sets the current module.
   def process_module exp
     module_name = class_name(exp.class_name).to_s

--- a/lib/brakeman/processors/lib/rails2_config_processor.rb
+++ b/lib/brakeman/processors/lib/rails2_config_processor.rb
@@ -12,7 +12,7 @@
 #  tracker.config[:rails][:action_controller][:session_store]
 #
 #Values for tracker.config[:rails] will still be Sexps.
-class Brakeman::Rails2ConfigProcessor < Brakeman::BaseProcessor
+class Brakeman::Rails2ConfigProcessor < Brakeman::BasicProcessor
   #Replace block variable in
   #
   #  Rails::Initializer.run |config|

--- a/lib/brakeman/processors/lib/rails2_route_processor.rb
+++ b/lib/brakeman/processors/lib/rails2_route_processor.rb
@@ -1,10 +1,10 @@
-require 'brakeman/processors/base_processor'
+require 'brakeman/processors/lib/basic_processor'
 
 #Processes the Sexp from routes.rb. Stores results in tracker.routes.
 #
 #Note that it is only interested in determining what methods on which
 #controllers are used as routes, not the generated URLs for routes.
-class Brakeman::Rails2RoutesProcessor < Brakeman::BaseProcessor
+class Brakeman::Rails2RoutesProcessor < Brakeman::BasicProcessor
   include Brakeman::RouteHelper
 
   attr_reader :map, :nested, :current_controller
@@ -76,7 +76,7 @@ class Brakeman::Rails2RoutesProcessor < Brakeman::BaseProcessor
       end
       exp
     else
-      super
+      process_default exp
     end
   end
 

--- a/lib/brakeman/processors/lib/rails3_config_processor.rb
+++ b/lib/brakeman/processors/lib/rails3_config_processor.rb
@@ -12,7 +12,7 @@
 #  tracker.config[:rails][:active_record][:whitelist_attributes]
 #
 #Values for tracker.config[:rails] will still be Sexps.
-class Brakeman::Rails3ConfigProcessor < Brakeman::BaseProcessor
+class Brakeman::Rails3ConfigProcessor < Brakeman::BasicProcessor
   RAILS_CONFIG = Sexp.new(:call, nil, :config)
 
   def initialize *args

--- a/lib/brakeman/processors/lib/rails3_route_processor.rb
+++ b/lib/brakeman/processors/lib/rails3_route_processor.rb
@@ -2,7 +2,7 @@
 #
 #Note that it is only interested in determining what methods on which
 #controllers are used as routes, not the generated URLs for routes.
-class Brakeman::Rails3RoutesProcessor < Brakeman::BaseProcessor
+class Brakeman::Rails3RoutesProcessor < Brakeman::BasicProcessor
   include Brakeman::RouteHelper
 
   attr_reader :map, :nested, :current_controller
@@ -53,7 +53,7 @@ class Brakeman::Rails3RoutesProcessor < Brakeman::BaseProcessor
     when :controller
       process_controller_block exp
     else
-      super
+      process_default exp
     end
   end
 


### PR DESCRIPTION
After #583 I remembered I did a lot of similar work earlier in the year. That work was intended to reduce the number of `Sexps` that get created. In the end, though, it just wasn't significant enough to justify all the changes. But this is a smaller change that will be also helpful as I attempt to add copy-on-write `Sexp`s.

This change slightly reduces time spent indexing calls and max memory usage.
