### PR TITLE
Use RubyParser.for_current_ruby when checking syntax.

### DIFF
--- a/lib/brakeman/file_parser.rb
+++ b/lib/brakeman/file_parser.rb
@@ -32,7 +32,7 @@ module Brakeman
 
     def parse_ruby input, path
       begin
-        RubyParser.new.parse input, path
+        RubyParser.for_current_ruby.parse input, path
       rescue Racc::ParseError => e
         @tracker.error e, "Could not parse #{path}"
         nil

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -297,7 +297,7 @@ class Brakeman::Scanner
   end
 
   def parse_ruby input
-    RubyParser.new.parse input
+    RubyParser.for_current_ruby.parse input
   end
 end
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -232,7 +232,7 @@ module BrakemanTester::RescanTestHelper
   end
 
   def parse code
-    RubyParser.new.parse code
+    RubyParser.for_current_ruby.parse code
   end
 end
 

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1,7 +1,7 @@
 class AliasProcessorTests < Test::Unit::TestCase
   def assert_alias expected, original, full = false
-    original_sexp = RubyParser.new.parse original
-    expected_sexp = RubyParser.new.parse expected
+    original_sexp = RubyParser.for_current_ruby.parse original
+    expected_sexp = RubyParser.for_current_ruby.parse expected
     processed_sexp = Brakeman::AliasProcessor.new.process_safely original_sexp
 
     if full
@@ -332,9 +332,9 @@ class AliasProcessorTests < Test::Unit::TestCase
   end
 
   def test_default_branch_limit_before_reset_with_option
-    expected_y = RubyParser.new.parse "((((0 or 1) or 2) or 3) or 4)"
-    expected_x = RubyParser.new.parse "5 or 6"
-    original_sexp = RubyParser.new.parse <<-RUBY
+    expected_y = RubyParser.for_current_ruby.parse "((((0 or 1) or 2) or 3) or 4)"
+    expected_x = RubyParser.for_current_ruby.parse "5 or 6"
+    original_sexp = RubyParser.for_current_ruby.parse <<-RUBY
     x = 0
 
     if something

--- a/test/tests/find_return_value.rb
+++ b/test/tests/find_return_value.rb
@@ -2,8 +2,8 @@ require 'brakeman/processors/lib/find_return_value'
 
 class FindReturnValueTests < Test::Unit::TestCase
   def assert_returns expected, original, env = nil
-    expected = RubyParser.new.parse(expected) if expected.is_a? String
-    original = RubyParser.new.parse(original) if original.is_a? String
+    expected = RubyParser.for_current_ruby.parse(expected) if expected.is_a? String
+    original = RubyParser.for_current_ruby.parse(original) if original.is_a? String
     return_value = Brakeman::FindReturnValue.return_value original, env
 
     assert_equal expected, return_value

--- a/test/tests/output_processor.rb
+++ b/test/tests/output_processor.rb
@@ -85,7 +85,7 @@ class OutputProcessorTests < Test::Unit::TestCase
                                                Sexp.new(:ivar, :@x)))
 
     input = '"#{params[:plugin]}/app/views/#{params[:view]}"'
-    s_input = RubyParser.new.parse(input)
+    s_input = RubyParser.for_current_ruby.parse(input)
 
     assert_output input,
       Brakeman::BaseProcessor.new(nil).process(s_input)
@@ -187,7 +187,7 @@ class OutputProcessorTests < Test::Unit::TestCase
       s(:dxstr, "", s(:evstr, s(:call, nil, :x)))
 
 
-    input = Brakeman::BaseProcessor.new(nil).process(RubyParser.new.parse('`1#{x}2#{y}3`'))
+    input = Brakeman::BaseProcessor.new(nil).process(RubyParser.for_current_ruby.parse('`1#{x}2#{y}3`'))
     assert_output '`1#{x}2#{y}3`', input
   end
 end


### PR DESCRIPTION
Brakeman currently uses `RubyParser.new.parse` when checking syntax. RubyParser by default will use 1.9 and then fall back to 1.8. This is no bueno for projects using Ruby 2.0+.

`RubyParser.for_current_ruby` will select the parser version based on the Ruby version in the project folder. This also works quite nicely for projects using rvm or rbenv.