### PR TITLE
Use highline 1.x series >= 1.6.20 rather than 1.6.x

### DIFF
--- a/brakeman.gemspec
+++ b/brakeman.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ruby2ruby", "~>2.1.1"
   s.add_dependency "terminal-table", "~>1.4.5"
   s.add_dependency "fastercsv", "~>1.5"
-  s.add_dependency "highline", "~>1.6.20"
+  s.add_dependency "highline", [">= 1.6.20", "~> 1.6"]
   s.add_dependency "erubis", "~>2.6"
   s.add_dependency "haml", ">=3.0", "<5.0"
   s.add_dependency "sass", "~>3.0"


### PR DESCRIPTION
ref: http://www.benjaminfleischer.com/2013/08/21/psa-gem-versions/

Without this change, brakeman is incompatible with the libraries using the 1.7 series of highline, which there doesn't appear to a reason for.