### PR TITLE
Adds option "exit_on_new_warnings_only".

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -70,7 +70,7 @@ begin
       puts MultiJson.dump(vulns, :pretty => true)
     end
 
-    if options[:exit_on_warn] and (vulns[:new].count + vulns[:fixed].count > 0)
+    if options[:exit_on_warn] && vulns[:new].count > 0
       exit Brakeman::Warnings_Found_Exit_Code
     end
   else


### PR DESCRIPTION
This is useful when using brakeman on a CI system that depends on the exit status to determine if new vulnerabilities have been detected and it is not desirable to have a non-zero exit status when vulnerabilities have been fixed.
