### PR TITLE
Process chained assignment properly

### DIFF
--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -682,6 +682,44 @@ class AliasProcessorTests < Test::Unit::TestCase
     OUTPUT
   end
 
+  def test_chained_assignment
+    assert_alias '1', <<-INPUT
+    x = y = 1
+    x
+    INPUT
+
+    assert_alias '1', <<-INPUT
+    @x = @y = 1
+    @x
+    INPUT
+
+    assert_alias '1', <<-INPUT
+    $x = $y = 1
+    $x
+    INPUT
+
+    assert_alias '1', <<-INPUT
+    X = Y = 1
+    X
+    INPUT
+
+    assert_alias '1', <<-INPUT
+    @@x = @@y = 1
+    @@x
+    INPUT
+
+    assert_alias '1', <<-INPUT
+    w.x = x.y = 1
+    w.x
+    INPUT
+
+    assert_alias '5', <<-INPUT
+    A = @b = @@c = $D = e.f = 1
+    z = A + @b + @@c + $D + e.f
+    z
+    INPUT
+  end
+
   def test_branch_with_self_assign_target
     assert_alias 'a.w.y', <<-INPUT
     x = a


### PR DESCRIPTION
Previously,

```ruby
x = y = 1
p x
```
Would turn into
```ruby
x = y = 1
p(y = 1)
```
Which is obviously not what we want.

This fixes this embarrassingly old issue reported [on StackOverflow](https://stackoverflow.com/questions/11314450/how-to-secure-link-to-variable-cross-site-scripting-vulnerabilities).