### PR TITLE
Warn on SQL query keys, not values in hash arguments

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -342,7 +342,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
   def check_hash_keys exp
     hash_iterate(exp) do |key, value|
       unless symbol?(key)
-        unsafe_key = unsafe_sql? value
+        unsafe_key = unsafe_sql? key
         return unsafe_key if unsafe_key
       end
     end

--- a/test/apps/rails4/app/controllers/friendly_controller.rb
+++ b/test/apps/rails4/app/controllers/friendly_controller.rb
@@ -75,4 +75,9 @@ class FriendlyController
   private def private_some_stuff
     eval params[:what_is_this_java?]
   end
+
+  def where_hashes
+    User.where('stuff' => params[:stuff]) # no warning
+    User.where(params[:key] => params[:stuff]) # warn
+  end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 2,
       :template => 8,
-      :generic => 73
+      :generic => 74
     }
   end
 
@@ -900,6 +900,39 @@ class Rails4Tests < Test::Unit::TestCase
       :message => /^Possible\ SQL\ injection/,
       :confidence => 0,
       :relative_path => "app/models/user.rb"
+  end
+
+  def test_hash_keys_not_values
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :warning_type => "SQL Injection",
+      :line => 80,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/controllers/friendly_controller.rb",
+      :code => s(:call, s(:const, :User), :where, s(:hash, s(:str, "stuff"), s(:call, s(:params), :[], s(:lit, :stuff)))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :stuff))
+
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :warning_type => "SQL Injection",
+      :line => 81,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/controllers/friendly_controller.rb",
+      :code => s(:call, s(:const, :User), :where, s(:hash, s(:call, s(:params), :[], s(:lit, :key)), s(:call, s(:params), :[], s(:lit, :stuff)))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :stuff))
+
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "ec196cf3f65f4d45b41345d19cdec2ced1420781bd379a5223b9fa9318bec3d4",
+      :warning_type => "SQL Injection",
+      :line => 81,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/controllers/friendly_controller.rb",
+      :code => s(:call, s(:const, :User), :where, s(:hash, s(:call, s(:params), :[], s(:lit, :key)), s(:call, s(:params), :[], s(:lit, :stuff)))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :key))
   end
  
   def test_format_validation_model_alias_processing


### PR DESCRIPTION
This has apparently been a bug since forever.

fixes #738