### PR TITLE
Treat String#html_safe the same as raw()

### DIFF
--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -57,8 +57,12 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
 
     if exp.node_type == :output
       out = exp.value
-    elsif exp.node_type == :escaped_output and raw_call? exp
-      out = exp.value.first_arg
+    elsif exp.node_type == :escaped_output
+      if raw_call? exp
+        out = exp.value.first_arg
+      elsif html_safe_call? exp
+        out = exp.value.target
+      end
     end
 
     if input = has_immediate_user_input?(out)
@@ -141,8 +145,12 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
   #Otherwise, ignore
   def process_escaped_output exp
     unless check_for_immediate_xss exp
-      if raw_call? exp and not duplicate? exp
-        process exp.value.first_arg
+      if not duplicate? exp
+        if raw_call? exp
+          process exp.value.first_arg
+        elsif html_safe_call? exp
+          process exp.value.target
+        end
       end
     end
     exp
@@ -320,6 +328,10 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
 
   def raw_call? exp
     exp.value.node_type == :call and exp.value.method == :raw
+  end
+
+  def html_safe_call? exp
+    exp.value.node_type == :call and exp.value.method == :html_safe
   end
 
   def ignore_call? target, method

--- a/test/apps/rails4/app/views/another/html_safe_is_not.html.erb
+++ b/test/apps/rails4/app/views/another/html_safe_is_not.html.erb
@@ -1,0 +1,1 @@
+<%= params[:x].html_safe %>

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -13,7 +13,7 @@ class Rails4Tests < Test::Unit::TestCase
     @expected ||= {
       :controller => 0,
       :model => 2,
-      :template => 4,
+      :template => 5,
       :generic => 60
     }
   end
@@ -569,6 +569,18 @@ class Rails4Tests < Test::Unit::TestCase
       :message => /^Unescaped\ parameter\ value/,
       :confidence => 0,
       :relative_path => "app/views/users/index.html.erb",
+      :user_input => nil
+  end
+
+  def test_cross_site_scripting_with_html_safe
+    assert_warning :type => :template,
+      :warning_code => 2,
+      :fingerprint => "b04cfd8d120b773a3e9f70af8762f7efa7c5ca5c7f83136131d6cc75259cd429",
+      :warning_type => "Cross Site Scripting",
+      :line => 1,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/views/another/html_safe_is_not.html.erb",
       :user_input => nil
   end
 


### PR DESCRIPTION
That is, as unescaped output.

I believe previously the reasoning was `html_safe` was applied on purpose and so we shouldn't warn. Given how often `html_safe` confuses people, maybe that is not a valid assumption.