### PR TITLE
Avoid warning about mass assignment with literals

### DIFF
--- a/lib/brakeman/checks/check_mass_assignment.rb
+++ b/lib/brakeman/checks/check_mass_assignment.rb
@@ -82,6 +82,8 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
           confidence = CONFIDENCE[:low]
           user_input = input.match
         end
+      elsif node_type? call.first_arg, :lit, :str
+        return
       else
         confidence = CONFIDENCE[:low]
         user_input = nil

--- a/test/apps/rails_with_xss_plugin/app/controllers/users_controller.rb
+++ b/test/apps/rails_with_xss_plugin/app/controllers/users_controller.rb
@@ -139,4 +139,8 @@ class UsersController < ApplicationController
   def test_sanitize
     @x = params[:x]
   end
+
+  def string_mass
+    User.new("stuff")
+  end
 end

--- a/test/tests/rails_with_xss_plugin.rb
+++ b/test/tests/rails_with_xss_plugin.rb
@@ -103,6 +103,17 @@ class RailsWithXssPluginTests < Test::Unit::TestCase
       :file => /users_controller\.rb/
   end
 
+  def test_mass_assignment_with_string
+    assert_no_warning :type => :warning,
+      :warning_code => 17,
+      :fingerprint => "2893b1a48ec56548a5a48d38324c5d78f7845066713ad79bb0ec17032672c862",
+      :warning_type => "Mass Assignment",
+      :line => 97,
+      :message => /^Unprotected\ mass\ assignment/,
+      :confidence => 2,
+      :relative_path => "app/controllers/other_controller.rb",
+      :user_input => nil
+  end
 
   def test_redirect_to_model_instance
     assert_no_warning :type => :warning,


### PR DESCRIPTION
like `Comment.new("here is a comment")`

Probably doesn't happen much, as it likely means Brakeman thought something was a model that isn't really.