### PR TITLE
Stop useless renaming of sexps

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -115,7 +115,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
   end
 
   #Does not actually process string interpolation, but notes that it occurred.
-  def process_string_interp exp
+  def process_dstr exp
     @string_interp = Match.new(:interp, exp)
     process_default exp
   end
@@ -328,7 +328,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
       end
     elsif sexp? exp
       case exp.node_type
-      when :string_interp, :dstr
+      when :dstr
         exp.each do |e|
           if sexp? e
             match = has_immediate_user_input?(e)
@@ -336,7 +336,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
           end
         end
         false
-      when :string_eval, :evstr
+      when :evstr
         if sexp? exp.value
           if exp.value.node_type == :rlist
             exp.value.each_sexp do |e|
@@ -390,14 +390,14 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
       end
     elsif sexp? exp
       case exp.node_type
-      when :string_interp, :dstr
+      when :dstr
         exp.each do |e|
           if sexp? e and match = has_immediate_model?(e, out)
             return match
           end
         end
         false
-      when :string_eval, :evstr
+      when :evstr
         if sexp? exp.value
           if exp.value.node_type == :rlist
             exp.value.each_sexp do |e|

--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -252,7 +252,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
   end
 
   #Process as default
-  def process_string_interp exp
+  def process_dstr exp
     process_default exp
   end
 

--- a/lib/brakeman/checks/check_execute.rb
+++ b/lib/brakeman/checks/check_execute.rb
@@ -82,10 +82,10 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
   end
 
   def dangerous_open_arg? exp
-    if node_type? exp, :string_interp, :dstr
+    if string_interp? exp
       # Check for input at start of string
       exp[1] == "" and
-        node_type? exp[2], :evstr, :string_eval and
+        node_type? exp[2], :evstr and
         has_immediate_user_input? exp[2]
     else
       has_immediate_user_input? exp
@@ -137,7 +137,7 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
         e = e.target
       end
 
-      if node_type? e, :or, :evstr, :string_eval, :string_interp
+      if node_type? e, :or, :evstr, :dstr
         if res = dangerous?(e)
           return res
         end

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -38,7 +38,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
 
     #Ignore situations where the href is an interpolated string
     #with something before the user input
-    return if node_type?(url_arg, :string_interp) && !url_arg[1].chomp.empty?
+    return if string_interp?(url_arg) && !url_arg[1].chomp.empty?
 
     return if call? url_arg and ignore_call? url_arg.target, url_arg.method
 

--- a/lib/brakeman/checks/check_render.rb
+++ b/lib/brakeman/checks/check_render.rb
@@ -36,7 +36,7 @@ class Brakeman::CheckRender < Brakeman::BaseCheck
 
 
       if input = has_immediate_user_input?(view)
-        if node_type? view, :string_interp, :dstr
+        if string_interp? view
           confidence = CONFIDENCE[:med]
         else
           confidence = CONFIDENCE[:high]

--- a/lib/brakeman/checks/check_select_vulnerability.rb
+++ b/lib/brakeman/checks/check_select_vulnerability.rb
@@ -43,7 +43,7 @@ class Brakeman::CheckSelectVulnerability < Brakeman::BaseCheck
     if sexp? third_arg and include_user_input? third_arg
       add_result result
 
-      if node_type? third_arg, :string_interp, :dstr
+      if string_interp? third_arg
         confidence = CONFIDENCE[:med]
       else
         confidence = CONFIDENCE[:low]

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -246,7 +246,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   end
 
   #Process a method definition.
-  def process_methdef exp
+  def process_defn exp
     meth_env do
       exp.body = process_all! exp.body
     end
@@ -266,16 +266,13 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   end
 
   #Process a method definition on self.
-  def process_selfdef exp
+  def process_defs exp
     env.scope do
       set_env_defaults
       exp.body = process_all! exp.body
     end
     exp
   end
-
-  alias process_defn process_methdef
-  alias process_defs process_selfdef
 
   #Local assignment
   # x = 1

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -167,10 +167,10 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
         target.value << first_arg.value
         env[target_var] = target
         return target
-      elsif string? target and node_type? first_arg, :dstr, :string_interp
+      elsif string? target and string_interp? first_arg
         exp = Sexp.new(:dstr, target.value + first_arg[1]).concat(first_arg[2..-1])
         env[target_var] = exp
-      elsif string? first_arg and node_type? target, :dstr, :string_interp
+      elsif string? first_arg and string_interp? target
         if string? target.last
           target.last.value << first_arg.value
         elsif target.last.is_a? String

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -101,7 +101,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       return res if res
     elsif target == ARRAY_CONST and method == :new
       return Sexp.new(:array, *exp.args)
-    elsif target == HASH_CONST and method == :new and first_arg.nil? and !node_type?(@exp_context.last, :iter, :call_with_block)
+    elsif target == HASH_CONST and method == :new and first_arg.nil? and !node_type?(@exp_context.last, :iter)
       return Sexp.new(:hash)
     end
 
@@ -193,7 +193,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     exp
   end
 
-  def process_call_with_block exp
+  def process_iter exp
     @exp_context.push exp
     exp[1] = process exp.block_call
     @exp_context.pop
@@ -229,8 +229,6 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
 
     exp
   end
