### PR TITLE
Better Haml handling

### DIFF
--- a/lib/brakeman/processors/haml_template_processor.rb
+++ b/lib/brakeman/processors/haml_template_processor.rb
@@ -4,7 +4,8 @@ require 'brakeman/processors/template_processor'
 class Brakeman::HamlTemplateProcessor < Brakeman::TemplateProcessor
   HAML_FORMAT_METHOD = /format_script_(true|false)_(true|false)_(true|false)_(true|false)_(true|false)_(true|false)_(true|false)/
   HAML_HELPERS = s(:colon2, s(:const, :Haml), :Helpers)
-  
+  JAVASCRIPT_FILTER = s(:colon2, s(:colon2, s(:const, :Haml), :Filters), :Javascript)
+
   #Processes call, looking for template output
   def process_call exp
     target = exp.target
@@ -36,28 +37,31 @@ class Brakeman::HamlTemplateProcessor < Brakeman::TemplateProcessor
               if string? out
                 ignore
               else
-                case method.to_s
-                when "push_text"
-                  build_output_from_push_text(out)
-                when HAML_FORMAT_METHOD
-                  if $4 == "true"
-                    if string_interp? out
-                      build_output_from_push_text(out, :escaped_output)
-                    else
-                      Sexp.new :format_escaped, out
-                    end
-                  else
-                    if string_interp? out
+                r = case method.to_s
+                    when "push_text"
                       build_output_from_push_text(out)
-                    else
-                      Sexp.new :format, out
-                    end
-                  end
-                else
-                  raise "Unrecognized action on _hamlout: #{method}"
-                end
-              end
+                    when HAML_FORMAT_METHOD
+                      if $4 == "true"
+                        if string_interp? out
+                          build_output_from_push_text(out, :escaped_output)
+                        else
+                          Sexp.new :format_escaped, out
+                        end
+                      else
+                        if string_interp? out
+                          build_output_from_push_text(out)
+                        else
+                          Sexp.new :format, out
+                        end
+                      end
 
+                    else
+                      raise "Unrecognized action on _hamlout: #{method}"
+                    end
+
+                @javascript = false
+                r
+              end
             end
 
       res.line(exp.line)
@@ -83,6 +87,14 @@ class Brakeman::HamlTemplateProcessor < Brakeman::TemplateProcessor
       #Process call to render()
       exp.arglist = process exp.arglist
       make_render_in_view exp
+    elsif target == nil and method == :find_and_preserve
+      process exp.first_arg
+    elsif method == :render_with_options
+      if target == JAVASCRIPT_FILTER
+        @javascript = true
+      end
+
+      process exp.first_arg
     else
       exp.target = target
       exp.arglist = process exp.arglist
@@ -144,7 +156,7 @@ class Brakeman::HamlTemplateProcessor < Brakeman::TemplateProcessor
   #Gets outputs from values interpolated into _hamlout.push_text
   def get_pushed_value exp, default = :output
     return exp unless sexp? exp
-    
+
     case exp.node_type
     when :format
       exp.node_type = :output
@@ -160,6 +172,8 @@ class Brakeman::HamlTemplateProcessor < Brakeman::TemplateProcessor
       exp.map! { |e| get_pushed_value e }
     else
       if call? exp and exp.target == HAML_HELPERS and exp.method == :html_escape
+        s = Sexp.new(:escaped_output, exp.first_arg)
+      elsif @javascript and call? exp and (exp.method == :j or exp.method == :escape_javascript)
         s = Sexp.new(:escaped_output, exp.first_arg)
       else
         s = Sexp.new(default, exp)

--- a/test/apps/rails4/app/views/users/haml_test.html.haml
+++ b/test/apps/rails4/app/views/users/haml_test.html.haml
@@ -4,3 +4,5 @@
   #innerstuff
     %h1= raw params[:y]
     =" #{User.first.name.html_safe}"
+    :javascript
+      var import_file_upload_id = "#{j(params[:id])}";

--- a/test/apps/rails4/app/views/users/haml_test.html.haml
+++ b/test/apps/rails4/app/views/users/haml_test.html.haml
@@ -3,3 +3,4 @@
     %p= params[:x]
   #innerstuff
     %h1= raw params[:y]
+    =" #{User.first.name.html_safe}"

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -13,7 +13,7 @@ class Rails4Tests < Test::Unit::TestCase
     @expected ||= {
       :controller => 0,
       :model => 2,
-      :template => 7,
+      :template => 8,
       :generic => 62
     }
   end
@@ -642,6 +642,17 @@ class Rails4Tests < Test::Unit::TestCase
       :user_input => s(:call, nil, :params)
   end
 
+  def test_cross_site_scripting_haml_interpolation
+    assert_warning :type => :template,
+      :warning_code => 2,
+      :fingerprint => "9d4de763367e98fe87e2923d1426e474b3e41a4754e1bc06d3a672bc68b89b79",
+      :warning_type => "Cross Site Scripting",
+      :line => 6,
+      :message => /^Unescaped\ model\ attribute/,
+      :confidence => 0,
+      :relative_path => "app/views/users/haml_test.html.haml",
+      :user_input => nil
+  end
 
   def test_sql_injection_in_chained_string_building
     assert_warning :type => :warning,

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -654,6 +654,18 @@ class Rails4Tests < Test::Unit::TestCase
       :user_input => nil
   end
 
+  def test_cross_site_scripting_find_and_preserve_escape_javascript
+    assert_no_warning :type => :template,
+      :warning_code => 2,
+      :fingerprint => "d75b08fa4d1ef70aa2be54f4568b7486aaf91beae65c7adc1422d3582fdbf5b0",
+      :warning_type => "Cross Site Scripting",
+      :line => 8,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 2,
+      :relative_path => "app/views/users/haml_test.html.haml",
+      :user_input => s(:call, s(:call, nil, :params), :[], s(:lit, :id))
+  end
+
   def test_sql_injection_in_chained_string_building
     assert_warning :type => :warning,
       :warning_code => 0,


### PR DESCRIPTION
- Handle `find_and_preserve` calls (essentially passes through input)
- Handle `render_with_options` calls (input isn't escaped, at least for Javascript filter)
- If `escape_javascript` or `j` are used inside `:javascript` block, treat as escaped