### PR TITLE
add additional_libs option to process arbitrary additional directories

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -17,6 +17,8 @@ module Brakeman
   #Options:
   #
   #  * :app_path - path to root of Rails app (required)
+  #  * :additional_checks_path - array of additional directories containing additional out-of-tree checks to run
+  #  * :additional_libs_path - array of additional application relative lib directories (ex. app/mailers) to process
   #  * :assume_all_routes - assume all methods are routes (default: true)
   #  * :check_arguments - check arguments of methods (default: true)
   #  * :collapse_mass_assignment - report unprotected models in single warning (default: false)

--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -15,6 +15,7 @@ module Brakeman
       if options[:only_files]
         init_options[:only_files] = Regexp.new("(?:" << options[:only_files].map { |f| Regexp.escape f }.join("|") << ")")
       end
+      init_options[:additional_libs_path] = options[:additional_libs_path]
       new(root, init_options)
     end
 
@@ -22,6 +23,7 @@ module Brakeman
       @root = root
       @skip_files = init_options[:skip_files]
       @only_files = init_options[:only_files]
+      @additional_libs_path = init_options[:additional_libs_path] || []
     end
 
     def expand_path(path)
@@ -71,10 +73,15 @@ module Brakeman
     end
 
     def lib_paths
-      @lib_files ||= find_paths("lib").reject { |path| path.include? "/generators/" or path.include? "lib/tasks/" }
+      @lib_files ||= find_paths("lib").reject { |path| path.include? "/generators/" or path.include? "lib/tasks/" } +
+                     find_additional_lib_paths
     end
 
   private
+
+    def find_additional_lib_paths
+      @additional_libs_path.collect{ |path| find_paths path }.flatten
+    end
 
     def find_paths(directory, extensions = "*.rb")
       pattern = @root + "/{engines/*/,}#{directory}/**/#{extensions}"

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -124,6 +124,11 @@ module Brakeman::Options
           options[:skip_libs] = true
         end
 
+        opts.on "--add-libs-path path1,path2,etc", Array, "An application relative lib directory (ex. app/mailers) to process" do |paths|
+          options[:additional_libs_path] ||= Set.new
+          options[:additional_libs_path].merge paths
+        end
+
         opts.on "-t", "--test Check1,Check2,etc", Array, "Only run the specified checks" do |checks|
           checks.each_with_index do |s, index|
             if s[0,5] != "Check"

--- a/test/apps/rails4/app/api/api.rb
+++ b/test/apps/rails4/app/api/api.rb
@@ -1,0 +1,6 @@
+module API
+
+  def insecure_command_execution
+    Open3.capture2 "ls #{params[:dir]}"
+  end
+end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -1,7 +1,7 @@
 abort "Please run using test/test.rb" unless defined? BrakemanTester
 
 EXTERNAL_CHECKS_PATH = File.expand_path(File.join(File.dirname(__FILE__), "..", "/apps/rails4/external_checks"))
-Rails4 = BrakemanTester.run_scan "rails4", "Rails 4", {:additional_checks_path => [EXTERNAL_CHECKS_PATH], :run_all_checks => true}
+Rails4 = BrakemanTester.run_scan "rails4", "Rails 4", {:additional_checks_path => [EXTERNAL_CHECKS_PATH], :run_all_checks => true, :additional_libs_path => ["app/api"]}
 
 class Rails4Tests < Test::Unit::TestCase
   include BrakemanTester::FindWarning
@@ -16,7 +16,7 @@ class Rails4Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 1,
       :template => 2,
-      :generic => 48
+      :generic => 49
     }
   end
 
@@ -550,6 +550,18 @@ class Rails4Tests < Test::Unit::TestCase
       :confidence => 0,
       :relative_path => "app/controllers/another_controller.rb",
       :user_input => s(:call, s(:params), :[], s(:lit, :x))
+  end
+
+  def test_additional_libs_option
+    assert_warning :type => :warning,
+      :warning_code => 14,
+      :fingerprint => "528555766bb642ac7137a2a3b14d022ad12cc2006925b2a028d7f07c1c804204",
+      :warning_type => "Command Injection",
+      :line => 4,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 0,
+      :relative_path => "app/api/api.rb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :dir))
   end
 
   def test_command_injection_in_library


### PR DESCRIPTION
We had a patch to process the `lib` directory, as well as other directories that are "lib equivalent". Now that V3.0.0 processes the `lib` directory we thought it might be useful for upstream brakeman to support the same thing.

P.S. I will have to update the unit test after https://github.com/presidentbeef/brakeman/pull/605/ is merged, since the warning count will change.

/cc @gregose @mastahyeti @oreoshake 