### PR TITLE
Port render path improvements from Brakeman Pro

### DIFF
--- a/lib/brakeman/processor.rb
+++ b/lib/brakeman/processor.rb
@@ -47,8 +47,8 @@ module Brakeman
 
     #Process variable aliasing in controller source and save it in the
     #tracker.
-    def process_controller_alias name, src, only_method = nil
-      ControllerAliasProcessor.new(@app_tree, @tracker, only_method).process_controller name, src
+    def process_controller_alias name, src, only_method = nil, file = nil
+      ControllerAliasProcessor.new(@app_tree, @tracker, only_method).process_controller name, src, file
     end
 
     #Process a model source

--- a/lib/brakeman/processors/controller_alias_processor.rb
+++ b/lib/brakeman/processors/controller_alias_processor.rb
@@ -182,7 +182,7 @@ class Brakeman::ControllerAliasProcessor < Brakeman::AliasProcessor
       end
     end
 
-    render_path = Brakeman::RenderPath.new.add_controller_render(@current_class, @current_method, line, @file)
+    render_path = Brakeman::RenderPath.new.add_controller_render(@current_class, @current_method, line, relative_path(@file))
     super name, args, render_path, line
   end
 

--- a/lib/brakeman/processors/controller_alias_processor.rb
+++ b/lib/brakeman/processors/controller_alias_processor.rb
@@ -59,7 +59,7 @@ class Brakeman::ControllerAliasProcessor < Brakeman::AliasProcessor
           method = processor.process method
         end
 
-        @file = mixin[:files].first
+        @file = mixin.file
         #Then process it like any other method in the controller
         process method
       end
@@ -176,7 +176,7 @@ class Brakeman::ControllerAliasProcessor < Brakeman::AliasProcessor
     # If line is null, assume implicit render and set the end of the action
     # method as the line number
     if line.nil? and controller = @tracker.controllers[@current_class]
-      if meth = controller[:public][@current_method]
+      if meth = controller.get_method(@current_method)
         line = meth[:src] && meth[:src].last && meth[:src].last.line
         line += 1
       end

--- a/lib/brakeman/processors/controller_alias_processor.rb
+++ b/lib/brakeman/processors/controller_alias_processor.rb
@@ -20,12 +20,13 @@ class Brakeman::ControllerAliasProcessor < Brakeman::AliasProcessor
     @method_cache = {} #Cache method lookups
   end
 
-  def process_controller name, src
+  def process_controller name, src, file
     if not node_type? src, :class
       Brakeman.debug "#{name} is not a class, it's a #{src.node_type}"
       return
     else
       @current_class = name
+      @file = file
 
       process_default src
 
@@ -58,6 +59,7 @@ class Brakeman::ControllerAliasProcessor < Brakeman::AliasProcessor
           method = processor.process method
         end
 
+        @file = mixin[:files].first
         #Then process it like any other method in the controller
         process method
       end
@@ -180,7 +182,7 @@ class Brakeman::ControllerAliasProcessor < Brakeman::AliasProcessor
       end
     end
 
-    render_path = Brakeman::RenderPath.new.add_controller_render(@current_class, @current_method, line)
+    render_path = Brakeman::RenderPath.new.add_controller_render(@current_class, @current_method, line, @file)
     super name, args, render_path, line
   end
 

--- a/lib/brakeman/processors/controller_alias_processor.rb
+++ b/lib/brakeman/processors/controller_alias_processor.rb
@@ -166,13 +166,22 @@ class Brakeman::ControllerAliasProcessor < Brakeman::AliasProcessor
   #Processes the default template for the current action
   def process_default_render exp
     process_layout
-    process_template template_name, nil
+    process_template template_name, nil, nil, nil
   end
 
   #Process template and add the current class and method name as called_from info
-  def process_template name, args
-    render_path = Brakeman::RenderPath.new.add_controller_render(@current_class, @current_method)
-    super name, args, render_path
+  def process_template name, args, _, line
+    # If line is null, assume implicit render and set the end of the action
+    # method as the line number
+    if line.nil? and controller = @tracker.controllers[@current_class]
+      if meth = controller[:public][@current_method]
+        line = meth[:src] && meth[:src].last && meth[:src].last.line
+        line += 1
+      end
+    end
+
+    render_path = Brakeman::RenderPath.new.add_controller_render(@current_class, @current_method, line)
+    super name, args, render_path, line
   end
 
   #Turns a method name into a template name

