### PR TITLE
Ignore case value for XSS purposes

### DIFF
--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -260,6 +260,19 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
     exp
   end
 
+  def process_case exp
+    #Ignore user input in case value
+    #TODO: also ignore when values
+
+    current = 2
+    while current < exp.length
+      process exp[current] if exp[current]
+      current += 1
+    end
+
+    exp
+  end
+
   def setup
     @ignore_methods = Set[:button_to, :check_box, :content_tag, :escapeHTML, :escape_once,
                            :field_field, :fields_for, :h, :hidden_field,

--- a/test/apps/rails4/app/controllers/users_controller.rb
+++ b/test/apps/rails4/app/controllers/users_controller.rb
@@ -65,4 +65,15 @@ class UsersController < ApplicationController
   def email_finds
     Email.find_by_id! params[:email][:id]
   end
+
+  def case_statement
+    @x = case params[:x]
+         when :yes
+           "yep"
+         when :no
+           "nope"
+         else
+           "dunno"
+         end
+  end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -343,6 +343,18 @@ class Rails4Tests < Test::Unit::TestCase
       :user_input => s(:call, s(:params), :[], s(:lit, :page))
   end
 
+  def test_no_cross_site_scripting_in_case_value
+    assert_no_warning :type => :template,
+      :warning_code => 5,
+      :fingerprint => "e9a2843313999c2e856065efaf0a84ffc56ed912112c34927f406339bb395715",
+      :warning_type => "Cross Site Scripting",
+      :line => 1,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 2,
+      :relative_path => "app/views/users/case_statement.html.erb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :x))
+  end
+
   def test_cross_site_request_forgery_with_skip_before_action
     assert_warning :type => :warning,
       :warning_code => 8,


### PR DESCRIPTION
For example.
```ruby
case params[:x]
when ...
```
should not warn about `params[:x]`.