### PR TITLE
Fix CVE-2015-3227 for Rails 3.2.x

### DIFF
--- a/lib/brakeman/checks/check_xml_dos.rb
+++ b/lib/brakeman/checks/check_xml_dos.rb
@@ -6,29 +6,37 @@ class Brakeman::CheckXMLDoS < Brakeman::BaseCheck
   @description = "Checks for XML denial of service (CVE-2015-3227)"
 
   def run_check
+    version = tracker.config[:rails_version]
+
     fix_version = case
+                  when version_between?("2.0.0", "3.2.21")
+                    "3.2.22"
                   when version_between?("4.1.0", "4.1.10")
                     "4.1.11"
                   when version_between?("4.2.0", "4.2.1")
                     "4.2.2"
-                  when version_between?("4.1.11", "4.1.99")
-                    return
-                  when version_between?("4.2.2", "9.9.9")
-                    return
-                  when has_workaround?
-                    return
-                  else
+                  when version_between?("4.0.0", "4.0.99")
                     "4.2.2"
+                  when (version.nil? and tracker.options[:rails3])
+                    version = "3.x"
+                    "3.2.22"
+                  when (version.nil? and tracker.options[:rails4])
+                    version = "4.x"
+                    "4.2.2"
+                  else
+                    return
                   end
 
-    message = "Rails #{tracker.config[:rails_version]} is vulnerable to denial of service via XML parsing (CVE-2015-3227). Upgrade to Rails version #{fix_version}"
+    return if has_workaround?
+
+    message = "Rails #{version} is vulnerable to denial of service via XML parsing (CVE-2015-3227). Upgrade to Rails version #{fix_version}"
 
     warn :warning_type => "Denial of Service",
       :warning_code => :CVE_2015_3227,
       :message => message,
       :confidence => CONFIDENCE[:med],
       :gem_info => gemfile_or_environment,
-      :link_path => "repos/canvas-lms/config/application.rb"
+      :link_path => "https://groups.google.com/d/msg/rubyonrails-security/bahr2JLnxvk/x4EocXnHPp8J"
   end
 
   def has_workaround?

--- a/test/tests/cves.rb
+++ b/test/tests/cves.rb
@@ -131,4 +131,15 @@ class CVETests < Test::Unit::TestCase
       :relative_path => "Gemfile",
       :user_input => nil
   end
+
+  def test_CVE_2015_3227_3_2_22
+    before_rescan_of "Gemfile.lock", "rails3.2" do
+      replace "Gemfile.lock", "rails (3.2.9.rc2)", "rails (3.2.22)"
+    end
+
+    assert_version "3.2.22"
+    assert_no_warning :type => :warning,
+      :warning_code => 88,
+      :warning_type => "Denial of Service"
+  end
 end

--- a/test/tests/rails32.rb
+++ b/test/tests/rails32.rb
@@ -159,7 +159,7 @@ class Rails32Tests < Test::Unit::TestCase
       :fingerprint => "ab42647fbdea61e25c4b794e82a8b315054e2fac4328bb3fd4be6a744889a987",
       :warning_type => "Denial of Service",
       :line => 64,
-      :message => /^Rails\ 3\.2\.9\.rc2\ is\ vulnerable\ to\ denial\ /,
+      :message => /^Rails\ 3\.2\.9\.rc2 is vulnerable to denial of service via XML parsing \(CVE-2015-3227\). Upgrade to Rails version 3.2.22/,
       :confidence => 1,
       :relative_path => "Gemfile.lock",
       :user_input => nil


### PR DESCRIPTION
Closes #667 and also fixes several other issues with this check.