### PR TITLE
Inline render fixes

### DIFF
--- a/lib/brakeman/checks/check_render_inline.rb
+++ b/lib/brakeman/checks/check_render_inline.rb
@@ -27,14 +27,14 @@ class Brakeman::CheckRenderInline < Brakeman::CheckCrossSiteScripting
           :warning_type => "Cross Site Scripting",
           :warning_code => :cross_site_scripting_inline,
           :message => "Unescaped #{friendly_type_of input} rendered inline",
-          :code => input.match,
+          :user_input => input,
           :confidence => CONFIDENCE[:high]
       elsif input = has_immediate_model?(render_value)
         warn :result => result,
           :warning_type => "Cross Site Scripting",
           :warning_code => :cross_site_scripting_inline,
           :message => "Unescaped model attribute rendered inline",
-          :code => input,
+          :user_input => input,
           :confidence => CONFIDENCE[:med]
       end
     end

--- a/lib/brakeman/checks/check_render_inline.rb
+++ b/lib/brakeman/checks/check_render_inline.rb
@@ -20,23 +20,35 @@ class Brakeman::CheckRenderInline < Brakeman::CheckCrossSiteScripting
     if node_type? call, :render and
       (call.render_type == :text or call.render_type == :inline)
 
-      render_value = call[2]
+      unless call.render_type == :text and content_type_set? call[3]
+        render_value = call[2]
 
-      if input = has_immediate_user_input?(render_value)
-        warn :result => result,
-          :warning_type => "Cross Site Scripting",
-          :warning_code => :cross_site_scripting_inline,
-          :message => "Unescaped #{friendly_type_of input} rendered inline",
-          :user_input => input,
-          :confidence => CONFIDENCE[:high]
-      elsif input = has_immediate_model?(render_value)
-        warn :result => result,
-          :warning_type => "Cross Site Scripting",
-          :warning_code => :cross_site_scripting_inline,
-          :message => "Unescaped model attribute rendered inline",
-          :user_input => input,
-          :confidence => CONFIDENCE[:med]
+        if input = has_immediate_user_input?(render_value)
+          warn :result => result,
+            :warning_type => "Cross Site Scripting",
+            :warning_code => :cross_site_scripting_inline,
+            :message => "Unescaped #{friendly_type_of input} rendered inline",
+            :user_input => input,
+            :confidence => CONFIDENCE[:high]
+        elsif input = has_immediate_model?(render_value)
+          warn :result => result,
+            :warning_type => "Cross Site Scripting",
+            :warning_code => :cross_site_scripting_inline,
+            :message => "Unescaped model attribute rendered inline",
+            :user_input => input,
+            :confidence => CONFIDENCE[:med]
+        end
       end
+    end
+  end
+
+  CONTENT_TYPES = ["text/html", "text/javascript", "application/javascript"]
+
+  def content_type_set? opts
+    if hash? opts
+      content_type = hash_access(opts, :content_type)
+
+      string? content_type and not CONTENT_TYPES.include? content_type.value
     end
   end
 end

--- a/test/apps/rails4/app/controllers/another_controller.rb
+++ b/test/apps/rails4/app/controllers/another_controller.rb
@@ -29,9 +29,9 @@ class AnotherController < ApplicationController
     render :inline => "<%= #{params[:name]} %>"
     render :inline => "<%= #{user_name} %>"
 
-    # should not warn
-    render :text => CGI.escapeHTML(params[:q])
-    render :text => "Welcome back, #{CGI::escapeHTML(params[:name])}!}"
+    render :text => CGI.escapeHTML(params[:q]) # should not warn
+    render :text => "Welcome back, #{CGI::escapeHTML(params[:name])}!}" # should not warn
+    render :text => params[:q], :content_type => "text/plain" # should not warn
   end
 
   def use_params_in_regex

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -623,65 +623,71 @@ class Rails4Tests < Test::Unit::TestCase
   def test_cross_site_scripting_render_text
     assert_warning :type => :warning,
       :warning_code => 84,
-      :fingerprint => "9e40043f992762c78415ef06c2b50916d6f16112759fb2762b9a781e09d651e0",
+      :fingerprint => "a0b38ce5204afaaddfb5ba121d286bade5fe56cacbae1eb6c6e08482729638dd",
       :warning_type => "Cross Site Scripting",
       :line => 24,
-      :message => /^Unescaped\ parameter\ value/,
+      :message => /^Unescaped\ parameter\ value\ rendered\ inlin/,
       :confidence => 0,
       :relative_path => "app/controllers/another_controller.rb",
-      :user_input => nil
+      :code => s(:render, :text, s(:dstr, "Welcome back, ", s(:evstr, s(:call, s(:params), :[], s(:lit, :name))), s(:str, "!}")), s(:hash)),
+      :user_input => s(:call, s(:params), :[], s(:lit, :name))
 
     assert_warning :type => :warning,
       :warning_code => 84,
