### PR TITLE
Add session key manipulation check

### DIFF
--- a/lib/brakeman/call_index.rb
+++ b/lib/brakeman/call_index.rb
@@ -98,9 +98,12 @@ class Brakeman::CallIndex
       @calls_by_method[call[:method]] ||= []
       @calls_by_method[call[:method]] << call
 
-      unless call[:target].is_a? Sexp
+      if not call[:target].is_a? Sexp
         @calls_by_target[call[:target]] ||= []
         @calls_by_target[call[:target]] << call
+      elsif call[:target].node_type == :params or call[:target].node_type == :session
+        @calls_by_target[call[:target].node_type] ||= []
+        @calls_by_target[call[:target].node_type] << call
       end
     end
   end

--- a/lib/brakeman/checks/check_session_manipulation.rb
+++ b/lib/brakeman/checks/check_session_manipulation.rb
@@ -1,0 +1,36 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckSessionManipulation < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = "Check for user input in session keys"
+
+  def run_check
+    tracker.find_call(:method => :[]=, :target => :session).each do |result|
+      process_result result
+    end
+  end
+
+  def process_result result
+    return if duplicate? result or result[:call].original_line
+    add_result result
+
+    index = result[:call].first_arg
+
+    if input = has_immediate_user_input?(index)
+      if params? index
+        confidence = CONFIDENCE[:high]
+      else
+        confidence = CONFIDENCE[:med]
+      end
+
+      warn :result => result,
+        :warning_type => "Session Manipulation",
+        :warning_code => :session_key_manipulation,
+        :message => "#{friendly_type_of(input).capitalize} used as key in session hash",
+        :code => result[:call],
+        :user_input => input.match,
+        :confidence => confidence
+    end
+  end
+end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -90,6 +90,7 @@ module Brakeman::WarningCodes
     :csrf_not_protected_by_raising_exception => 86,
     :CVE_2015_3226 => 87,
     :CVE_2015_3227 => 88,
+    :session_key_manipulation => 89,
   }
 
   def self.code name

--- a/test/apps/rails4/app/controllers/users_controller.rb
+++ b/test/apps/rails4/app/controllers/users_controller.rb
@@ -87,4 +87,9 @@ class UsersController < ApplicationController
   def eval_it
     @x = eval(params[:x])
   end
+
+  def session_key
+    session[params[:x]] = params[:y]
+    session["blah-#{params[:token]}"] = user.thing
+  end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -14,7 +14,7 @@ class Rails4Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 2,
       :template => 8,
-      :generic => 62
+      :generic => 64
     }
   end
 
@@ -81,6 +81,30 @@ class Rails4Tests < Test::Unit::TestCase
       :confidence => 0,
       :file => /secret_token\.rb/,
       :relative_path => "config/initializers/secret_token.rb"
+  end
+
+  def test_session_manipulation
+    assert_warning :type => :warning,
+      :warning_code => 89,
+      :fingerprint => "7cb52cac7d8562181aab8f09a34f6393708261c60d2a485a0b89ebd3e8f4b2f4",
+      :warning_type => "Session Manipulation",
+      :line => 92,
+      :message => /^Parameter\ value\ used\ as\ key\ in\ session\ h/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :x))
+  end
+
+  def test_session_manipulation_indirect
+    assert_warning :type => :warning,
+      :warning_code => 89,
+      :fingerprint => "08cbdbed8bcd19a7746434865a0e4a4dc363dd980953cc5b535a318970c95d20",
+      :warning_type => "Session Manipulation",
+      :line => 93,
+      :message => /^Parameter\ value\ used\ as\ key\ in\ session\ h/,
+      :confidence => 1,
+      :relative_path => "app/controllers/users_controller.rb",
+      :user_input => s(:call, s(:params), :[], s(:lit, :token))
   end
 
   def test_json_escaped_by_default_in_rails_4


### PR DESCRIPTION
Warn when user input is used for a session hash key, as suggested by @joernchen.

Also adds the ability to search for calls with `params` or `session` as the target.