### PR TITLE
Handle <%== as raw output in ERB templates

### DIFF
--- a/lib/brakeman/processors/erubis_template_processor.rb
+++ b/lib/brakeman/processors/erubis_template_processor.rb
@@ -80,6 +80,11 @@ class Brakeman::ErubisTemplateProcessor < Brakeman::TemplateProcessor
 
         if arg.node_type == :str
           ignore
+        elsif exp.method == :safe_append=
+          s = Sexp.new :output, arg
+          s.line(exp.line)
+          @current_template[:outputs] << s
+          s
         else
           s = Sexp.new :escaped_output, arg
           s.line(exp.line)

--- a/test/apps/rails4/app/views/users/index.html.erb
+++ b/test/apps/rails4/app/views/users/index.html.erb
@@ -13,3 +13,5 @@
 <%= number_to_percentage(params[:cost], negative_format: params[:format]) %>
 
 <%= render Thing.new(content: render(partial: "stuff")) %>
+
+<%== params[:double] %>

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -13,7 +13,7 @@ class Rails4Tests < Test::Unit::TestCase
     @expected ||= {
       :controller => 0,
       :model => 2,
-      :template => 3,
+      :template => 4,
       :generic => 58
     }
   end
@@ -557,6 +557,18 @@ class Rails4Tests < Test::Unit::TestCase
       :message => /^Unescaped\ model\ attribute/,
       :confidence => 1,
       :relative_path => "app/controllers/another_controller.rb",
+      :user_input => nil
+  end
+
+  def test_cross_site_scripting_with_double_equals
+    assert_warning :type => :template,
+      :warning_code => 2,
+      :fingerprint => "046c3a770f455c30aa5e3a49bc1309e6511c142783e2f1d0c0eddcbcef366cef",
+      :warning_type => "Cross Site Scripting",
+      :line => 16,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/views/users/index.html.erb",
       :user_input => nil
   end
 


### PR DESCRIPTION
`<%== whatever %>` should result in unescaped/raw output.

Sadly, I fixed parsing double equals in 46b97150eb05eb4425813812927a246e87a5b3c0 but didn't add a test for XSS.