### PR TITLE
Avoid warning when linking to a decorated model

### DIFF
--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -91,6 +91,15 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     end
   end
 
+  def ignore_call? target, method
+    decorated_model? method or super
+  end
+
+  def decorated_model? method
+    tracker.config.has_gem? :draper and
+      method == :decorate
+  end
+
   def ignored_method? target, method
     @ignore_methods.include? method or
       method.to_s =~ /_path$/ or

--- a/test/apps/rails3.1/app/controllers/users_controller.rb
+++ b/test/apps/rails3.1/app/controllers/users_controller.rb
@@ -184,4 +184,8 @@ class UsersController < ApplicationController
   def redirect_merge
     redirect_to params.merge(host: 'http://app.webthing.com/stuff', port: '80').except(:action, :controller, :auth_token)
   end
+
+  def drape
+    @user = (params[:id] ? User.find(params[:id]) : current_user).decorate
+  end
 end

--- a/test/apps/rails3.1/app/views/users/drape.html.erb
+++ b/test/apps/rails3.1/app/views/users/drape.html.erb
@@ -1,0 +1,1 @@
+<%= link_to @user.name, @user %>

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -61,6 +61,18 @@ class Rails31Tests < Test::Unit::TestCase
       :file => /other_controller\.rb/
   end
 
+  def test_link_to_decorated_model
+    assert_no_warning :type => :template,
+      :warning_code => 4,
+      :fingerprint => "2eacd2da6edd4b26585956c8b36840d7631f4a5132388829d8e4e4d0b5aaae7d",
+      :warning_type => "Cross Site Scripting",
+      :line => 1,
+      :message => /^Unsafe\ model\ attribute\ in\ link_to\ href/,
+      :confidence => 1,
+      :relative_path => "app/views/users/drape.html.erb",
+      :user_input => s(:call, s(:const, :User), :find, s(:call, s(:params), :[], s(:lit, :id)))
+  end
+
   def test_redirect_multiple_values
     assert_no_warning :type => :warning,
       :warning_type => "Redirect",


### PR DESCRIPTION
If draper gem is used, ignore `decorate` calls in `link_to`.