### PR TITLE
Allow support for j and escape_javascript

### DIFF
--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -287,9 +287,9 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
   end
 
   def setup
-    @ignore_methods = Set[:button_to, :check_box, :content_tag, :escapeHTML, :escape_once,
+    @ignore_methods = Set[:button_to, :check_box, :content_tag, :escapeHTML, :escape_javascript, :escape_once,
                            :field_field, :fields_for, :h, :hidden_field,
-                           :hidden_field, :hidden_field_tag, :image_tag, :label,
+                           :hidden_field, :hidden_field_tag, :image_tag, :j, :label,
                            :link_to, :mail_to, :radio_button, :select,
                            :submit_tag, :text_area, :text_field,
                            :text_field_tag, :url_encode, :url_for,

--- a/test/apps/rails_with_xss_plugin/app/views/layouts/users.html.erb
+++ b/test/apps/rails_with_xss_plugin/app/views/layouts/users.html.erb
@@ -6,6 +6,9 @@
   <meta http-equiv="content-type" content="text/html;charset=UTF-8" />
   <title>Users: <%= controller.action_name %></title>
   <%= stylesheet_link_tag 'scaffold' %>
+<script>
+  var browser="<%= j request.env['HTTP_USER_AGENT'] %>";
+</script>
 </head>
 <body>
 


### PR DESCRIPTION
Hello,

The `j` and `escape_javascript` method are used in javascript blocks to ensure that
text is properly escaped to be in a javascript string.

This works much the same way as `escapeHTML` and `h` do for ensuring that text is safe for inclusion in an html tag.

This can be found throughout stack overflow and the docs can be found [here](http://apidock.com/rails/ActionView/Helpers/JavaScriptHelper/escape_javascript).

Does this sounds like a good inclusion?
What else can I provide to help drive that decision?

Thanks for this great tool