### PR TITLE
Handle lambdas in filters instead of blocks

### DIFF
--- a/test/apps/rails3.1/app/controllers/admin_controller.rb
+++ b/test/apps/rails3.1/app/controllers/admin_controller.rb
@@ -3,7 +3,7 @@ class AdminController < ApplicationController
   skip_before_filter :login_required, :except => :do_admin_stuff
   skip_filter :authenticate_user!, :except => :do_admin_stuff
   skip_before_filter :require_user, :except => [:do_admin_stuff, :do_other_stuff]
-
+  before_filter -> { @thing = params[:t] }, only: [:use_lambda_filter]
 
   def constantize_some_stuff
     klass = params[:class].constantize
@@ -46,6 +46,10 @@ class AdminController < ApplicationController
 
     system "echo #{1}"
     exec "nmap 192.168.#{1}.1"
+    system @thing # no warning
+  end
 
+  def use_lambda_filter
+    eval @thing
   end
 end

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -15,7 +15,7 @@ class Rails31Tests < Test::Unit::TestCase
       :model => 3,
       :template => 23,
       :controller => 4,
-      :generic => 79 }
+      :generic => 80 }
   end
 
   def test_without_protection
@@ -1265,5 +1265,17 @@ class Rails31Tests < Test::Unit::TestCase
       :message => /^Possible\ command\ injection/,
       :confidence => 1,
       :relative_path => "app/controllers/admin_controller.rb"
+  end
+
+  def test_eval_from_lambda_filter
+    assert_warning :type => :warning,
+      :warning_code => 13,
+      :fingerprint => "58e5c4088dc57057a112ab5c472633752f787b8f6b0437bbd19d82fa06afbddb",
+      :warning_type => "Dangerous Eval",
+      :line => 53,
+      :message => /^User\ input\ in\ eval/,
+      :confidence => 0,
+      :relative_path => "app/controllers/admin_controller.rb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :t))
   end
 end


### PR DESCRIPTION
See test.

Basically, treat

```ruby
before_filter ->{ do_stuff}
```

like

```ruby
before_filter do
  do_stuff
end
```