### PR TITLE
Add Support for a progress dot formatter similar to rspec's default format

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -134,6 +134,7 @@ module Brakeman
       :parallel_checks => true,
       :relative_path => false,
       :report_progress => true,
+      :progress_dots => false,
       :html_style => "#{File.expand_path(File.dirname(__FILE__))}/brakeman/format/style.css"
     }
   end

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -31,6 +31,10 @@ module Brakeman::Options
           options[:report_progress] = progress
         end
 
+        opts.on "--[no-]progress-dots", "Show progress as dots" do |progress_dots|
+          options[:progress_dots] = progress_dots
+        end
+
         opts.on "-p", "--path PATH", "Specify path to Rails application" do |path|
           options[:app_path] = path
         end

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -38,32 +38,44 @@ class Brakeman::Scanner
 
   #Process everything in the Rails application
   def process
-    Brakeman.notify "Processing gems..."
+    Brakeman.notify "Processing gems"
     process_gems
     guess_rails_version
-    Brakeman.notify "Processing configuration..."
+    Brakeman.notify ""
+    Brakeman.notify "Processing configuration"
     process_config
-    Brakeman.notify "Parsing files..."
+    Brakeman.notify ""
+    Brakeman.notify "Parsing files"
     parse_files
-    Brakeman.notify "Processing initializers..."
+    Brakeman.notify ""
+    Brakeman.notify "Processing initializers"
     process_initializers
-    Brakeman.notify "Processing libs..."
+    Brakeman.notify ""
+    Brakeman.notify "Processing libs"
     process_libs
-    Brakeman.notify "Processing routes...          "
+    Brakeman.notify ""
+    Brakeman.notify "Processing routes"
     process_routes
-    Brakeman.notify "Processing templates...       "
+    Brakeman.notify ""
+    Brakeman.notify "Processing templates"
     process_templates
-    Brakeman.notify "Processing data flow in templates..."
+    Brakeman.notify ""
+    Brakeman.notify "Processing data flow in templates"
     process_template_data_flows
-    Brakeman.notify "Processing models...          "
+    Brakeman.notify ""
+    Brakeman.notify "Processing models"
     process_models
-    Brakeman.notify "Processing controllers...     "
+    Brakeman.notify ""
+    Brakeman.notify "Processing controllers"
     process_controllers
-    Brakeman.notify "Processing data flow in controllers..."
+    Brakeman.notify ""
+    Brakeman.notify "Processing data flow in controllers"
     process_controller_data_flows
-    Brakeman.notify "Indexing call sites...        "
+    Brakeman.notify ""
+    Brakeman.notify "Indexing call sites"
     index_call_sites
     tracker
+    Brakeman.notify ""
   end
 
   def parse_files

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -301,7 +301,11 @@ class Brakeman::Scanner
 
   def report_progress(current, total, type = "files")
     return unless @options[:report_progress]
-    $stderr.print " #{current}/#{total} #{type} processed\r"
+    if @options[:progress_dots]
+      $stderr.print "."
+    else
+      $stderr.print " #{current}/#{total} #{type} processed\r"
+    end
   end
 
   def index_call_sites


### PR DESCRIPTION
Thanks for making such an awesome Gem! 

I'd like to be able to track progress similar to the rspec dot formatter. This seemed like a pretty straightforward way of achieving that. I turned it off by default leaving the in place progress formatter as the default.

I also added a bit more whitespace and removed the trailing dots/whitespace from each section. This seemed a bit more clear even with the default progress format.