--- a/lib/brakeman/processors/lib/render_path.rb
+++ b/lib/brakeman/processors/lib/render_path.rb
@@ -6,22 +6,24 @@ module Brakeman
       @path = []
     end
 
-    def add_controller_render controller_name, method_name, line
+    def add_controller_render controller_name, method_name, line, file
       method_name ||= ""
 
       @path << { :type => :controller,
                  :class => controller_name.to_sym,
                  :method => method_name.to_sym,
-                 :line => line
+                 :line => line,
+                 :file => file
                 }
 
       self
     end
 
-    def add_template_render template_name, line
+    def add_template_render template_name, line, file
       @path << { :type => :template,
                  :name => template_name.to_sym,
-                 :line => line
+                 :line => line,
+                 :file => file
                }
 
       self

--- a/lib/brakeman/processors/lib/render_path.rb
+++ b/lib/brakeman/processors/lib/render_path.rb
@@ -95,7 +95,7 @@ module Brakeman
     end
 
     def to_json *args
-      MultiJson.dump(self.to_a)
+      MultiJson.dump(@path)
     end
 
     def initialize_copy original

--- a/lib/brakeman/processors/lib/render_path.rb
+++ b/lib/brakeman/processors/lib/render_path.rb
@@ -6,19 +6,23 @@ module Brakeman
       @path = []
     end
 
-    def add_controller_render controller_name, method_name
+    def add_controller_render controller_name, method_name, line
       method_name ||= ""
 
       @path << { :type => :controller,
                  :class => controller_name.to_sym,
-                 :method => method_name.to_sym }
+                 :method => method_name.to_sym,
+                 :line => line
+                }
 
       self
     end
 
-    def add_template_render template_name
+    def add_template_render template_name, line
       @path << { :type => :template,
-                 :name => template_name.to_sym }
+                 :name => template_name.to_sym,
+                 :line => line
+               }
 
       self
     end

--- a/lib/brakeman/processors/template_alias_processor.rb
+++ b/lib/brakeman/processors/template_alias_processor.rb
@@ -19,7 +19,7 @@ class Brakeman::TemplateAliasProcessor < Brakeman::AliasProcessor
 
   #Process template
   def process_template name, args, _, line = nil
-    file = @template[:file] || tracker.templates[@template[:name]]
+    file = relative_path(@template.file || @tracker.templates[@template.name])
 
     if @called_from
       if @called_from.include_template? name

--- a/lib/brakeman/processors/template_alias_processor.rb
+++ b/lib/brakeman/processors/template_alias_processor.rb
@@ -19,15 +19,17 @@ class Brakeman::TemplateAliasProcessor < Brakeman::AliasProcessor
 
   #Process template
   def process_template name, args, _, line = nil
+    file = @template[:file] || tracker.templates[@template[:name]]
+
     if @called_from
       if @called_from.include_template? name
         Brakeman.debug "Skipping circular render from #{@template.name} to #{name}"
         return
       end
 
-      super name, args, @called_from.dup.add_template_render(@template.name, line)
+      super name, args, @called_from.dup.add_template_render(@template.name, line, file)
     else
-      super name, args, Brakeman::RenderPath.new.add_template_render(@template.name, line)
+      super name, args, Brakeman::RenderPath.new.add_template_render(@template.name, line, file)
     end
   end
 

--- a/lib/brakeman/processors/template_alias_processor.rb
+++ b/lib/brakeman/processors/template_alias_processor.rb
@@ -18,16 +18,16 @@ class Brakeman::TemplateAliasProcessor < Brakeman::AliasProcessor
   end
 
   #Process template
-  def process_template name, args
+  def process_template name, args, _, line = nil
     if @called_from
       if @called_from.include_template? name
         Brakeman.debug "Skipping circular render from #{@template.name} to #{name}"
         return
       end
 
