### PR TITLE
Better handling of string concatenation

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -160,6 +160,19 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
         target.value << first_arg.value
         env[target_var] = target
         return target
+      elsif string? target and node_type? first_arg, :dstr, :string_interp
+        exp = Sexp.new(:dstr, target.value + first_arg[1]).concat(first_arg[2..-1])
+        env[target_var] = exp
+      elsif string? first_arg and node_type? target, :dstr, :string_interp
+        if string? target.last
+          target.last.value << first_arg.value
+        elsif target.last.is_a? String
+          target.last << first_arg.value
+        else
+          target << first_arg
+        end
+        env[target_var] = target
+        return first_arg
       elsif array? target
         target << first_arg
         env[target_var] = target

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -77,6 +77,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   #Process a method call.
   def process_call exp
     target_var = exp.target
+    target_var &&= target_var.deep_clone
     exp = process_default exp
 
     #In case it is replaced with something else
@@ -164,8 +165,8 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
         env[target_var] = target
         return target
       else
-        target = find_push_target exp
-        env[target] = exp unless target.nil? #Happens in TemplateAliasProcessor
+        target = find_push_target(target_var)
+        env[target] = exp unless target.nil? # Happens in TemplateAliasProcessor
       end
     end
 

--- a/test/apps/rails4/app/controllers/another_controller.rb
+++ b/test/apps/rails4/app/controllers/another_controller.rb
@@ -37,4 +37,22 @@ class AnotherController < ApplicationController
   def use_params_in_regex
     @x = something.match /#{params[:x]}/
   end
+
+  def building_strings_for_sql
+    query = "SELECT * FROM users WHERE"
+
+    if params[:search].to_i == 1
+      query << " role = 'admin'"
+    else
+      query << " role = 'admin' " + params[:search]
+    end
+
+    begin
+      result = {:result => User.find_by_sql(query) }
+    rescue
+      result = {}
+    end
+
+    render json: result.as_json
+  end
 end

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -50,6 +50,14 @@ class AliasProcessorTests < Test::Unit::TestCase
     RUBY
   end
 
+  def test_string_append_call
+    assert_alias "'hello ' << params[:x]", <<-RUBY
+    x = ""
+    x << 'hello ' << params[:x]
+    x
+    RUBY
+  end
+
   def test_array_index
     assert_alias "'cookie'", <<-RUBY
       dessert = ["fruit", "pie", "ice cream"]

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -58,6 +58,23 @@ class AliasProcessorTests < Test::Unit::TestCase
     RUBY
   end
 
+  def test_string_interp_concat
+    assert_alias '"#{y}\nthing"', <<-'RUBY'
+    x = "#{y}\n"
+    x << "thing"
+    x
+    RUBY
+  end
+
+  def test_string_concat_interp
+    assert_alias '"hello\n#{world}"', <<-'RUBY'
+    x = ""
+    x << "hello"
+    x << "\n#{world}"
+    x
+    RUBY
+  end
+
   def test_array_index
     assert_alias "'cookie'", <<-RUBY
       dessert = ["fruit", "pie", "ice cream"]

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -14,7 +14,7 @@ class Rails4Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 2,
       :template => 6,
-      :generic => 60
+      :generic => 61
     }
   end
 
@@ -702,7 +702,19 @@ class Rails4Tests < Test::Unit::TestCase
       :user_input => s(:lvar, :locale)
   end
 
- def test_no_sql_injection_from_arel_methods
+  def test_sql_injection_string_concat
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "b92b1e8d755fb15bed56f8e6f872f81784813b0eae3682b68dd0601e4fb9c0a6",
+      :warning_type => "SQL Injection",
+      :line => 51,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/controllers/another_controller.rb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :search))
+  end
+
+  def test_no_sql_injection_from_arel_methods
     assert_no_warning :type => :warning,
       :warning_code => 0,
       :fingerprint => "61d957cdeca70a82f53d7ec72287fc21f67c67c6e8dbc9c3c4cb2d115f3a5602",


### PR DESCRIPTION
There was an issue with code like this:

```ruby
x = ""
x << "a"
```
Where `x` would not be updated because it was already replaced with `""`.

This change also handles concatenating with interpolated strings

```ruby
x = "#{y}"
x << "stuff"
puts x
```
will output
```ruby
puts "#{y}stuff"
```