-
-  alias process_iter process_call_with_block
 
   #Process a new scope.
   def process_scope exp
@@ -844,7 +842,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   def top_target exp, last = nil
     if call? exp
       top_target exp.target, exp
-    elsif node_type? exp, :iter, :call_with_block
+    elsif node_type? exp, :iter
       top_target exp.block_call, last
     else
       exp || last

--- a/lib/brakeman/processors/base_processor.rb
+++ b/lib/brakeman/processors/base_processor.rb
@@ -68,15 +68,13 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
     call
   end
 
-  #String with interpolation. Changes Sexp node type to :string_interp
+  #String with interpolation.
   def process_dstr exp
     exp = exp.dup
     exp.shift
     exp.map! do |e|
       if e.is_a? String
         e
-      elsif e.value.is_a? String
-        e.value
       else
         res = process e
         if res.empty?
@@ -87,7 +85,7 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
       end
     end.compact!
 
-    exp.unshift :string_interp
+    exp.unshift :dstr
   end
 
   #Processes a block. Changes Sexp node type to :rlist
@@ -103,10 +101,8 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
   end
 
   #Processes the inside of an interpolated String.
-  #Changes Sexp node type to :string_eval
   def process_evstr exp
     exp = exp.dup
-    exp[0] = :string_eval
     exp[1] = process exp[1]
     exp
   end

--- a/lib/brakeman/processors/base_processor.rb
+++ b/lib/brakeman/processors/base_processor.rb
@@ -49,7 +49,7 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
     exp
   end
 
-  #Processes calls with blocks. Changes Sexp node type to :call_with_block
+  #Processes calls with blocks.
   #
   #s(:iter, CALL, {:lasgn|:masgn}, BLOCK)
   def process_iter exp
@@ -63,7 +63,7 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
       block = nil
     end
 
-    call = Sexp.new(:call_with_block, call, exp.block_args, block).compact
+    call = Sexp.new(:iter, call, exp.block_args, block).compact
     call.line(exp.line)
     call
   end

--- a/lib/brakeman/processors/controller_alias_processor.rb
+++ b/lib/brakeman/processors/controller_alias_processor.rb
@@ -122,7 +122,7 @@ class Brakeman::ControllerAliasProcessor < Brakeman::AliasProcessor
   end
 
   #Check for +respond_to+
-  def process_call_with_block exp
+  def process_iter exp
     super
 
     if call? exp.block_call and exp.block_call.method == :respond_to

--- a/lib/brakeman/processors/controller_alias_processor.rb
+++ b/lib/brakeman/processors/controller_alias_processor.rb
@@ -51,10 +51,10 @@ class Brakeman::ControllerAliasProcessor < Brakeman::AliasProcessor
         processor = Brakeman::ControllerProcessor.new(@app_tree, @tracker)
         method = mixin[:public][name][:src].deep_clone
 
-        if node_type? method, :methdef
+        if node_type? method, :defn
           method = processor.process_defn method
         else
-          #Should be a methdef, but this will catch other cases
+          #Should be a defn, but this will catch other cases
           method = processor.process method
         end
 
@@ -71,7 +71,7 @@ class Brakeman::ControllerAliasProcessor < Brakeman::AliasProcessor
 
   #Processes a method definition, which may include
   #processing any rendered templates.
-  def process_methdef exp
+  def process_defn exp
     meth_name = exp.method_name
 
     Brakeman.debug "Processing #{@current_class}##{meth_name}"

--- a/lib/brakeman/processors/controller_processor.rb
+++ b/lib/brakeman/processors/controller_processor.rb
@@ -213,7 +213,7 @@ class Brakeman::ControllerProcessor < Brakeman::BaseProcessor
   def process_defn exp
     name = exp.method_name
     @current_method = name
-    res = Sexp.new :methdef, name, exp.formal_args, *process_all!(exp.body)
+    res = Sexp.new :defn, name, exp.formal_args, *process_all!(exp.body)
     res.line(exp.line)
     @current_method = nil
 
@@ -243,7 +243,7 @@ class Brakeman::ControllerProcessor < Brakeman::BaseProcessor
     end
 
     @current_method = name
-    res = Sexp.new :selfdef, target, name, exp.formal_args, *process_all!(exp.body)
+    res = Sexp.new :defs, target, name, exp.formal_args, *process_all!(exp.body)
     res.line(exp.line)
     @current_method = nil
 

--- a/lib/brakeman/processors/haml_template_processor.rb
+++ b/lib/brakeman/processors/haml_template_processor.rb
@@ -118,10 +118,10 @@ class Brakeman::HamlTemplateProcessor < Brakeman::TemplateProcessor
   #HAML likes to put interpolated values into _hamlout.push_text
   #but we want to handle those individually
   def build_output_from_push_text exp
-    if node_type? exp, :string_interp, :dstr
+    if string_interp? exp
       exp.map! do |e|
         if sexp? e
-          if node_type? e, :string_eval, :evstr
+          if node_type? e, :evstr
             e = e.value
           end
 
@@ -148,7 +148,7 @@ class Brakeman::HamlTemplateProcessor < Brakeman::TemplateProcessor
       exp
     when :str, :ignore, :output, :escaped_output
       exp
