### PR TITLE
Several XSS check fixes

### DIFF
--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -325,7 +325,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
   end
 
   def ignore_call? target, method
-    ignored_method?(method) or
+    ignored_method?(target, method) or
     safe_input_attribute?(target, method) or
     ignored_model_method?(method) or
     form_builder_method?(target, method) or
@@ -341,7 +341,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
     IGNORE_MODEL_METHODS.include? method
   end
 
-  def ignored_method? method
+  def ignored_method? target, method
     @ignore_methods.include? method or method.to_s =~ IGNORE_LIKE
   end
 

--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -173,11 +173,14 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
           add_result exp
 
           link_path = "cross_site_scripting"
+          warning_code = :cross_site_scripting
+
           if @known_dangerous.include? exp.method
             confidence = CONFIDENCE[:high]
             if exp.method == :to_json
               message += " in JSON hash"
               link_path += "_to_json"
+              warning_code = :xss_to_json
             end
           else
             confidence = CONFIDENCE[:low]
@@ -185,7 +188,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
 
           warn :template => @current_template,
             :warning_type => "Cross Site Scripting",
-            :warning_code => :xss_to_json,
+            :warning_code => warning_code,
             :message => message,
             :code => exp,
             :user_input => @matched.match,

--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -323,7 +323,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
   end
 
   def ignore_call? target, method
-    ignored_method?(target, method) or
+    ignored_method?(method) or
     safe_input_attribute?(target, method) or
     ignored_model_method?(method) or
     form_builder_method?(target, method) or
@@ -339,9 +339,8 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
     IGNORE_MODEL_METHODS.include? method
   end
 
-  def ignored_method? target, method
-    target.nil? and
-    (@ignore_methods.include? method or method.to_s =~ IGNORE_LIKE)
+  def ignored_method? method
+    @ignore_methods.include? method or method.to_s =~ IGNORE_LIKE
   end
 
   def cgi_escaped? target, method

--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -61,6 +61,8 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
       out = exp.value.first_arg
     end
 
+    return if call? out and ignore_call? out.target, out.method
+
     if input = has_immediate_user_input?(out)
       add_result exp
 

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -42,6 +42,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     #with something before the user input
     return if node_type?(url_arg, :string_interp) && !url_arg[1].chomp.empty?
 
+    return if call? url_arg and ignore_call? url_arg.target, url_arg.method
 
     if input = has_immediate_user_input?(url_arg)
       message = "Unsafe #{friendly_type_of input} in link_to href"

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -11,6 +11,8 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
                         
   @description = "Checks to see if values used for hrefs are sanitized using a :url_safe_method to protect against javascript:/data: XSS"
 
+  IGNORE_LIKE = /_path$/
+
   def run_check
     @ignore_methods = Set[:button_to, :check_box,
                            :field_field, :fields_for, :hidden_field,
@@ -88,5 +90,9 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
           :link_path => "link_to_href"
       end
     end
+  end
+
+  def ignored_method? method
+    @ignore_methods.include? method or method.to_s =~ IGNORE_LIKE
   end
 end

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -11,13 +11,11 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
                         
   @description = "Checks to see if values used for hrefs are sanitized using a :url_safe_method to protect against javascript:/data: XSS"
 
-  IGNORE_LIKE = /_path$/
-
   def run_check
     @ignore_methods = Set[:button_to, :check_box,
                            :field_field, :fields_for, :hidden_field,
                            :hidden_field, :hidden_field_tag, :image_tag, :label,
-                           :mail_to, :radio_button, :select,
+                           :mail_to, :polymorphic_url, :radio_button, :select,
                            :submit_tag, :text_area, :text_field,
                            :text_field_tag, :url_encode, :url_for,
                            :will_paginate].merge(tracker.options[:url_safe_methods] || [])
@@ -93,7 +91,9 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     end
   end
 
-  def ignored_method? method
-    @ignore_methods.include? method or method.to_s =~ IGNORE_LIKE
+  def ignored_method? target, method
+    @ignore_methods.include? method or
+      method.to_s =~ /_path$/ or
+      (target.nil? and method.to_s =~ /_url$/)
   end
 end

--- a/test/apps/rails4/app/views/another/various_xss.html.erb
+++ b/test/apps/rails4/app/views/another/various_xss.html.erb
@@ -1,0 +1,8 @@
+<%= link_to 'stuff', cool_thing_url(params[:x]) %> Don't warn
+<%= link_to 'stuff', Thing.find(params[:id]).home_url %> Warn
+<%= link_to 'stuff', Thing.find(params[:id]).home_path %> Don't warn
+<%= link_to 'other stuff', home_path(Thing.find(params[:id])) %> Don't warn
+<%= raw(x(params[:x])) %> Warn with warning code 2 not 5
+<% form_for Thing.first do |t| %>
+  <%== t.select(things, Thing.new(params[:t]).stuff) %>
+<% end %>


### PR DESCRIPTION
* `safe_methods` and `url_safe_methods` will match any method, even if they have a target
* Fix how ignored methods were handled in XSS checks (they weren't being checked in immediate output)
* Ignore `*_path` methods as URLs
* Ignore `polymorphic_url` as URL
* Ignore `*_url` methods as URLs but not if they have a target
* Warning code for low confidence XSS warnings was for JSON output (`5`) instead of plain XSS (`2`)