### PR TITLE
Allow method to be specified by regex

### DIFF
--- a/lib/brakeman/call_index.rb
+++ b/lib/brakeman/call_index.rb
@@ -139,6 +139,8 @@ class Brakeman::CallIndex
   def calls_by_method method
     if method.is_a? Array
       calls_by_methods method
+    elsif method.is_a? Regexp
+      calls_by_methods_regex method
     else
       @calls_by_method[method.to_sym] || []
     end
@@ -152,6 +154,14 @@ class Brakeman::CallIndex
       calls.concat @calls_by_method[method] if @calls_by_method.key? method
     end
 
+    calls
+  end
+
+  def calls_by_methods_regex methods_regex
+    calls = []
+    @calls_by_method.each do |key, value|
+      calls.concat value if key.to_s.match methods_regex
+    end
     calls
   end
 

--- a/test/tests/call_index.rb
+++ b/test/tests/call_index.rb
@@ -16,6 +16,10 @@ class CallIndexTests < Test::Unit::TestCase
     assert @call_index.find_calls(opts).length
   end
 
+  def test_find_by_method_regex
+    assert_found 2, :method => %r{do_it(?:_now)?}
+  end
+
   def test_find_by_method
     assert_found 1, :method => :hello
   end


### PR DESCRIPTION
The options to `find_calls` includes `:method - symbol, array of symbols, or regular expression to match method(s)` but passing a regular expression without a target does not actually work without this patch.