-    when :block, :rlist, :string_interp, :dstr
+    when :block, :rlist, :dstr
       exp.map! { |e| get_pushed_value e }
     else
       if call? exp and exp.target == HAML_HELPERS and exp.method == :html_escape

--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -23,12 +23,12 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
   end
 
   #Process body of method
-  def process_methdef exp
+  def process_defn exp
     process_all exp.body
   end
 
   #Process body of method
-  def process_selfdef exp
+  def process_defs exp
     process_all exp.body
   end
 

--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -42,7 +42,7 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
     exp
   end
 
-  def process_call_with_block exp
+  def process_iter exp
     call = exp.block_call
 
     if call.node_type == :call
@@ -62,8 +62,6 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
 
     exp
   end
-
-  alias process_iter process_call_with_block
 
   #Calls to render() are converted to s(:render, ...) but we would
   #like them in the call cache still for speed

--- a/lib/brakeman/processors/lib/find_call.rb
+++ b/lib/brakeman/processors/lib/find_call.rb
@@ -68,11 +68,11 @@ class Brakeman::FindCall < Brakeman::BasicProcessor
   end
 
   #Process body of method
-  def process_methdef exp
+  def process_defn exp
     process_all exp.body
   end
 
-  alias :process_selfdef :process_methdef
+  alias :process_defs :process_defn
 
   #Process body of block
   def process_rlist exp

--- a/lib/brakeman/processors/lib/find_return_value.rb
+++ b/lib/brakeman/processors/lib/find_return_value.rb
@@ -38,7 +38,7 @@ class Brakeman::FindReturnValue
 
     find_explicit_return_values exp
 
-    if node_type? exp, :methdef, :selfdef, :defn, :defs
+    if node_type? exp, :defn, :defs
       body = exp.body
 
       unless body.empty?

--- a/lib/brakeman/processors/library_processor.rb
+++ b/lib/brakeman/processors/library_processor.rb
@@ -103,7 +103,6 @@ class Brakeman::LibraryProcessor < Brakeman::BaseProcessor
 
   def process_defn exp
     exp = @alias_processor.process exp
-    exp.node_type = :methdef
 
     if @current_class
       exp.body = process_all! exp.body
@@ -118,7 +117,6 @@ class Brakeman::LibraryProcessor < Brakeman::BaseProcessor
 
   def process_defs exp
     exp = @alias_processor.process exp
-    exp.node_type = :selfdef
 
     if @current_class
       exp.body = process_all! exp.body

--- a/lib/brakeman/processors/model_processor.rb
+++ b/lib/brakeman/processors/model_processor.rb
@@ -185,7 +185,7 @@ class Brakeman::ModelProcessor < Brakeman::BaseProcessor
     name = exp.method_name
 
     @current_method = name
-    res = Sexp.new :methdef, name, exp.formal_args, *process_all!(exp.body)
+    res = Sexp.new :defn, name, exp.formal_args, *process_all!(exp.body)
     res.line(exp.line)
     @current_method = nil
 
@@ -216,7 +216,7 @@ class Brakeman::ModelProcessor < Brakeman::BaseProcessor
     end
 
     @current_method = name
-    res = Sexp.new :selfdef, target, name, exp.formal_args, *process_all!(exp.body)
+    res = Sexp.new :defs, target, name, exp.formal_args, *process_all!(exp.body)
     res.line(exp.line)
     @current_method = nil
 

--- a/lib/brakeman/processors/output_processor.rb
+++ b/lib/brakeman/processors/output_processor.rb
@@ -79,7 +79,7 @@ class Brakeman::OutputProcessor < Ruby2Ruby
 
   alias process_methdef process_defn
 
-  def process_call_with_block exp
+  def process_iter exp
     call = process exp[0]
     block = process_rlist exp[2..-1]
     out = "#{call} do\n #{block}\n end"

--- a/lib/brakeman/processors/output_processor.rb
+++ b/lib/brakeman/processors/output_processor.rb
@@ -43,9 +43,6 @@ class Brakeman::OutputProcessor < Ruby2Ruby
     "cookies"
   end
 
-  alias process_string_interp process_dstr
-  alias process_string_eval process_evstr
-
   def process_rlist exp
     out = exp.map do |e|
       res = process e
@@ -173,35 +170,4 @@ class Brakeman::OutputProcessor < Ruby2Ruby
     exp.clear
     out
   end
-
-  #This is copied from Ruby2Ruby, except the :string_eval type has been added
-  def util_dthing(type, exp)
-    s = []
-
-    # first item in sexp is a string literal
-    s << dthing_escape(type, exp.shift)
-
-    until exp.empty?
-      pt = exp.shift
-      case pt
-      when Sexp then
-        case pt.first
-        when :str then
-          s << dthing_escape(type, pt.last)
-        when :evstr, :string_eval then
-          s << '#{' << process(pt) << '}' # do not use interpolation here
-        else
-          raise "unknown type: #{pt.inspect}"
-        end
-      when String then
-        s << pt
-      else
-        # HACK: raise "huh?: #{pt.inspect}" -- hitting # constants in regexps
-        # do nothing for now
-      end
-    end
-
-    s.join
-  end
-
 end

