### PR TITLE
Better render path information for templates

### DIFF
--- a/lib/brakeman/processors/controller_alias_processor.rb
+++ b/lib/brakeman/processors/controller_alias_processor.rb
@@ -1,5 +1,6 @@
 require 'brakeman/processors/alias_processor'
 require 'brakeman/processors/lib/render_helper'
+require 'brakeman/processors/lib/render_path'
 require 'brakeman/processors/lib/find_return_value'
 
 #Processes aliasing in controllers, but includes following
@@ -170,7 +171,8 @@ class Brakeman::ControllerAliasProcessor < Brakeman::AliasProcessor
 
   #Process template and add the current class and method name as called_from info
   def process_template name, args
-    super name, args, ["#@current_class##@current_method"]
+    render_path = Brakeman::RenderPath.new.add_controller_render(@current_class, @current_method)
+    super name, args, render_path
   end
 
   #Turns a method name into a template name

--- a/lib/brakeman/processors/lib/render_path.rb
+++ b/lib/brakeman/processors/lib/render_path.rb
@@ -1,0 +1,100 @@
+module Brakeman
+  class RenderPath
+    attr_reader :path
+
+    def initialize
+      @path = []
+    end
+
+    def add_controller_render controller_name, method_name
+      method_name ||= ""
+
+      @path << { :type => :controller,
+                 :class => controller_name.to_sym,
+                 :method => method_name.to_sym }
+
+      self
+    end
+
+    def add_template_render template_name
+      @path << { :type => :template,
+                 :name => template_name.to_sym }
+
+      self
+    end
+
+    def include_template? name
+      name = name.to_sym
+
+      @path.any? do |loc|
+        loc[:type] == :template and loc[:name] == name
+      end
+    end
+
+    def include_controller? klass
+      klass = klass.to_sym
+
+      @path.any? do |loc|
+        loc[:type] == :controller and loc[:class] == klass
+      end
+    end
+
+    def include_any_method? method_names
+      names = method_names.map(&:to_sym)
+
+      @path.any? do |loc|
+        loc[:type] == :controller and names.include? loc[:method]
+      end
+    end
+
+    def rendered_from_controller?
+      @path.any? do |loc|
+        loc[:type] == :controller
+      end
+    end
+
+    def each &block
+      @path.each &block
+    end
+
+    def join *args
+      self.to_a.join *args
+    end
+
+    def length
+      @path.length
+    end
+
+    def to_a
+      @path.map do |loc|
+        case loc[:type]
+        when :template
+          "Template:#{loc[:name]}"
+        when :controller
+          "#{loc[:class]}##{loc[:method]}"
+        end
+      end
+    end
+
+    def last
+      self.to_a.last
+    end
+
+    def to_s
+      self.to_a.to_s
+    end
+
+    def to_sym
+      self.to_s.to_sym
+    end
+
+    def to_json *args
+      self.to_a.to_json *args
+    end
+
+    def initialize_copy original
+      @path = original.path.dup
+      self
+    end
+  end
+end

--- a/lib/brakeman/processors/lib/render_path.rb
+++ b/lib/brakeman/processors/lib/render_path.rb
@@ -89,7 +89,7 @@ module Brakeman
     end
 
     def to_json *args
-      self.to_a.to_json *args
+      MultiJson.dump(self.to_a)
     end
 
     def initialize_copy original

--- a/lib/brakeman/processors/template_alias_processor.rb
+++ b/lib/brakeman/processors/template_alias_processor.rb
@@ -1,6 +1,7 @@
 require 'set'
 require 'brakeman/processors/alias_processor'
 require 'brakeman/processors/lib/render_helper'
+require 'brakeman/processors/lib/render_path'
 require 'brakeman/tracker'
 
 #Processes aliasing in templates.
@@ -19,14 +20,14 @@ class Brakeman::TemplateAliasProcessor < Brakeman::AliasProcessor
   #Process template
   def process_template name, args
     if @called_from
-      unless @called_from.grep(/Template:#{name}$/).empty?
+      if @called_from.include_template? name
         Brakeman.debug "Skipping circular render from #{@template[:name]} to #{name}"
         return
       end
 
-      super name, args, @called_from + ["Template:#{@template[:name]}"]
+      super name, args, @called_from.dup.add_template_render(@template[:name])
     else
-      super name, args, ["Template:#{@template[:name]}"]
+      super name, args, Brakeman::RenderPath.new.add_template_render(@template[:name])
     end
   end
 

--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -257,7 +257,7 @@ class Brakeman::Tracker
   def reset_templates options = { :only_rendered => false }
     if options[:only_rendered]
       @templates.delete_if do |name, template|
-        name.to_s.include? "Controller#"
+        template[:caller] and template[:caller].rendered_from_controller?
       end
     else
       @templates = {}
@@ -311,11 +311,10 @@ class Brakeman::Tracker
     @controllers.each do |name, controller|
       if controller[:files].include?(path)
         controller_name = name
-        template_matcher = /^#{name}#/
 
         #Remove templates rendered from this controller
         @templates.each do |template_name, template|
-          if template[:caller] and not template[:caller].grep(template_matcher).empty?
+          if template[:caller] and template[:caller].include_controller? name
             reset_template template_name
             @call_index.remove_template_indexes template_name
           end

--- a/test/tests/json_output.rb
+++ b/test/tests/json_output.rb
@@ -6,10 +6,10 @@ class JSONOutputTests < Test::Unit::TestCase
   end
 
   def test_for_render_path
-    assert @json["warnings"].all? { |warning|
-      warning.keys.include?("render_path") and
-      (warning["render_path"].nil? or warning["render_path"].is_a? Array)
-    }
+    @json["warnings"].each do |warning|
+      is_right_thing = warning.keys.include?("render_path") && (warning["render_path"].nil? or warning["render_path"].is_a? Array)
+      assert is_right_thing, "#{warning["render_path"].class} is not right"
+    end
   end
 
   def test_for_expected_keys

--- a/test/tests/render_path.rb
+++ b/test/tests/render_path.rb
@@ -1,0 +1,56 @@
+class RenderPathTests < Test::Unit::TestCase
+  def setup
+    @r = Brakeman::RenderPath.new
+  end
+
+  def test_include_controller
+    @r.add_controller_render :TestController, :test
+
+    assert @r.include_controller? :TestController
+  end
+
+  def test_rendered_from_controller
+    @r.add_controller_render :TestController, :test
+
+    assert @r.rendered_from_controller?
+  end
+
+  def test_include_template
+    @r.add_template_render 'some/template'
+
+    assert @r.include_template? :'some/template'
+  end
+
+  def test_include_any_method
+    @r.add_controller_render :TestController, :test
+    @r.add_controller_render :TestController, :test2
+    @r.add_controller_render :TestController, :test3
+
+    assert @r.include_any_method? ['test']
+  end
+
+  def test_each
+    @r.add_controller_render :TestController, :test
+    @r.add_template_render 'some/template'
+
+    @r.each do |loc|
+      case loc[:type]
+      when :template
+        assert_equal :'some/template', loc[:name]
+      when :controller
+        assert_equal :TestController, loc[:class]
+        assert_equal :test, loc[:method]
+      end
+    end
+  end
+
+  def test_dup
+    @r.add_controller_render :TestController, :test
+
+    s = @r.dup
+    s.add_template_render 'some/template'
+
+    assert_equal 1, @r.length
+    assert_equal 2, s.length
+  end
+end


### PR DESCRIPTION
Use an actual data structure instead of an array of strings with semantics embedded in them.

Ideally this information should then be available in the JSON report, but that is a pretty serious change so for now it's only an internal change.