### PR TITLE
Convert any string config keys into symbols.

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -99,6 +99,9 @@ module Brakeman
 
       if options
         options.each { |k, v| options[k] = Set.new v if v.is_a? Array }
+        
+        # After parsing the yaml config file for options, convert any string keys into symbols.
+        options.keys.select {|k| k.is_a? String}.map {|k| k.to_sym }.each {|k| options[k] = options[k.to_s]; options.delete(k.to_s) }
 
         # notify if options[:quiet] and quiet is nil||false
         notify "[Notice] Using configuration in #{config}" unless (options[:quiet] || quiet)


### PR DESCRIPTION
After parsing the yaml config file for options, convert any string config keys into symbols.
I had to add this to get the following config file working:
```
skip_checks:
  - CheckMassAssignment
```
Otherwise the default options `:skip_checks` key takes precedence.

Am I doing something wrong? I couldn't find examples of how this config file should look like.