--- a/lib/brakeman/processors/output_processor.rb
+++ b/lib/brakeman/processors/output_processor.rb
@@ -77,8 +77,6 @@ class Brakeman::OutputProcessor < Ruby2Ruby
     return "def #{name}#{args}\n#{body}\nend".gsub(/\n\s*\n+/, "\n")
   end
 
-  alias process_methdef process_defn
-
   def process_iter exp
     call = process exp[0]
     block = process_rlist exp[2..-1]

--- a/lib/brakeman/processors/slim_template_processor.rb
+++ b/lib/brakeman/processors/slim_template_processor.rb
@@ -25,7 +25,7 @@ class Brakeman::SlimTemplateProcessor < Brakeman::TemplateProcessor
         ignore
       elsif render? arg
         make_output make_render_in_view arg
-      elsif node_type? arg, :interp, :dstr
+      elsif string_interp? arg
         process_inside_interp arg
       elsif node_type? arg, :ignore
         ignore
@@ -61,7 +61,7 @@ class Brakeman::SlimTemplateProcessor < Brakeman::TemplateProcessor
   #Better to pull those values out directly.
   def process_inside_interp exp
     exp.map! do |e|
-      if node_type? e, :evstr, :string_eval
+      if node_type? e, :evstr
         e.value = process_interp_output e.value
         e
       else

--- a/lib/brakeman/processors/template_alias_processor.rb
+++ b/lib/brakeman/processors/template_alias_processor.rb
@@ -43,7 +43,7 @@ class Brakeman::TemplateAliasProcessor < Brakeman::AliasProcessor
   FORM_BUILDER_CALL = Sexp.new(:call, Sexp.new(:const, :FormBuilder), :new)
 
   #Looks for form methods and iterating over collections of Models
-  def process_call_with_block exp
+  def process_iter exp
     process_default exp
 
     call = exp.block_call
@@ -76,8 +76,6 @@ class Brakeman::TemplateAliasProcessor < Brakeman::AliasProcessor
 
     exp
   end
-
-  alias process_iter process_call_with_block
 
   #Checks if +exp+ is a call to Model.all or Model.find*
   def get_model_target exp

--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -94,7 +94,7 @@ class Brakeman::Tracker
         [:private, :public, :protected].each do |visibility|
           info[visibility].each do |method_name, definition|
             src = definition[:src]
-            if src.node_type == :selfdef
+            if src.node_type == :defs
               method_name = "#{src[1]}.#{method_name}"
             end
 
@@ -231,7 +231,7 @@ class Brakeman::Tracker
         [:private, :public, :protected].each do |visibility|
           info[visibility].each do |method_name, definition|
             src = definition[:src]
-            if src.node_type == :selfdef
+            if src.node_type == :defs
               method_name = "#{src[1]}.#{method_name}"
             end
 

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -129,6 +129,10 @@ module Brakeman::Util
     exp.is_a? Sexp and exp.node_type == :str
   end
 
+  def string_interp? exp
+    exp.is_a? Sexp and exp.node_type == :dstr
+  end
+
   #Check if _exp_ represents a Symbol: s(:lit, :...)
   def symbol? exp
     exp.is_a? Sexp and exp.node_type == :lit and exp[1].is_a? Symbol

--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -451,23 +451,23 @@ class Sexp
 
   #Returns name of method being defined in a method definition.
   def method_name
-    expect :defn, :defs, :methdef, :selfdef
+    expect :defn, :defs
 
     case self.node_type
-    when :defn, :methdef
+    when :defn
       self[1]
-    when :defs, :selfdef
+    when :defs
       self[2]
     end
   end
 
   def formal_args
-    expect :defn, :defs, :methdef, :selfdef
+    expect :defn, :defs
 
     case self.node_type
-    when :defn, :methdef
+    when :defn
       self[2]
-    when :defs, :selfdef
+    when :defs
       self[3]
     end
   end
@@ -475,13 +475,13 @@ class Sexp
   #Sets body, which is now a complicated process because the body is no longer
   #a separate Sexp, but just a list of Sexps.
   def body= exp
-    expect :defn, :defs, :methdef, :selfdef, :class, :module
+    expect :defn, :defs, :class, :module
     @my_hash_value = nil
 
     case self.node_type
-    when :defn, :methdef, :class
+    when :defn, :class
       index = 3
-    when :defs, :selfdef
+    when :defs
       index = 4
     when :module
       index = 2
@@ -499,12 +499,12 @@ class Sexp
   #Returns body of a method definition, class, or module.
   #This will be an untyped Sexp containing a list of Sexps from the body.
   def body
-    expect :defn, :defs, :methdef, :selfdef, :class, :module
+    expect :defn, :defs, :class, :module
 
     case self.node_type
-    when :defn, :methdef, :class
+    when :defn, :class
       self[3..-1]
-    when :defs, :selfdef
+    when :defs
       self[4..-1]
     when :module
       self[2..-1]

--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -357,7 +357,7 @@ class Sexp
   #      s(:lasgn, :y),
   #       s(:block, s(:lvar, :y), s(:call, nil, :z, s(:arglist))))
   def block_call
-    expect :iter, :call_with_block
+    expect :iter
     self[1]
   end
 
@@ -374,10 +374,10 @@ class Sexp
       return find_node :block, delete
     end
 
-    expect :iter, :call_with_block, :scope, :resbody
+    expect :iter, :scope, :resbody
 
     case self.node_type
