### PR TITLE
Only run scans when test runs

### DIFF
--- a/test/test.rb
+++ b/test/test.rb
@@ -25,19 +25,9 @@ module BrakemanTester
     #Run scan on app at the given path
     def run_scan path, name = nil, opts = {}
       opts.merge! :app_path => "#{TEST_PATH}/apps/#{path}",
-        :quiet => false,
         :url_safe_methods => [:ensure_valid_proto!]
 
-      announce "Processing #{name} application..."
-
       Brakeman.run(opts).report.to_hash
-    end
-
-    #Make an announcement
-    def announce msg
-      $stderr.puts "-" * 40
-      $stderr.puts msg
-      $stderr.puts "-" * 40
     end
   end
 end

--- a/test/tests/only_files_option.rb
+++ b/test/tests/only_files_option.rb
@@ -1,7 +1,5 @@
 abort "Please run using test/test.rb" unless defined? BrakemanTester
 
-Rails32OnlyFiles = BrakemanTester.run_scan "rails3.2", "Rails 3.2", { :only_files => ["app/views/users/"], :skip_files => ["app/views/users/sanitized.html.erb"] }
-
 class OnlyFilesOptionTests < Test::Unit::TestCase
   include BrakemanTester::FindWarning
   include BrakemanTester::CheckExpected
@@ -21,7 +19,7 @@ class OnlyFilesOptionTests < Test::Unit::TestCase
   end
 
   def report
-    Rails32OnlyFiles
+    @@report ||= BrakemanTester.run_scan "rails3.2", "Rails 3.2", { :only_files => ["app/views/users/"], :skip_files => ["app/views/users/sanitized.html.erb"] }
   end
 
   def test_escaped_params_to_json

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -5,8 +5,6 @@
 
 abort "Please run using test/test.rb" unless defined? BrakemanTester
 
-Rails2 = BrakemanTester.run_scan "rails2", "Rails 2", :run_all_checks => true, :collapse_mass_assignment => true
-
 class Rails2Tests < Test::Unit::TestCase
   include BrakemanTester::FindWarning
   include BrakemanTester::CheckExpected
@@ -28,7 +26,7 @@ class Rails2Tests < Test::Unit::TestCase
   end
 
   def report
-    Rails2
+    @@report ||= BrakemanTester.run_scan "rails2", "Rails 2", :run_all_checks => true, :collapse_mass_assignment => true
   end
 
   def test_no_errors
@@ -1399,8 +1397,6 @@ class Rails2Tests < Test::Unit::TestCase
   end
 end
 
-Rails2WithOptions = BrakemanTester.run_scan "rails2", "Rails 2", :run_all_checks => true
-
 class Rails2WithOptionsTests < Test::Unit::TestCase
   include BrakemanTester::FindWarning
   include BrakemanTester::CheckExpected
@@ -1422,7 +1418,7 @@ class Rails2WithOptionsTests < Test::Unit::TestCase
   end
 
   def report
-    Rails2WithOptions
+    @@report ||= BrakemanTester.run_scan "rails2", "Rails 2", :run_all_checks => true
   end
 
   def test_no_errors

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -1,14 +1,12 @@
 abort "Please run using test/test.rb" unless defined? BrakemanTester
 
-Rails3 = BrakemanTester.run_scan "rails3", "Rails 3", :rails3 => true,
-  :config_file => File.join(TEST_PATH, "apps", "rails3", "config", "brakeman.yml")
-
 class Rails3Tests < Test::Unit::TestCase
   include BrakemanTester::FindWarning
   include BrakemanTester::CheckExpected
   
   def report
-    Rails3
+    @@report ||= BrakemanTester.run_scan "rails3", "Rails 3", :rails3 => true,
+      :config_file => File.join(TEST_PATH, "apps", "rails3", "config", "brakeman.yml")
   end
 
   def expected

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -1,13 +1,11 @@
 abort "Please run using test/test.rb" unless defined? BrakemanTester
 
-Rails31 = BrakemanTester.run_scan "rails3.1", "Rails 3.1", :rails3 => true, :parallel_checks => false, :interprocedural => true
-
 class Rails31Tests < Test::Unit::TestCase
   include BrakemanTester::FindWarning
   include BrakemanTester::CheckExpected
 
   def report
