### PR TITLE
Fix command/string interpolation code output yet again

### DIFF
--- a/lib/brakeman/processors/output_processor.rb
+++ b/lib/brakeman/processors/output_processor.rb
@@ -43,41 +43,8 @@ class Brakeman::OutputProcessor < Ruby2Ruby
     "cookies"
   end
 
-  def process_string_interp exp
-    out = '"'
-    exp.each do |e|
-      if e.is_a? String
-        out << e
-      else
-        res = process e
-        out << res unless res == "" 
-      end
-    end
-    out << '"'
-    exp.clear
-    out
-  end
-
-  def process_string_eval exp
-    out = "\#{#{process(exp[0])}}"
-    exp.clear
-    out
-  end
-
-  def process_dxstr exp
-    out = "`"
-    out << exp.map! do |e|
-      if e.is_a? String
-        e
-      elsif string? e
-        e[1]
-      else
-        "\#{#{process e}}"
-      end
-    end.join
-    exp.clear
-    out << "`"
-  end
+  alias process_string_interp process_dstr
+  alias process_string_eval process_evstr
 
   def process_rlist exp
     out = exp.map do |e|
@@ -226,6 +193,8 @@ class Brakeman::OutputProcessor < Ruby2Ruby
         else
           raise "unknown type: #{pt.inspect}"
         end
+      when String then
+        s << pt
       else
         # HACK: raise "huh?: #{pt.inspect}" -- hitting # constants in regexps
         # do nothing for now

--- a/test/tests/output_processor.rb
+++ b/test/tests/output_processor.rb
@@ -83,6 +83,12 @@ class OutputProcessorTests < Test::Unit::TestCase
                                       "",
                                       Sexp.new(:string_eval,
                                                Sexp.new(:ivar, :@x)))
+
+    input = '"#{params[:plugin]}/app/views/#{params[:view]}"'
+    s_input = RubyParser.new.parse(input)
+
+    assert_output input,
+      Brakeman::BaseProcessor.new(nil).process(s_input)
   end
 
   def test_output_format
@@ -179,5 +185,9 @@ class OutputProcessorTests < Test::Unit::TestCase
   def test_command_interpolation
     assert_output '`#{x}`',
       s(:dxstr, "", s(:evstr, s(:call, nil, :x)))
+
+
+    input = Brakeman::BaseProcessor.new(nil).process(RubyParser.new.parse('`1#{x}2#{y}3`'))
+    assert_output '`1#{x}2#{y}3`', input
   end
 end


### PR DESCRIPTION
Should only affect code formatting in warning reports, no fingerprints.