### PR TITLE
Fix output formatting of command interpolation

### DIFF
--- a/lib/brakeman/processors/output_processor.rb
+++ b/lib/brakeman/processors/output_processor.rb
@@ -72,7 +72,7 @@ class Brakeman::OutputProcessor < Ruby2Ruby
       elsif string? e
         e[1]
       else
-        process e
+        "\#{#{process e}}"
       end
     end.join
     exp.clear

--- a/test/tests/output_processor.rb
+++ b/test/tests/output_processor.rb
@@ -175,4 +175,9 @@ class OutputProcessorTests < Test::Unit::TestCase
       s(:rescue, s(:call, nil, :a),
         s(:resbody, s(:array), s(:call, nil, :b)))
   end
+
+  def test_command_interpolation
+    assert_output '`#{x}`',
+      s(:dxstr, "", s(:evstr, s(:call, nil, :x)))
+  end
 end


### PR DESCRIPTION
Should look like

```ruby
`#{x}`
```
not
```ruby
`x`
```