### PR TITLE
Add missing link path for dangerous evaluation

### DIFF
--- a/lib/brakeman/checks/check_evaluation.rb
+++ b/lib/brakeman/checks/check_evaluation.rb
@@ -30,7 +30,8 @@ class Brakeman::CheckEvaluation < Brakeman::BaseCheck
         :message => "User input in eval",
         :code => result[:call],
         :user_input => input,
-        :confidence => CONFIDENCE[:high]
+        :confidence => CONFIDENCE[:high],
+        :link_path => "dangerous_evaluation"
     end
   end
 end


### PR DESCRIPTION
When Brakeman reports a dangerous evaluation it links to:

http://brakemanscanner.org/docs/warning_types/dangerous_eval/

Instead of:

http://brakemanscanner.org/docs/warning_types/dangerous_evaluation/

This adds the `link_path` option to the dangerous evaluation check to
link to the correct url.