-      super name, args, @called_from.dup.add_template_render(@template.name)
+      super name, args, @called_from.dup.add_template_render(@template.name, line)
     else
-      super name, args, Brakeman::RenderPath.new.add_template_render(@template.name)
+      super name, args, Brakeman::RenderPath.new.add_template_render(@template.name, line)
     end
   end
 

--- a/lib/brakeman/rescanner.rb
+++ b/lib/brakeman/rescanner.rb
@@ -118,8 +118,8 @@ class Brakeman::Rescanner < Brakeman::Scanner
           end
         end
 
-        controller.src.each_value do |src|
-          @processor.process_controller_alias controller.name, src
+        controller.src.each do |file, src|
+          @processor.process_controller_alias controller.name, src, nil, file
         end
       end
     end
@@ -165,7 +165,7 @@ class Brakeman::Rescanner < Brakeman::Scanner
 
         controller.src.each do |file, src|
           unless @paths.include? file
-            @processor.process_controller_alias controller.name, src, r[2]
+            @processor.process_controller_alias controller.name, src, r[2], file
           end
         end
       elsif r[0] == :template

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -221,8 +221,8 @@ class Brakeman::Scanner
 
     track_progress controllers, "controllers" do |name, controller|
       Brakeman.debug "Processing #{name}"
-      controller.src.each_value do |src|
-        @processor.process_controller_alias name, src
+      controller.src.each do |file, src|
+        @processor.process_controller_alias name, src, nil, file
       end
     end
 

--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -89,9 +89,8 @@ class Brakeman::Warning
   end
 
   #Returns name of a view, including where it was rendered from
-  def view_name
-    return @view_name if @view_name
-    if called_from
+  def view_name(include_renderer = true)
+    if called_from and include_renderer
       @view_name = "#{template.name} (#{called_from.last})"
     else
       @view_name = template.name
@@ -183,10 +182,10 @@ class Brakeman::Warning
     Digest::SHA2.new(256).update("#{warning_code_string}#{code_string}#{location_string}#{@relative_path}#{self.confidence}").to_s
   end
 
-  def location
+  def location include_renderer = true
     case @warning_set
     when :template
-      location = { :type => :template, :template => self.view_name }
+      location = { :type => :template, :template => self.view_name(include_renderer) }
     when :model
       location = { :type => :model, :model => self.model }
     when :controller
@@ -210,7 +209,7 @@ class Brakeman::Warning
       :link => self.link,
       :code => (@code && self.format_code(false)),
       :render_path => self.called_from,
-      :location => self.location,
+      :location => self.location(false),
       :user_input => (@user_input && self.format_user_input(false)),
       :confidence => TEXT_CONFIDENCE[self.confidence]
     }

--- a/test/tests/json_output.rb
+++ b/test/tests/json_output.rb
@@ -39,4 +39,8 @@ class JSONOutputTests < Test::Unit::TestCase
   def test_paths
     assert @@json["warnings"].all? { |w| not w["file"].start_with? "/" }
   end
+
+  def test_template_names_dont_have_renderer
+    assert @@json["warnings"].none? { |warning| warning["render_path"] and warning["location"]["template"].include? "(" }
+  end
 end

--- a/test/tests/render_path.rb
+++ b/test/tests/render_path.rb
@@ -4,34 +4,34 @@ class RenderPathTests < Test::Unit::TestCase
   end
 
   def test_include_controller
-    @r.add_controller_render :TestController, :test
+    @r.add_controller_render :TestController, :test, 1
 
     assert @r.include_controller? :TestController
   end
 
   def test_rendered_from_controller
-    @r.add_controller_render :TestController, :test
+    @r.add_controller_render :TestController, :test, 1
 
     assert @r.rendered_from_controller?
   end
 
   def test_include_template
-    @r.add_template_render 'some/template'
+    @r.add_template_render 'some/template', 1
 
     assert @r.include_template? :'some/template'
   end
 
   def test_include_any_method
