### PR TITLE
Remove formatting for local variables

### DIFF
--- a/lib/brakeman/processors/output_processor.rb
+++ b/lib/brakeman/processors/output_processor.rb
@@ -23,12 +23,6 @@ class Brakeman::OutputProcessor < Ruby2Ruby
     end
   end
 
-  def process_lvar exp
-    out = "(local #{exp[0]})"
-    exp.clear
-    out
-  end
-
   def process_ignore exp
     exp.clear
     "[ignored]"

--- a/test/tests/output_processor.rb
+++ b/test/tests/output_processor.rb
@@ -22,7 +22,7 @@ class OutputProcessorTests < Test::Unit::TestCase
   end
 
   def test_output_local_variable
-    assert_output "(local x)", Sexp.new(:lvar, :x)
+    assert_output "x", Sexp.new(:lvar, :x)
   end
 
   def test_output_ignore
@@ -46,8 +46,8 @@ class OutputProcessorTests < Test::Unit::TestCase
   end
 
   def test_output_output
-    assert_output "[Output] (local x)", Sexp.new(:output,
-                                                 Sexp.new(:lvar, :x))
+    assert_output "[Output] x", Sexp.new(:output,
+                                         Sexp.new(:lvar, :x))
   end
 
   def test_output_output_format
@@ -155,7 +155,7 @@ class OutputProcessorTests < Test::Unit::TestCase
                Sexp.new(:args),
                Sexp.new(:ivar, :@x))
 
-    assert_output "def x(y)\n  @x = (local y)\nend",
+    assert_output "def x(y)\n  @x = y\nend",
       Sexp.new(:methdef,
                :x,
                Sexp.new(:args, :y),


### PR DESCRIPTION
`(local x)` is just not Ruby syntax, and I don't think it is useful now. Originally I think it was for debugging.
