### PR TITLE
process inner body expressions to trigger interpolated string warnings

### DIFF
--- a/lib/brakeman/processors/library_processor.rb
+++ b/lib/brakeman/processors/library_processor.rb
@@ -106,10 +106,8 @@ class Brakeman::LibraryProcessor < Brakeman::BaseProcessor
     exp.node_type = :methdef
 
     if @current_class
-      exp.body = process_all! exp.body
       @current_class[:public][exp.method_name] = { :src => exp, :file => @file_name }
     elsif @current_module
-      exp.body = process_all! exp.body
       @current_module[:public][exp.method_name] = { :src => exp, :file => @file_name }
     end
 
@@ -121,10 +119,8 @@ class Brakeman::LibraryProcessor < Brakeman::BaseProcessor
     exp.node_type = :selfdef
 
     if @current_class
-      exp.body = process_all! exp.body
       @current_class[:public][exp.method_name] = { :src => exp, :file => @file_name }
     elsif @current_module
-      exp.body = process_all! exp.body
       @current_module[:public][exp.method_name] = { :src => exp, :file => @file_name }
     end
 

--- a/lib/brakeman/processors/library_processor.rb
+++ b/lib/brakeman/processors/library_processor.rb
@@ -106,8 +106,10 @@ class Brakeman::LibraryProcessor < Brakeman::BaseProcessor
     exp.node_type = :methdef
 
     if @current_class
+      exp.body = process_all! exp.body
       @current_class[:public][exp.method_name] = { :src => exp, :file => @file_name }
     elsif @current_module
+      exp.body = process_all! exp.body
       @current_module[:public][exp.method_name] = { :src => exp, :file => @file_name }
     end
 
@@ -119,8 +121,10 @@ class Brakeman::LibraryProcessor < Brakeman::BaseProcessor
     exp.node_type = :selfdef
 
     if @current_class
+      exp.body = process_all! exp.body
       @current_class[:public][exp.method_name] = { :src => exp, :file => @file_name }
     elsif @current_module
+      exp.body = process_all! exp.body
       @current_module[:public][exp.method_name] = { :src => exp, :file => @file_name }
     end
 

--- a/test/apps/rails4/lib/sweet_lib.rb
+++ b/test/apps/rails4/lib/sweet_lib.rb
@@ -2,4 +2,9 @@ class SweetLib
   def do_some_cool_stuff bad
     `ls #{bad}`
   end
+
+  def test_find_group
+    #Should warn, no escaping done for :group
+    User.find(:all, :conditions => "title = 'blah'", :group => "something, #{params[:group]}")
+  end
 end

--- a/test/apps/rails4/lib/sweet_lib.rb
+++ b/test/apps/rails4/lib/sweet_lib.rb
@@ -5,6 +5,6 @@ class SweetLib
 
   def test_find_group
     #Should warn, no escaping done for :group
-    User.find(:all, :conditions => "title = 'blah'", :group => "something, #{params[:group]}")
+    system("rm #{@bad}")
   end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -16,7 +16,7 @@ class Rails4Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 1,
       :template => 2,
-      :generic => 47
+      :generic => 48
     }
   end
 
@@ -555,13 +555,25 @@ class Rails4Tests < Test::Unit::TestCase
   def test_command_injection_in_library
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "9a11e7271784d69c667ad82481596096781a4873297d3f7523d290f51465f9d6",
+      :fingerprint => "21857e8872d187312a0b2470876bf6c8a8885df84c510d766f4639d95ae7cef7",
       :warning_type => "Command Injection",
       :line => 3,
       :message => /^Possible\ command\ injection/,
       :confidence => 1,
       :relative_path => "lib/sweet_lib.rb",
       :user_input => s(:lvar, :bad)
+  end
+
+  def test_sql_injection_interpolated_group_param_in_library
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "6e102c5b2e1ac8f8dd9db995daa10e1dceb9c53c628bac781ff25108acfae9dc",
+      :warning_type => "SQL Injection",
+      :line => 8,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "lib/sweet_lib.rb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :group))
   end
 
   def test_command_injection_from_not_skipping_before_filter

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -567,7 +567,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_sql_injection_interpolated_group_param_in_library
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "6e102c5b2e1ac8f8dd9db995daa10e1dceb9c53c628bac781ff25108acfae9dc",
+      :fingerprint => "dd032fd10d9f75171111dada136906dcb605c61ad492431ca2fa243707264a4c",
       :warning_type => "SQL Injection",
       :line => 8,
       :message => /^Possible\ SQL\ injection/,

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -555,7 +555,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_command_injection_in_library
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "21857e8872d187312a0b2470876bf6c8a8885df84c510d766f4639d95ae7cef7",
+      :fingerprint => "9a11e7271784d69c667ad82481596096781a4873297d3f7523d290f51465f9d6",
       :warning_type => "Command Injection",
       :line => 3,
       :message => /^Possible\ command\ injection/,
@@ -567,7 +567,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_sql_injection_interpolated_group_param_in_library
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "dd032fd10d9f75171111dada136906dcb605c61ad492431ca2fa243707264a4c",
+      :fingerprint => "3acaa2bbe232e6fb04e9bfe309bdf1b16bab7495f469fcafdb83181b044d4922",
       :warning_type => "SQL Injection",
       :line => 8,
       :message => /^Possible\ SQL\ injection/,

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -555,7 +555,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_command_injection_in_library
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "9a11e7271784d69c667ad82481596096781a4873297d3f7523d290f51465f9d6",
+      :fingerprint => "21857e8872d187312a0b2470876bf6c8a8885df84c510d766f4639d95ae7cef7",
       :warning_type => "Command Injection",
       :line => 3,
       :message => /^Possible\ command\ injection/,
@@ -564,16 +564,16 @@ class Rails4Tests < Test::Unit::TestCase
       :user_input => s(:lvar, :bad)
   end
 
-  def test_sql_injection_interpolated_group_param_in_library
+  def test_command_injection_interpolated_string_in_library
     assert_warning :type => :warning,
-      :warning_code => 0,
-      :fingerprint => "3acaa2bbe232e6fb04e9bfe309bdf1b16bab7495f469fcafdb83181b044d4922",
-      :warning_type => "SQL Injection",
+      :warning_code => 14,
+      :fingerprint => "69855e4f6509c389b337195c00517b13b89a69773dcd1281ee3ae5577c8f2cf0",
+      :warning_type => "Command Injection",
       :line => 8,
-      :message => /^Possible\ SQL\ injection/,
-      :confidence => 0,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 1,
       :relative_path => "lib/sweet_lib.rb",
-      :user_input => s(:call, s(:params), :[], s(:lit, :group))
+      :user_input => s(:ivar, :@bad)
   end
 
   def test_command_injection_from_not_skipping_before_filter


### PR DESCRIPTION
We had added library processing to our internal fork of brakeman and noticed that some things, like warnings related to interpolated strings, were not getting triggered in scanned libs. So, I made a change in https://github.com/github/brakeman/pull/10 that processes the inner body expression similar to how other processors do (controllers, etc). However, I'm still not 100% sure if the approach taken is idiomatic with the rest of brakeman. So, please let me know if there is a more "correct" way of ensuring that the nested body's are processed so that interpolated strings are analyzed correctly. 

/cc @gregose @mastahyeti @oreoshake 