### PR TITLE
Remove formatting newlines from HAML templates

### DIFF
--- a/lib/brakeman/parsers/template_parser.rb
+++ b/lib/brakeman/parsers/template_parser.rb
@@ -75,7 +75,7 @@ module Brakeman
       Brakeman.load_brakeman_dependency 'sass'
 
       Haml::Engine.new(text,
-                       :escape_html => !!tracker.config[:escape_html]).precompiled
+                       :escape_html => !!tracker.config[:escape_html]).precompiled.gsub(/([^\\])\\n/, '\1')
     end
 
     def parse_slim text

--- a/test/apps/rails4/app/views/users/haml_test.html.haml
+++ b/test/apps/rails4/app/views/users/haml_test.html.haml
@@ -1,0 +1,5 @@
+#content
+  .some.stuff
+    %p= params[:x]
+  #innerstuff
+    %h1= raw params[:y]

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Test::Unit::TestCase
     @expected ||= {
       :controller => 0,
       :model => 1,
-      :template => 2,
+      :template => 3,
       :generic => 49
     }
   end
@@ -525,6 +525,18 @@ class Rails4Tests < Test::Unit::TestCase
       :message => /^Unescaped\ model\ attribute/,
       :confidence => 1,
       :relative_path => "app/controllers/another_controller.rb",
+      :user_input => nil
+  end
+
+  def test_xss_haml_line_number
+    assert_warning :type => :template,
+      :warning_code => 2,
+      :fingerprint => "f46cf9e2ae9df8f14d195c41589aa3f64a2347b93b899d8871bf4daffeb33c5f",
+      :warning_type => "Cross Site Scripting",
+      :line => 5,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/views/users/haml_test.html.haml",
       :user_input => nil
   end
 


### PR DESCRIPTION
In order to avoid really wrong line numbers in newer versions of ruby_parser.

If any templates happen to have `\n` in the template code and that code is included in a warning, it will be missing the `\n`.