### PR TITLE
Special case `if [...].include? x`

### DIFF
--- a/test/apps/rails4/app/models/user.rb
+++ b/test/apps/rails4/app/models/user.rb
@@ -12,4 +12,15 @@ class User < ActiveRecord::Base
   def symbol_stuff
     self.where(User.table_name.to_sym)
   end
+
+  scope :sorted_by, ->(field, asc) {
+    asc = ['desc', 'asc'].include?(asc) ? asc : 'asc'
+
+    ordering = if field == 'extension'
+                 "substring_index(#{table_name}.data_file_name, '.', -1) #{asc}"
+               elsif SORTABLE_COLUMNS.include?(field)
+                 { field.to_sym => asc.to_sym }
+               end
+    order(ordering) # should not warn about `asc` interpolation
+  }
 end

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -640,4 +640,30 @@ class AliasProcessorTests < Test::Unit::TestCase
     x
     INPUT
   end
+
+  def test_branch_array_include
+    assert_alias 'x', <<-INPUT
+    if [1,2,3].include? x
+      stuff
+    end
+
+    x
+    INPUT
+
+    assert_output <<-INPUT, <<-OUTPUT
+    if [1,2,3].include? x
+      y = x + 2
+      p y
+    end
+
+    x
+    INPUT
+    if [1,2,3].include? x
+      y = 3
+      p 3
+    end
+
+    x
+    OUTPUT
+  end
 end


### PR DESCRIPTION
For code like this:

```ruby
if [1, 2, "a", "b"].include? x
  do_something_with x
end
```

inside the true branch `x` will be the first value of the array (in this case, `1`) because, logically, `x` must be one of those values, and all of them are likely just as safe (when they are all literals).

This allows Brakeman to avoid warning when a value has been whitelisted using this pattern