### PR TITLE
Ignore tasks

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -71,7 +71,7 @@ module Brakeman
     end
 
     def lib_paths
-      @lib_files ||= find_paths("lib").reject { |path| path.include? "/generators/" }
+      @lib_files ||= find_paths("lib").reject { |path| path.include? "/generators/" or path.include? "lib/tasks/" }
     end
 
   private

--- a/test/apps/rails4/lib/tasks/some_task.rb
+++ b/test/apps/rails4/lib/tasks/some_task.rb
@@ -1,0 +1,6 @@
+class SomeTask
+  def some_task
+    # Should not warn because we are ignoring tasks
+    `#{x}`
+  end
+end


### PR DESCRIPTION
Since tasks are typically run by developers, not accessible via the web app, skip processing them.