### PR TITLE
Catch divide by zero in alias processing

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -142,7 +142,16 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       end
     when :/
       if number? target and number? first_arg
-        exp = Sexp.new(:lit, target.value / first_arg.value)
+        if first_arg.value == 0 and not target.value.is_a? Float
+          if @tracker
+            location = [@current_class, @current_method, "line #{first_arg.line}"].compact.join(' ')
+            require 'brakeman/processors/output_processor'
+            code = Brakeman::OutputProcessor.new.format(exp)
+            @tracker.error Exception.new("Potential divide by zero: #{code} (#{location})")
+          end
+        else
+          exp = Sexp.new(:lit, target.value / first_arg.value)
+        end
       end
     when :[]
       if array? target

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -33,6 +33,20 @@ class AliasProcessorTests < Test::Unit::TestCase
     RUBY
   end
 
+  def test_divide_by_zero
+    assert_alias '1 / 0', <<-RUBY
+    x = 1 / 0
+    x
+    RUBY
+  end
+
+  def test_infinity
+    e = RubyParser.new.parse "x = 1.0 / 0; x"
+    a = Brakeman::AliasProcessor.new.process_safely e
+
+    assert_equal Sexp.new(:lit, 1.0 / 0), a.last
+  end
+
   def test_concatentation
     assert_alias "'Hello world!'", <<-RUBY
       x = "Hello"


### PR DESCRIPTION
This used to be caught but something must have changed. In the future this should be a warning not an error.

Fixes #729