### PR TITLE
Do not include `nil` in call chains

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -41,7 +41,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     Brakeman.debug "Finding possible SQL calls using constantized()"
     calls.concat tracker.find_call(:methods => @sql_targets).select { |result| constantize_call? result }
 
-    connect_targets = active_record_models.keys + [nil, :"ActiveRecord::Base"]
+    connect_targets = active_record_models.keys + [:connection, :"ActiveRecord::Base"]
     calls.concat tracker.find_call(:targets => connect_targets, :methods => @connection_calls, :chained => true).select { |result| connect_call? result }
 
     Brakeman.debug "Finding calls to named_scope or scope"

--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -152,6 +152,8 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
   def get_chain call
     if node_type? call, :call, :attrasgn
       get_chain(call.target) + [call.method]
+    elsif call.nil?
+      []
     else
       [get_target(call)]
     end


### PR DESCRIPTION
Weird detail on finding method calls.

`x.y` would have a call chain of `[nil, :x, :y]` but that makes it a lot harder to search for `x.y` calls.