-    @r.add_controller_render :TestController, :test
-    @r.add_controller_render :TestController, :test2
-    @r.add_controller_render :TestController, :test3
+    @r.add_controller_render :TestController, :test, 10
+    @r.add_controller_render :TestController, :test2, 20
+    @r.add_controller_render :TestController, :test3, 30
 
     assert @r.include_any_method? ['test']
   end
 
   def test_each
-    @r.add_controller_render :TestController, :test
-    @r.add_template_render 'some/template'
+    @r.add_controller_render :TestController, :test, 1
+    @r.add_template_render 'some/template', 2
 
     @r.each do |loc|
       case loc[:type]
@@ -45,10 +45,10 @@ class RenderPathTests < Test::Unit::TestCase
   end
 
   def test_dup
-    @r.add_controller_render :TestController, :test
+    @r.add_controller_render :TestController, :test, 1
 
     s = @r.dup
-    s.add_template_render 'some/template'
+    s.add_template_render 'some/template', 2
 
     assert_equal 1, @r.length
     assert_equal 2, s.length

--- a/test/tests/render_path.rb
+++ b/test/tests/render_path.rb
@@ -4,34 +4,34 @@ class RenderPathTests < Test::Unit::TestCase
   end
 
   def test_include_controller
-    @r.add_controller_render :TestController, :test, 1
+    @r.add_controller_render :TestController, :test, 1, 'app/controllers/test_controller.rb'
 
     assert @r.include_controller? :TestController
   end
 
   def test_rendered_from_controller
-    @r.add_controller_render :TestController, :test, 1
+    @r.add_controller_render :TestController, :test, 1, 'app/controllers/test_controller.rb'
 
     assert @r.rendered_from_controller?
   end
 
   def test_include_template
-    @r.add_template_render 'some/template', 1
+    @r.add_template_render 'some/template', 1, 'app/views/some/template.html.erb'
 
     assert @r.include_template? :'some/template'
   end
 
   def test_include_any_method
-    @r.add_controller_render :TestController, :test, 10
-    @r.add_controller_render :TestController, :test2, 20
-    @r.add_controller_render :TestController, :test3, 30
+    @r.add_controller_render :TestController, :test, 10, 'app/controllers/test_controller.rb'
+    @r.add_controller_render :TestController, :test2, 20, 'app/controllers/test_controller.rb'
+    @r.add_controller_render :TestController, :test3, 30, 'app/controllers/test_controller.rb'
 
     assert @r.include_any_method? ['test']
   end
 
   def test_each
-    @r.add_controller_render :TestController, :test, 1
-    @r.add_template_render 'some/template', 2
+    @r.add_controller_render :TestController, :test, 1, 'app/controllers/test_controller.rb'
+    @r.add_template_render 'some/template', 2, 'app/views/some/template.html.erb'
 
     @r.each do |loc|
       case loc[:type]
@@ -45,10 +45,10 @@ class RenderPathTests < Test::Unit::TestCase
   end
 
   def test_dup
-    @r.add_controller_render :TestController, :test, 1
+    @r.add_controller_render :TestController, :test, 1, 'app/controllers/test_controller.rb'
 
     s = @r.dup
-    s.add_template_render 'some/template', 2
+    s.add_template_render 'some/template', 2, 'app/views/some/template.html.erb'
 
     assert_equal 1, @r.length
     assert_equal 2, s.length


### PR DESCRIPTION
Finally finish porting over changes to the render path representation in JSON reports.

Render paths used to look like this:

```json
"render_path": ["HomeController#test_xss_with_or"]
```

Now they look like this:

```json
"render_path": [{"type":"controller","class":"HomeController","method":"test_xss_with_or","line":142,"file":"app/controllers/home_controller.rb"}]
```

The render path is basically where a view is rendered from and can include several steps if the view is a partial.

Additionally, this change removes the "render location" from the template name. A rendered template used to have a location like this:

```json
"location": {
  "type": "template",
  "template": "home/test_xss_with_or (HomeController#test_xss_with_or)"
}
```

The information inside the parentheses is redundant since it's included in the render path information.

With this change, the location now looks like this:

```json
"location": {
  "type": "template",
  "template": "home/test_xss_with_or"
}
```