-    Rails31
+    @@report ||= BrakemanTester.run_scan "rails3.1", "Rails 3.1", :rails3 => true, :parallel_checks => false, :interprocedural => true
   end
 
   def expected

--- a/test/tests/rails32.rb
+++ b/test/tests/rails32.rb
@@ -5,8 +5,6 @@
 
 abort "Please run using test/test.rb" unless defined? BrakemanTester
 
-Rails32 = BrakemanTester.run_scan "rails3.2", "Rails 3.2"
-
 class Rails32Tests < Test::Unit::TestCase
   include BrakemanTester::FindWarning
   include BrakemanTester::CheckExpected
@@ -26,11 +24,11 @@ class Rails32Tests < Test::Unit::TestCase
   end
 
   def report
-    Rails32
+    @@report ||= BrakemanTester.run_scan "rails3.2", "Rails 3.2"
   end
 
   def test_rc_version_number
-    assert_equal "3.2.9.rc2", Rails32[:config][:rails_version]
+    assert_equal "3.2.9.rc2", report[:config][:rails_version]
   end
 
   def test_sql_injection_CVE_2012_5664

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -1,14 +1,12 @@
 abort "Please run using test/test.rb" unless defined? BrakemanTester
 
-EXTERNAL_CHECKS_PATH = File.expand_path(File.join(File.dirname(__FILE__), "..", "/apps/rails4/external_checks"))
-Rails4 = BrakemanTester.run_scan "rails4", "Rails 4", {:additional_checks_path => [EXTERNAL_CHECKS_PATH], :run_all_checks => true, :additional_libs_path => ["app/api"]}
-
 class Rails4Tests < Test::Unit::TestCase
   include BrakemanTester::FindWarning
   include BrakemanTester::CheckExpected
 
   def report
-    Rails4
+    external_checks_path = File.expand_path(File.join(File.dirname(__FILE__), "..", "/apps/rails4/external_checks"))
+    @@report ||= BrakemanTester.run_scan "rails4", "Rails 4", {:additional_checks_path => [external_checks_path], :run_all_checks => true, :additional_libs_path => ["app/api"]}
   end
 
   def expected

--- a/test/tests/rails4_with_engines.rb
+++ b/test/tests/rails4_with_engines.rb
@@ -1,7 +1,5 @@
 abort "Please run using test/test.rb" unless defined? BrakemanTester
 
-Rails4WithEngines = BrakemanTester.run_scan "rails4_with_engines", "Rails4WithEngines"
-
 class Rails4WithEnginesTests < Test::Unit::TestCase
   include BrakemanTester::FindWarning
   include BrakemanTester::CheckExpected
@@ -15,7 +13,7 @@ class Rails4WithEnginesTests < Test::Unit::TestCase
   end
 
   def report
-    Rails4WithEngines
+   @@report ||= BrakemanTester.run_scan "rails4_with_engines", "Rails4WithEngines"
   end
 
   def test_i18n_xss_CVE_2013_4491

--- a/test/tests/rails_with_xss_plugin.rb
+++ b/test/tests/rails_with_xss_plugin.rb
@@ -1,13 +1,5 @@
 abort "Please run using test/test.rb" unless defined? BrakemanTester
 
-RailsWithXssPlugin = BrakemanTester.run_scan(
-  "rails_with_xss_plugin",
-  "RailsWithXssPlugin",
-  :absolute_paths => true,
-  :run_all_checks => true,
-  :collapse_mass_assignment => true
-)
-
 class RailsWithXssPluginTests < Test::Unit::TestCase
   include BrakemanTester::FindWarning
   include BrakemanTester::CheckExpected
@@ -21,7 +13,13 @@ class RailsWithXssPluginTests < Test::Unit::TestCase
   end
 
   def report
-    RailsWithXssPlugin
+    @@report ||= BrakemanTester.run_scan(
+      "rails_with_xss_plugin",
+      "RailsWithXssPlugin",
+      :absolute_paths => true,
+      :run_all_checks => true,
+      :collapse_mass_assignment => true
+    )
   end
 
   def test_default_routes_1


### PR DESCRIPTION
Also, since scans are no longer run upfront, make them quiet so they don't mess up the test output.

/cc @ichthala