-    when :iter, :call_with_block
+    when :iter
       self[3]
     when :scope
       self[1]
@@ -394,7 +394,7 @@ class Sexp
   #      s(:lasgn, :y), <- block_args
   #       s(:call, nil, :p, s(:arglist, s(:lvar, :y))))
   def block_args
-    expect :iter, :call_with_block
+    expect :iter
     if self[2] == 0 # ?! See https://github.com/presidentbeef/brakeman/issues/331
       return Sexp.new(:args)
     else

--- a/test/apps/rails2/config/brakeman.ignore
+++ b/test/apps/rails2/config/brakeman.ignore
@@ -3,7 +3,7 @@
     {
       "warning_type": "Cross Site Scripting",
       "warning_code": 2,
-      "fingerprint": "6300805e44167e6c3446efbd06b97206928855a2bfc6e1f3e61c097795956b13",
+      "fingerprint": "e53a25ddc8ca61f7c4b81602bae04cd6746cf6a7432e89407fbeb362a66f4e8f",
       "message": "Unescaped model attribute",
       "file": "app/views/other/ignore_me.html.erb",
       "line": 2,
@@ -21,7 +21,7 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "f2fa1da45eea252150f6920454822bda3ed5c83a2c376c1296a98037969dd45f",
+      "fingerprint": "5313b025804b1cbf885f2862078391086c6d5cba892f47ed31506cb5b23df24a",
       "message": "Possible SQL injection",
       "file": "app/views/other/ignore_me.html.erb",
       "line": 2,
@@ -34,9 +34,9 @@
       },
       "user_input": "params[:x]",
       "confidence": "High",
-      "note": "Ignoring for testing"
+      "note": ""
     }
   ],
-  "updated": "2013-07-12 16:58:59 -0700",
-  "brakeman_version": "2.0.0"
+  "updated": "2015-07-16 22:46:47 -0700",
+  "brakeman_version": "3.0.5"
 }

--- a/test/tests/output_processor.rb
+++ b/test/tests/output_processor.rb
@@ -145,7 +145,7 @@ class OutputProcessorTests < Test::Unit::TestCase
 
   def test_output_call_with_block
     assert_output "x do\n y\n end",
-      Sexp.new(:call_with_block,
+      Sexp.new(:iter,
                Sexp.new(:call, nil, :x),
                Sexp.new(:args),
                Sexp.new(:call, nil, :y))

--- a/test/tests/output_processor.rb
+++ b/test/tests/output_processor.rb
@@ -162,7 +162,7 @@ class OutputProcessorTests < Test::Unit::TestCase
                Sexp.new(:ivar, :@x))
 
     assert_output "def x(y)\n  @x = y\nend",