-      :fingerprint => "e8ab2a0727aec11bd56cdac0fa0e9f340e2d739fd964f0d9fe044f0707544bf0",
+      :fingerprint => "a8bac3d3d75f55126b8331b0c843c8e02154ebe61b1e7e88443c85c4c67c501e",
       :warning_type => "Cross Site Scripting",
       :line => 25,
-      :message => /^Unescaped\ model\ attribute/,
+      :message => /^Unescaped\ model\ attribute\ rendered\ inlin/,
       :confidence => 1,
       :relative_path => "app/controllers/another_controller.rb",
-      :user_input => nil
+      :code => s(:render, :text, s(:dstr, "Welcome back, ", s(:evstr, s(:call, s(:call, s(:const, :User), :current_user), :name)), s(:str, "!}")), s(:hash)),
+      :user_input => s(:call, s(:call, s(:const, :User), :current_user), :name)
 
     assert_warning :type => :warning,
       :warning_code => 84,
-      :fingerprint => "44697e7dc6c955c6bd7747c31f3c7617c0da3dcdb9bdae0963b62cbc4462e39f",
+      :fingerprint => "74de1c04495b3d230bc81868e420d2c6ca121a5cd6a721d2189ba81f4862010a",
       :warning_type => "Cross Site Scripting",
       :line => 26,
-      :message => /^Unescaped\ parameter\ value/,
+      :message => /^Unescaped\ parameter\ value\ rendered\ inlin/,
       :confidence => 0,
       :relative_path => "app/controllers/another_controller.rb",
-      :user_input => nil
+      :code => s(:render, :text, s(:call, s(:params), :[], s(:lit, :q)), s(:hash)),
+      :user_input => s(:call, s(:params), :[], s(:lit, :q))
 
     assert_warning :type => :warning,
       :warning_code => 84,
-      :fingerprint => "e8ab2a0727aec11bd56cdac0fa0e9f340e2d739fd964f0d9fe044f0707544bf0",
+      :fingerprint => "9f96bf32a7fa73d2ba20e1b838bfa133a94c3b7029d9aadf5b813c25e49a031f",
       :warning_type => "Cross Site Scripting",
       :line => 27,
-      :message => /^Unescaped\ model\ attribute/,
+      :message => /^Unescaped\ model\ attribute\ rendered\ inlin/,
       :confidence => 1,
       :relative_path => "app/controllers/another_controller.rb",
-      :user_input => nil
+      :code => s(:render, :text, s(:call, s(:call, s(:const, :User), :current_user), :name), s(:hash)),
+      :user_input => s(:call, s(:call, s(:const, :User), :current_user), :name)
   end
 
   def test_cross_site_scripting_render_inline
     assert_warning :type => :warning,
       :warning_code => 84,
-      :fingerprint => "9e40043f992762c78415ef06c2b50916d6f16112759fb2762b9a781e09d651e0",
+      :fingerprint => "1cfc027040376a06bd45ee3ce473dcd36adfa54e052d08651098d1c1e09bacec",
       :warning_type => "Cross Site Scripting",
       :line => 29,
-      :message => /^Unescaped\ parameter\ value/,
+      :message => /^Unescaped\ parameter\ value\ rendered\ inlin/,
       :confidence => 0,
       :relative_path => "app/controllers/another_controller.rb",
-      :user_input => nil
+      :code => s(:render, :inline, s(:dstr, "<%= ", s(:evstr, s(:call, s(:params), :[], s(:lit, :name))), s(:str, " %>")), s(:hash)),
+      :user_input => s(:call, s(:params), :[], s(:lit, :name))
 
     assert_warning :type => :warning,
       :warning_code => 84,
-      :fingerprint => "e8ab2a0727aec11bd56cdac0fa0e9f340e2d739fd964f0d9fe044f0707544bf0",
+      :fingerprint => "89c00a5b4a816c6cf0c4cd2618f1a76411c3fc55460bf9069bb7ca12abb75f75",
       :warning_type => "Cross Site Scripting",
       :line => 30,
-      :message => /^Unescaped\ model\ attribute/,
+      :message => /^Unescaped\ model\ attribute\ rendered\ inlin/,
       :confidence => 1,
       :relative_path => "app/controllers/another_controller.rb",
-      :user_input => nil
+      :code => s(:render, :inline, s(:dstr, "<%= ", s(:evstr, s(:call, s(:call, s(:const, :User), :current_user), :name)), s(:str, " %>")), s(:hash)),
+      :user_input => s(:call, s(:call, s(:const, :User), :current_user), :name)
   end
 
   def test_cross_site_scripting_with_double_equals


### PR DESCRIPTION
* Code should be the render call, not the dangerous value
* Do not warn if `:content_type` is set to something "safe"