### PR TITLE
Add check for inline XSS

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -328,7 +328,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
       end
     elsif sexp? exp
       case exp.node_type
-      when :string_interp
+      when :string_interp, :dstr
         exp.each do |e|
           if sexp? e
             match = has_immediate_user_input?(e)
@@ -336,7 +336,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
           end
         end
         false
-      when :string_eval
+      when :string_eval, :evstr
         if sexp? exp.value
           if exp.value.node_type == :rlist
             exp.value.each_sexp do |e|
@@ -390,14 +390,14 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
       end
     elsif sexp? exp
       case exp.node_type
-      when :string_interp
+      when :string_interp, :dstr
         exp.each do |e|
           if sexp? e and match = has_immediate_model?(e, out)
             return match
           end
         end
         false
-      when :string_eval
+      when :string_eval, :evstr
         if sexp? exp.value
           if exp.value.node_type == :rlist
             exp.value.each_sexp do |e|

--- a/lib/brakeman/checks/check_render.rb
+++ b/lib/brakeman/checks/check_render.rb
@@ -36,13 +36,13 @@ class Brakeman::CheckRender < Brakeman::BaseCheck
 
 
       if input = has_immediate_user_input?(view)
-        confidence = CONFIDENCE[:high]
-      elsif input = include_user_input?(view)
         if node_type? view, :string_interp, :dstr
           confidence = CONFIDENCE[:med]
         else
-          confidence = CONFIDENCE[:low]
+          confidence = CONFIDENCE[:high]
         end
+      elsif input = include_user_input?(view)
+        confidence = CONFIDENCE[:low]
       else
         return
       end

--- a/lib/brakeman/checks/check_render_inline.rb
+++ b/lib/brakeman/checks/check_render_inline.rb
@@ -1,0 +1,42 @@
+class Brakeman::CheckRenderInline < Brakeman::CheckCrossSiteScripting
+  Brakeman::Checks.add self
+
+  @description = "Checks for cross site scripting in render calls"
+
+  def run_check
+    setup
+
+    tracker.find_call(:target => nil, :method => :render).each do |result|
+      check_render result
+    end
+  end
+
+  def check_render result
+    return if duplicate? result
+    add_result result
+
+    call = result[:call]
+
+    if node_type? call, :render and
+      (call.render_type == :text or call.render_type == :inline)
+
+      render_value = call[2]
+
+      if input = has_immediate_user_input?(render_value)
+        warn :result => result,
+          :warning_type => "Cross Site Scripting",
+          :warning_code => :cross_site_scripting_inline,
+          :message => "Unescaped #{friendly_type_of input} rendered inline",
+          :code => input.match,
+          :confidence => CONFIDENCE[:high]
+      elsif input = has_immediate_model?(render_value)
+        warn :result => result,
+          :warning_type => "Cross Site Scripting",
+          :warning_code => :cross_site_scripting_inline,
+          :message => "Unescaped model attribute rendered inline",
+          :code => input,
+          :confidence => CONFIDENCE[:med]
+      end
+    end
+  end
+end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -85,6 +85,7 @@ module Brakeman::WarningCodes
     :CVE_2014_3514_call => 81,
     :unscoped_find => 82,
     :CVE_2011_2932 => 83,
+    :cross_site_scripting_inline => 84,
   }
 
   def self.code name

--- a/test/apps/rails4/app/controllers/another_controller.rb
+++ b/test/apps/rails4/app/controllers/another_controller.rb
@@ -17,4 +17,20 @@ class AnotherController < ApplicationController
   def also_use_bad_thing
     `#{@bad_thing}`
   end
+
+  def render_stuff
+    user_name = User.current_user.name
+
+    render :text => "Welcome back, #{params[:name]}!}"
+    render :text => "Welcome back, #{user_name}!}"
+    render :text => params[:q]
+    render :text => user_name
+
+    render :inline => "<%= #{params[:name]} %>"
+    render :inline => "<%= #{user_name} %>"
+
+    # should not warn
+    render :text => CGI.escapeHTML(params[:q])
+    render :text => "Welcome back, #{CGI::escapeHTML(params[:name])}!}"
+  end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -16,7 +16,7 @@ class Rails4Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 1,
       :template => 2,
-      :generic => 40
+      :generic => 46
     }
   end
 
@@ -461,6 +461,70 @@ class Rails4Tests < Test::Unit::TestCase
       :message => /^Rails\ 4\.0\.0 has\ a\ vulnerability\ in/,
       :confidence => 1,
       :relative_path => "Gemfile",
+      :user_input => nil
+  end
+
+  def test_cross_site_scripting_render_text
+    assert_warning :type => :warning,
+      :warning_code => 84,
+      :fingerprint => "9e40043f992762c78415ef06c2b50916d6f16112759fb2762b9a781e09d651e0",
+      :warning_type => "Cross Site Scripting",
+      :line => 24,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/controllers/another_controller.rb",
+      :user_input => nil
+
+    assert_warning :type => :warning,
+      :warning_code => 84,
+      :fingerprint => "e8ab2a0727aec11bd56cdac0fa0e9f340e2d739fd964f0d9fe044f0707544bf0",
+      :warning_type => "Cross Site Scripting",
+      :line => 25,
+      :message => /^Unescaped\ model\ attribute/,
+      :confidence => 1,
+      :relative_path => "app/controllers/another_controller.rb",
+      :user_input => nil
+
+    assert_warning :type => :warning,
+      :warning_code => 84,
+      :fingerprint => "44697e7dc6c955c6bd7747c31f3c7617c0da3dcdb9bdae0963b62cbc4462e39f",
+      :warning_type => "Cross Site Scripting",
+      :line => 26,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/controllers/another_controller.rb",
+      :user_input => nil
+
+    assert_warning :type => :warning,
+      :warning_code => 84,
+      :fingerprint => "e8ab2a0727aec11bd56cdac0fa0e9f340e2d739fd964f0d9fe044f0707544bf0",
+      :warning_type => "Cross Site Scripting",
+      :line => 27,
+      :message => /^Unescaped\ model\ attribute/,
+      :confidence => 1,
+      :relative_path => "app/controllers/another_controller.rb",
+      :user_input => nil
+  end
+
+  def test_cross_site_scripting_render_inline
+    assert_warning :type => :warning,
+      :warning_code => 84,
+      :fingerprint => "9e40043f992762c78415ef06c2b50916d6f16112759fb2762b9a781e09d651e0",
+      :warning_type => "Cross Site Scripting",
+      :line => 29,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/controllers/another_controller.rb",
+      :user_input => nil
+
+    assert_warning :type => :warning,
+      :warning_code => 84,
+      :fingerprint => "e8ab2a0727aec11bd56cdac0fa0e9f340e2d739fd964f0d9fe044f0707544bf0",
+      :warning_type => "Cross Site Scripting",
+      :line => 30,
+      :message => /^Unescaped\ model\ attribute/,
+      :confidence => 1,
+      :relative_path => "app/controllers/another_controller.rb",
       :user_input => nil
   end
 


### PR DESCRIPTION
Warn about unescaped values in `render :text` and `render :inline`.

For example,

```ruby
render :text => "Sorry, #{params[:username]} is not a valid user"
```

This change also fixes an issue in BaseCheck where some interpolated strings may have been missed. This may cause new warnings to be found and existing warnings to change confidence levels.