### PR TITLE
Calculate absolute paths correctly for Windows

### DIFF
--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -411,8 +411,9 @@ module Brakeman::Util
   end
 
   def relative_path file
-    if file and not file.empty? and file.start_with? '/'
-      Pathname.new(file).relative_path_from(Pathname.new(@tracker.app_path)).to_s
+    pname = Pathname.new file
+    if file and not file.empty? and pname.absolute?
+      pname.relative_path_from(Pathname.new(@tracker.app_path)).to_s
     else
       file
     end

--- a/test/tests/rails_with_xss_plugin.rb
+++ b/test/tests/rails_with_xss_plugin.rb
@@ -334,7 +334,7 @@ class RailsWithXssPluginTests < Test::Unit::TestCase
   end
 
   def test_absolute_paths
-    assert report[:generic_warnings].all? { |w| w.file.start_with? "/" }
+    assert report[:generic_warnings].all? { |w| (Pathname.new w.file).absolute? }
   end
 
   def test_cross_site_scripting_CVE_2012_1099


### PR DESCRIPTION
The current method of determining if a file is absolute does not work
correctly on Windows. The result is that ignore files contain an
absolute path instead of a relative path. This also leads to an
incorrect fingerprint which prevents developers and continuous
integration tools from sharing ignored warnings.