### PR TITLE
Remove URI.escape from HTML report with GitHub repo url

### DIFF
--- a/lib/brakeman/report/report_html.rb
+++ b/lib/brakeman/report/report_html.rb
@@ -195,7 +195,7 @@ class Brakeman::Report::HTML < Brakeman::Report::Base
 
     if warning.file
       github_url = github_url warning.file, warning.line
-      message.gsub!(/(near line \d+)/, "<a href='#{URI.escape github_url, /'/}' target='_blank'>\\1</a>") if github_url
+      message.gsub!(/(near line \d+)/, "<a href=\"#{github_url}\" target='_blank'>\\1</a>") if github_url
     end
 
     if @highlight_user_input and warning.user_input


### PR DESCRIPTION
Apparently `URI.escape` is deprecated and in this case it was only to escape single quotes. So I just removed the need for that.

Fixes #624

//cc: @gregose