-      Sexp.new(:methdef,
+      Sexp.new(:defn,
                :x,
                Sexp.new(:args, :y),
                Sexp.new(:iasgn, :@x, Sexp.new(:lvar, :y)))

--- a/test/tests/output_processor.rb
+++ b/test/tests/output_processor.rb
@@ -79,9 +79,9 @@ class OutputProcessorTests < Test::Unit::TestCase
 
 
   def test_output_string_interp
-    assert_output '"#{@x}"', Sexp.new(:string_interp,
+    assert_output '"#{@x}"', Sexp.new(:dstr,
                                       "",
-                                      Sexp.new(:string_eval,
+                                      Sexp.new(:evstr,
                                                Sexp.new(:ivar, :@x)))
 
     input = '"#{params[:plugin]}/app/views/#{params[:view]}"'

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -656,7 +656,7 @@ class Rails2Tests < Test::Unit::TestCase
   def test_sql_injection_active_record_base_connection
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "37885d589fc5c41553dcc38b36b506c2e508d1f37ce040eb6dca92a958f858fb",
+      :fingerprint => "9aab1347248beb5a3bec91e84b133dcd8fc1bd2b113b744e2df59acf9085cd81",
       :warning_type => "SQL Injection",
       :line => 31,
       :message => /^Possible\ SQL\ injection/,
@@ -1320,7 +1320,7 @@ class Rails2Tests < Test::Unit::TestCase
   def test_regex_dos
     assert_warning :type => :warning,
       :warning_code => 76,
-      :fingerprint => "4ac4f6438b6ad6deb9dfec0d96a47f071853396b4325dad85ebb6aa87b309c98",
+      :fingerprint => "de95ff1870e84933cb5a67bdd5c10cfa666b0bcd95cc78d7dd962215be9ed20c",
       :warning_type => "Denial of Service",
       :line => 74,
       :message => /^Parameter\ value\ used\ in\ regex/,
@@ -1332,7 +1332,7 @@ class Rails2Tests < Test::Unit::TestCase
   def test_indirect_regex_dos
     assert_warning :type => :warning,
       :warning_code => 76,
-      :fingerprint => "b7a197708a04abd2d8f0ca402f3bb0e8690f57685814e09440d1946ba279b14f",
+      :fingerprint => "afdb18fa56308063ad491b76821fb76724dd6f0bd9d3e6aac83c933af0b4baac",
       :warning_type => "Denial of Service",
       :line => 82,
       :message => /^Parameter\ value\ used\ in\ regex/,

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -55,7 +55,7 @@ class Rails3Tests < Test::Unit::TestCase
   def test_command_injection_params_interpolation
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "eb5287a6638bce4be342627db12d03f1e5b51175ed13549920921e3659c21df4",
+      :fingerprint => "d68453d17bca16814e8eaffdce5b1dcf3e87aeeca2d94f3dcf78e309cb1b29c6",
       :warning_type => "Command Injection",
       :line => 34,
       :message => /^Possible command injection near line 34:/,
@@ -93,7 +93,7 @@ class Rails3Tests < Test::Unit::TestCase
   def test_command_injection_capture2
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "744cb371d69e757edd75bf6d58c610e3e813ff2b75b353c4c89c67274e4a35bb",
+      :fingerprint => "a9e14a8381114ec58551a94c281c36782ec9d6d91d93c346e6e4f7a6f32e9c25",
       :warning_type => "Command Injection",
       :line => 146,
       :message => /^Possible\ command\ injection/,
@@ -104,7 +104,7 @@ class Rails3Tests < Test::Unit::TestCase
   def test_command_injection_capture2e
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "521c0a714d14ae878305ce737a2bdd5897dcea154c0622b14806ed6e6c60f526",
+      :fingerprint => "99283cfdb2799fc278d5e474d11dc952ead57861e29470cf5ac16629a5b07fb2",
       :warning_type => "Command Injection",
       :line => 147,
       :message => /^Possible\ command\ injection/,
@@ -115,7 +115,7 @@ class Rails3Tests < Test::Unit::TestCase
   def test_command_injection_capture3
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "b75a4b21f55912860d675ac300de862f6b2050688b32f745ea8944832e5e699f",
+      :fingerprint => "1c7506f2977852c07f8e41dcdad205794048b258b557e7d322acf86fab0a6877",
       :warning_type => "Command Injection",
       :line => 148,
       :message => /^Possible\ command\ injection/,
@@ -137,7 +137,7 @@ class Rails3Tests < Test::Unit::TestCase
   def test_command_injection_pipeline_r
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "987aad17f377a6101d5bd3e1611ae3716b276f319c3f91b69efd93717d993ea7",
+      :fingerprint => "f28aa6e2e73662dd58169db727fc30099da36a9e0d1817375bb257faed376e52",
       :warning_type => "Command Injection",
       :line => 150,
       :message => /^Possible\ command\ injection/,
@@ -170,7 +170,7 @@ class Rails3Tests < Test::Unit::TestCase
   def test_command_injection_spawn
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "6b25cb3fa42bb234319ddf690a164eda038b6f000e501fbfa872fb5fa627609b",
+      :fingerprint => "73d4d3114ea536247c38a4e0d5bbcde047ea3f304d2e6a22b1693003d5135409",
       :warning_type => "Command Injection",
       :line => 153,
       :message => /^Possible\ command\ injection/,
@@ -684,7 +684,7 @@ class Rails3Tests < Test::Unit::TestCase
   def test_sql_injection_delete_all
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "6ae0b599e368b7658cfe3772ab0823d68247796b3718eaa6c1228897d633e0a2",
+      :fingerprint => "4045f9ab95a70f3674f6e1ff7c1f0ac7bdd9ab39bf111f1d0c0b7a386643fbff",
       :warning_type => "SQL Injection",
       :line => 57,
       :message => /^Possible\ SQL\ injection/,
@@ -696,7 +696,7 @@ class Rails3Tests < Test::Unit::TestCase
   def test_sql_injection_destroy_all
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "0631b0564dfe4bb760c250e1de7f0678dd28e5be5c54841fa8581ac3bf2ffaaf",
+      :fingerprint => "7bbc1feebc89050e053bd3a24b9b00fe5d1879650368e82ee22b3cbc371a9ec3",
       :warning_type => "SQL Injection",
       :line => 58,
       :message => /^Possible\ SQL\ injection/,
@@ -708,7 +708,7 @@ class Rails3Tests < Test::Unit::TestCase
   def test_sql_injection_to_s_value
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "92eae7165aea8653ce37be36b5a843114fd7d6ce61f272db03239dfdaa151ee8",
+      :fingerprint => "0cf32bcc2320f59c97d4f5e051a764ee4fe7af987149ff118bce9900ff7a2faa",
       :warning_type => "SQL Injection",
       :line => 64,
       :message => /^Possible\ SQL\ injection/,

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -995,7 +995,7 @@ class Rails31Tests < Test::Unit::TestCase
   def test_sql_injection_with_interpolated_value
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "fd5cc1e0538e8a08b47e85cb7a9a699358908d8049daaaa5609539aa8aa03278",
+      :fingerprint => "d877102aa3a7f1c5a6074d9486e6c850dd9dab23cab4f149a9bd674b440bda49",
       :warning_type => "SQL Injection",
       :line => 33,
       :message => /^Possible\ SQL\ injection/,
@@ -1213,7 +1213,7 @@ class Rails31Tests < Test::Unit::TestCase
   def test_information_disclosure_detailed_exceptions_override
     assert_warning :type => :warning,
       :warning_code => 62,
-      :fingerprint => "16f60330426df3603595f5692c7b0916e38c8674a214fef45d7acf248a8db6b3",
+      :fingerprint => "e427e61359aa0f4f1e1a689066ff1c5034a54c9518da46755e308252b35b054d",
       :warning_type => "Information Disclosure",
       :line => 29,
       :message => /^Detailed\ exceptions\ may\ be\ enabled\ in\ 's/,
@@ -1224,7 +1224,7 @@ class Rails31Tests < Test::Unit::TestCase
   def test_command_injection_interpolation_inside_interpolation
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "5ef09b79bf1d08ccd42e376238f9a618227da4990ea7702a1d4da2e83f4820fe",
+      :fingerprint => "e12b7628a5656be025d37569da24a10157702f541cae63eca5d4211ff1ce632a",
       :warning_type => "Command Injection",
       :line => 34,
       :message => /^Possible\ command\ injection/,

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -134,7 +134,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_information_disclosure_detailed_exceptions_override
     assert_warning :type => :warning,
       :warning_code => 62,
-      :fingerprint => "c1c1c512feca03b77e560939098efabbc2ec9279ef66f75bc63a84f815b54ec2",
+      :fingerprint => "e023f55d7d83631e750435a7d8f432e7e6d0d87b0a82706f91f247ce004830c2",
       :warning_type => "Information Disclosure",
       :line => 6,
       :message => /^Detailed\ exceptions\ may\ be\ enabled\ in\ 's/,
@@ -190,7 +190,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_sql_injection_connection_execute
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "4efbd2d2fc76d30296c8aa66368ddaf337b4c677778f36cddfa2290da2ec514b",
+      :fingerprint => "7e96859dfdd7755eaa51af9ee04731c739af364215a97673b7576f348e88fcf1",
       :warning_type => "SQL Injection",
       :line => 8,
       :message => /^Possible\ SQL\ injection/,
@@ -202,7 +202,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_sql_injection_select_rows
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "2e3c08dfb1e17f7d2e6ee5d142223477b85d27e6aa88d2d06cf0a00d04ed2d5c",
+      :fingerprint => "f1a6d026c789b6a029812171695e88fc0de85116d6bba6df61235ccca8194827",
       :warning_type => "SQL Injection",
       :line => 54,
       :message => /^Possible\ SQL\ injection/,
@@ -214,19 +214,19 @@ class Rails4Tests < Test::Unit::TestCase
   def test_sql_injection_select_values
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "3538776239f624a1101afe68b2e894424e8ae3f68222a6eec9fb4421d01cc557",
+      :fingerprint => "700c504a68786c6a8d7a7125b5a722ede615e0f998f3c385d65bd12189220a99",
       :warning_type => "SQL Injection",
       :line => 46,
       :message => /^Possible\ SQL\ injection/,
       :confidence => 1,
       :relative_path => "app/controllers/friendly_controller.rb",
-      :user_input => s(:call, s(:call_with_block, s(:call, s(:call, nil, :destinations), :map), s(:args, :d), s(:call, s(:lvar, :d), :id)), :join, s(:str, ","))
+      :user_input => s(:call, s(:iter, s(:call, s(:call, nil, :destinations), :map), s(:args, :d), s(:call, s(:lvar, :d), :id)), :join, s(:str, ","))
   end
 
   def test_sql_injection_exec_query
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "59be915e75d6eb88def8fccebae1f9930bb6e50b2e598c7f04bf98c7a3235219",
+      :fingerprint => "f99145dd8cfb1abca2ff36722b4bd136382d86ffd2bb28eb5ac6d064677c845f",
       :warning_type => "SQL Injection",
       :line => 12,
       :message => /^Possible\ SQL\ injection/,
@@ -238,7 +238,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_sql_injection_exec_update
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "29fac7fc616f19edf59cc230f7a86292d6c69234b5879868eaf1d954f033974f",
+      :fingerprint => "cf9a74253c027dafb7f6bc090b0c4a7c36e9982d15c46e40bda37eeee78966ef",
       :warning_type => "SQL Injection",
       :line => 5,
       :message => /^Possible\ SQL\ injection/,
@@ -296,7 +296,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_sql_injection_in_find_by
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "ca9d658a7215099a35b3b3ec3867ffb8fb7ad497d31307ba8952d7dcb85e8ac9",
+      :fingerprint => "660d7f796162d23ff209f2d35bb647b3d0cc6ad280e9320ce9d3b2853c508730",
       :warning_type => "SQL Injection",
       :line => 47,
       :message => /^Possible\ SQL\ injection/,
@@ -422,7 +422,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_regex_denial_of_service
     assert_warning :type => :warning,
       :warning_code => 76,
-      :fingerprint => "6cca076d42e35f953627c7013ee8d6245f0ce564fd8a595cdb47f1d58a47f90f",
+      :fingerprint => "f162a94e8ba3c94a8e997b470687e9d5e44a7692b99248b8bc3e689c1a1b86ff",
       :warning_type => "Denial of Service",
       :line => 38,
       :message => /^Parameter\ value\ used\ in\ regex/,
@@ -646,7 +646,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_sql_injection_in_chained_string_building
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "6109b24aecaa204463bcebeb594becfe06d5f3c40cfe092b54a4c5146273e134",
+      :fingerprint => "e60bf02af3884ea73227f05e0b5e00a8ed4466958c22223dbbc4fc4f828c6a1c",
       :warning_type => "SQL Injection",
       :line => 34,
       :message => /^Possible\ SQL\ injection/,
@@ -705,7 +705,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_sql_injection_with_to_s_on_string_interp
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "4617dc460e895a734ac500b963bae96ee133e272611464519e7dcf52810075aa",
+      :fingerprint => "76279bb48be9716ee4618dbd0a3cda08a63fc1053484c4f29c0214940a57a202",
       :warning_type => "SQL Injection",
       :line => 39,
       :message => /^Possible\ SQL\ injection/,
@@ -770,7 +770,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_additional_libs_option
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "528555766bb642ac7137a2a3b14d022ad12cc2006925b2a028d7f07c1c804204",
+      :fingerprint => "e1bff55541ac57c8bae7b027e34c23bfe76f675d5a741d767d4a533bbce9ab4a",
       :warning_type => "Command Injection",
       :line => 4,
       :message => /^Possible\ command\ injection/,
@@ -782,7 +782,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_command_injection_in_library
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "21857e8872d187312a0b2470876bf6c8a8885df84c510d766f4639d95ae7cef7",
+      :fingerprint => "9a11e7271784d69c667ad82481596096781a4873297d3f7523d290f51465f9d6",
       :warning_type => "Command Injection",
       :line => 3,
       :message => /^Possible\ command\ injection/,
@@ -794,7 +794,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_command_injection_interpolated_string_in_library
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "899bf57685de767746ef220e51883b62eca23b505a6e17e57dcd8c2ca57959b8",
+      :fingerprint => "83151193b403812e79a00a3bf8f1e8a01d0232b6b8ae5b1bccb2fd146299e8c6",
       :warning_type => "Command Injection",
       :line => 8,
       :message => /^Possible\ command\ injection/,
@@ -806,7 +806,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_command_injection_from_not_skipping_before_filter
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "9f209feb4b84e753fe331875dda3c1fb30c2938bfda056f4583b15f64ef940b9",
+      :fingerprint => "b4a4bfc1dd6f5f193c9cd3f0819abb936375eee379e5373c08d23957d3af1cd0",
       :warning_type => "Command Injection",
       :line => 18,
       :message => /^Possible\ command\ injection/,
@@ -828,7 +828,7 @@ class Rails4Tests < Test::Unit::TestCase
 
     assert_warning :type => :warning,
       :warning_code => 14,
-      :fingerprint => "90bc5e7b29027e8d2f8d7bc110dbd173db1f05a8583010613c26f996cd86b02b",
+      :fingerprint => "b35ce0b104d755d40bec760daf5ca33578036f737094e453b9c79e0c441ef2b7",
       :warning_type => "Command Injection",
       :line => 83,
       :message => /^Possible\ command\ injection\ in\ open\(\)/,
@@ -860,7 +860,7 @@ class Rails4Tests < Test::Unit::TestCase
 
     assert_warning :type => :warning,
       :warning_code => 16,
-      :fingerprint => "fa018b141157364fad0135416637cf6007b5c77feebda276159e07de76a3f639",
+      :fingerprint => "2e235612f5ee3a6c20a094cec38c65ec4ae5f9550cd2cd31da69d5ef751967e6",
       :warning_type => "File Access",
       :line => 83,
       :message => /^Parameter\ value\ used\ in\ file\ name/,
@@ -870,7 +870,7 @@ class Rails4Tests < Test::Unit::TestCase
 
     assert_warning :type => :warning,
       :warning_code => 16,
-      :fingerprint => "9068352d27a2b01f54e7e23a926d2d8501edfe9ae2fb22d9670b46afff61ed4f",
+      :fingerprint => "a554792e632ec66fa9bee7a880a0ebf5b1938603ee2b673d240d03c4b9574ad9",
       :warning_type => "File Access",
       :line => 84,
       :message => /^Parameter\ value\ used\ in\ file\ name/,

--- a/test/tests/rails_with_xss_plugin.rb
+++ b/test/tests/rails_with_xss_plugin.rb
@@ -228,7 +228,7 @@ class RailsWithXssPluginTests < Test::Unit::TestCase
   def test_sql_injection_select_value
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "e725c387439202f28c1983bf225323d93b5891695c91b9389740e2da3d74855e",
+      :fingerprint => "fbf3545b52e589a9f9c25449b3505fadbdec63010664504e7366fbcc5fe6b43a",
       :warning_type => "SQL Injection",
       :line => 134,
       :message => /^Possible\ SQL\ injection/,
@@ -340,7 +340,7 @@ class RailsWithXssPluginTests < Test::Unit::TestCase
   def test_cross_site_scripting_CVE_2012_1099
     assert_warning :type => :template,
       :warning_code => 22,
-      :fingerprint => "d54bacec90be92ad8ca58164cdfd505114eae34db2fb5b03f7bc2a8fd93f1edb",
+      :fingerprint => "4ad12198bfbc84a389e439d3c4cc9c2551e3c2aa7b36182336463ca87e45ec5b",
       :warning_type => "Cross Site Scripting",
       :line => 18,
       :message => /^Upgrade\ to\ Rails\ 3\ or\ use\ options_for_se/,


### PR DESCRIPTION
Unfortunately this is going to change a lot of fingerprints.

The good news is it simplifies some code and makes it harder to introduce bugs because of node names.