### PR TITLE
Typo fix in "cross site script" warning type.

### DIFF
--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -108,7 +108,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
       message = "Unescaped #{friendly_type_of input}"
 
       warn :template => @current_template,
-        :warning_type => "Cross Site Scripting",
+        :warning_type => "Cross-Site Scripting",
         :warning_code => :cross_site_scripting,
         :message => message,
         :code => input.match,
@@ -147,7 +147,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
                end
 
         warn :template => @current_template,
-          :warning_type => "Cross Site Scripting",
+          :warning_type => "Cross-Site Scripting",
           :warning_code => warning_code,
           :message => message,
           :code => match,
@@ -223,7 +223,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
           end
 
           warn :template => @current_template,
-            :warning_type => "Cross Site Scripting",
+            :warning_type => "Cross-Site Scripting",
             :warning_code => :xss_to_json,
             :message => message,
             :code => exp,


### PR DESCRIPTION
Added a hyphen to the warning type. Sorry. I know it's nit-picky. (https://www.owasp.org/index.php/Cross-site_Scripting_(XSS))
