### PR TITLE
Fallback to the `railties` version when the `rails` gem is missing.

### DIFF
--- a/lib/brakeman/tracker/config.rb
+++ b/lib/brakeman/tracker/config.rb
@@ -62,7 +62,7 @@ module Brakeman
 
     def set_rails_version
       # Ignore ~>, etc. when using values from Gemfile
-      version = gem_version(:rails)
+      version = gem_version(:rails) || gem_version(:railties)
       if version and version.match(/(\d+\.\d+\.\d+.*)/)
         @rails_version = $1
 

--- a/test/tests/cves.rb
+++ b/test/tests/cves.rb
@@ -30,7 +30,7 @@ class CVETests < Test::Unit::TestCase
       :message => /^Rails\ 4\.1\.1\ does\ not\ encode\ JSON\ keys\ \(C/,
       :confidence => 0,
       :relative_path => "Gemfile",
-      :user_input => nil 
+      :user_input => nil
   end
 
   def test_CVE_2015_3226_4_2_1
@@ -47,7 +47,7 @@ class CVETests < Test::Unit::TestCase
       :message => /^Rails\ 4\.2\.1\ does\ not\ encode\ JSON\ keys\ \(C/,
       :confidence => 0,
       :relative_path => "Gemfile",
-      :user_input => nil 
+      :user_input => nil
   end
 
   def test_CVE_2015_3226_workaround
@@ -67,7 +67,7 @@ class CVETests < Test::Unit::TestCase
             end
           end
         end
-      end 
+      end
       RUBY
     end
 
@@ -80,7 +80,7 @@ class CVETests < Test::Unit::TestCase
       :message => /^Rails\ 4\.2\.1\ does\ not\ encode\ JSON\ keys\ \(C/,
       :confidence => 0,
       :relative_path => "Gemfile",
-      :user_input => nil 
+      :user_input => nil
   end
 
   def test_CVE_2015_3227_4_2_1
@@ -141,5 +141,13 @@ class CVETests < Test::Unit::TestCase
     assert_no_warning :type => :warning,
       :warning_code => 88,
       :warning_type => "Denial of Service"
+  end
+
+  def test_railties_version
+    before_rescan_of "Gemfile", "rails4" do
+      replace "Gemfile", "rails", "railties"
+    end
+
+    assert_version "4.0.0"
   end
 end


### PR DESCRIPTION
Rails apps that don't include `actionmailer` or `activerecord` might not have
the meta `rails` gem on their Gemfile, but the `railties` gem instead.

I'm not sure of where to add a test for this, and if makes sense to duplicate some of the Rails apps used for testing just to test this case, but if it makes sense I can duplicate the `rails4` app as a `rails4-railtie` one.