### PR TITLE
Don't ignore calls in models outside methods

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -179,7 +179,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       exp.block_args.each do |e|
         #Force block arg(s) to be local
         if node_type? e, :lasgn
-          env.current[Sexp.new(:lvar, e.lhs)] = e.rhs
+          env.current[Sexp.new(:lvar, e.lhs)] = Sexp.new(:lvar, e.lhs)
         elsif node_type? e, :kwarg
           env.current[Sexp.new(:lvar, e[1])] = e[2]
         elsif node_type? e, :masgn, :shadow

--- a/lib/brakeman/processors/model_processor.rb
+++ b/lib/brakeman/processors/model_processor.rb
@@ -170,7 +170,8 @@ class Brakeman::ModelProcessor < Brakeman::BaseProcessor
           end
         end
       end
-      ignore
+
+      exp
     else
       call = make_call target, method, process_all!(exp.args)
       call.line(exp.line)

--- a/test/apps/rails4/app/models/email.rb
+++ b/test/apps/rails4/app/models/email.rb
@@ -2,4 +2,18 @@ class Email < ActiveRecord::Base
   attr_accessible :email
 
   belongs_to :user
+
+  EMAIL_REGEX = /^[a-z0-9]+@[a-z0-9]+\.[a-z]+$/
+
+  validates_format_of :email, with: EMAIL_REGEX
+
+  scope :assigned_to_user, ->(user) {
+    task_table = User.table_name
+
+    joins("INNER JOIN #{task_table}
+          ON  #{task_table}.user_id = #{user.id}
+          AND (#{task_table}.type_id = #{table_name}.type_id)
+          AND (#{task_table}.manager_id = #{table_name}.manager_id)
+          ")
+  }
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -14,7 +14,7 @@ class Rails4Tests < Test::Unit::TestCase
   def expected
     @expected ||= {
       :controller => 0,
-      :model => 1,
+      :model => 2,
       :template => 3,
       :generic => 51
     }
@@ -619,6 +619,31 @@ class Rails4Tests < Test::Unit::TestCase
       :confidence => 1,
       :relative_path => "app/models/user.rb",
       :user_input => s(:call, s(:const, :User), :table_name)
+  end
+
+  def test_sql_injection_scope_alias_processing
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "a28e3653220903b78e2f00f1e571aa7afaa4f7db6f0789be8cf59c1b9eb583a1",
+      :warning_type => "SQL Injection",
+      :line => 13,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 1,
+      :relative_path => "app/models/email.rb",
+      :user_input => s(:lvar, :task_table)
+
+  end
+
+  def test_format_validation_model_alias_processing
+    assert_warning :type => :model,
+      :warning_code => 30,
+      :fingerprint => "d2bfa987fd0e59d1d515a0bc0baaf378d1dd75483184c945b662b96d370add28",
+      :warning_type => "Format Validation",
+      :line => 8,
+      :message => /^Insufficient\ validation\ for\ 'email'\ usin/,
+      :confidence => 0,
+      :relative_path => "app/models/email.rb",
+      :user_input => nil
   end
 
   def test_additional_libs_option


### PR DESCRIPTION
For whatever reason, calls outside of methods were ignored after initial processing, and did not go through alias processing. This meant constants were not propagated and things like [this happened](http://stackoverflow.com/questions/27853371/rails-brakeman-warning-of-sql-injection) when block/lambda arguments were not processed.