### PR TITLE
Avoid warning about model find/find_by* in hrefs

### DIFF
--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -55,7 +55,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
           :confidence => CONFIDENCE[:high],
           :link_path => "link_to_href"
       end
-    elsif has_immediate_model? url_arg
+    elsif has_immediate_model? url_arg or model_find_call? url_arg
 
       # Decided NOT warn on models.  polymorphic_path is called it a model is 
       # passed to link_to (which passes it to url_for)
@@ -104,5 +104,12 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     @ignore_methods.include? method or
       method.to_s =~ /_path$/ or
       (target.nil? and method.to_s =~ /_url$/)
+  end
+
+  def model_find_call? exp
+    return unless call? exp
+
+    MODEL_METHODS.include? exp.method or
+      exp.method.to_s =~ /^find_by_/
   end
 end

--- a/test/apps/rails4/app/views/another/various_xss.html.erb
+++ b/test/apps/rails4/app/views/another/various_xss.html.erb
@@ -6,3 +6,5 @@
 <% form_for Thing.first do |t| %>
   <%== t.select(things, Thing.new(params[:t]).stuff) %>
 <% end %>
+
+<%= link_to 'Bars', current_user.bars.find(params[:id]) %> Don't warn

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -766,6 +766,19 @@ class Rails4Tests < Test::Unit::TestCase
       :user_input => s(:call, nil, :params)
   end
 
+  def test_xss_no_warning_on_model_finds_in_href
+    assert_no_warning :type => :template,
+      :warning_code => 4,
+      :fingerprint => "ada8501c6761c382f47b0ecd03d653059f16aabd7ef1588900a916ae6fd877ef",
+      :warning_type => "Cross Site Scripting",
+      :line => 18,
+      :message => /^Unsafe\ parameter\ value\ in\ link_to\ href/,
+      :confidence => 1,
+      :relative_path => "app/views/users/index.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, "Bars"), s(:call, s(:call, s(:call, nil, :current_user), :bars), :find, s(:call, s(:call, nil, :params), :[], s(:lit, :id)))),
+      :user_input => s(:call, nil, :params)
+  end
+
   def test_cross_site_scripting_haml_interpolation
     assert_warning :type => :template,
       :warning_code => 2,

--- a/test/tests/rescanner.rb
+++ b/test/tests/rescanner.rb
@@ -177,7 +177,7 @@ class RescannerTests < Test::Unit::TestCase
 
       assert_reindex :controllers, :models, :templates
       assert_changes
-      assert_new 7 #User is no longer a model, causing MORE warnings
+      assert_new 6 #User is no longer a model, causing MORE warnings
       assert_fixed 8
     end
 


### PR DESCRIPTION
even if it's not obvious it's a model.