### PR TITLE
Do not warn about missing CSRF protection in API

### DIFF
--- a/lib/brakeman/checks/check_forgery_setting.rb
+++ b/lib/brakeman/checks/check_forgery_setting.rb
@@ -11,6 +11,9 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
 
   def run_check
     app_controller = tracker.controllers[:ApplicationController]
+
+    return unless ancestor? app_controller, :"ActionController::Base"
+
     if tracker.config[:rails][:action_controller] and
       tracker.config[:rails][:action_controller][:allow_forgery_protection] == Sexp.new(:false)
 

--- a/test/apps/rails4/app/controllers/application_controller.rb
+++ b/test/apps/rails4/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
-class ApplicationController < ActionController::Base
+class ApplicationController < ActionController::API
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  # protect_from_forgery with: :exception
 
   def show_detailed_exceptions?
     true

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -790,6 +790,18 @@ class Rails4Tests < Test::Unit::TestCase
       :user_input => s(:call, s(:call, nil, :params), :[], s(:lit, :x))
   end
 
+  def test_cross_site_request_forgery_setting_in_api_controller
+    assert_no_warning :type => :controller,
+      :warning_code => 7,
+      :fingerprint => "6f5239fb87c64764d0c209014deb5cf504c2c10ee424bd33590f0a4f22e01d8f",
+      :warning_type => "Cross-Site Request Forgery",
+      :line => nil,
+      :message => /^'protect_from_forgery'\ should\ be\ called\ /,
+      :confidence => 0,
+      :relative_path => "app/controllers/application_controller.rb",
+      :user_input => nil
+  end
+
   #Verify checks external to Brakeman are loaded
   def test_external_checks
     assert defined? Brakeman::CheckExternalCheckTest


### PR DESCRIPTION
If ApplicationController does not inherit from ActionController::Base, do not warn about missing/disabled `protect_from_forgery`.

This would close #573.