### PR TITLE
Fix call index issues

### DIFF
--- a/lib/brakeman/checks/check_mass_assignment.rb
+++ b/lib/brakeman/checks/check_mass_assignment.rb
@@ -155,7 +155,7 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
   # Look for and warn about uses of Parameters#permit! for mass assignment
   def check_permit!
     tracker.find_call(:method => :permit!).each do |result|
-      if params? result[:target]
+      if params? result[:call].target
         warn_on_permit! result
       end
     end

--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -137,6 +137,8 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
         class_name exp
       when :self
         @current_class || @current_module || nil
+      when :params, :session, :cookies
+        exp.node_type
       else
         exp
       end

--- a/test/tests/call_index.rb
+++ b/test/tests/call_index.rb
@@ -13,7 +13,7 @@ class CallIndexTests < Test::Unit::TestCase
   end
 
   def assert_found num, opts
-    assert @call_index.find_calls(opts).length
+    assert_equal num, @call_index.find_calls(opts).length
   end
 
   def test_find_by_method_regex

--- a/test/tests/call_index.rb
+++ b/test/tests/call_index.rb
@@ -1,3 +1,5 @@
+require 'brakeman/processors/lib/find_all_calls'
+
 class CallIndexTests < Test::Unit::TestCase
   def setup
     @calls = [
@@ -9,6 +11,17 @@ class CallIndexTests < Test::Unit::TestCase
       {:method => :do_it, :target => nil, :call => {}, :nested => false  },
       {:method => :do_it_now, :target => nil, :call => {}, :nested => false  },
     ]
+
+    src = Brakeman::AliasProcessor.new.process RubyParser.new.parse <<-RUBY
+      def x
+        x.y.z(1)
+        params[:x].y.z(2)
+      end
+    RUBY
+    all_calls = Brakeman::FindAllCalls.new(Object.new)
+    all_calls.process(src)
+    @calls += all_calls.calls
+
     @call_index = Brakeman::CallIndex.new(@calls)
   end
 
@@ -54,5 +67,15 @@ class CallIndexTests < Test::Unit::TestCase
 
   def test_find_by_no_target_and_methods
     assert_found 2, :target => nil, :method => [:do_it, :do_it_now]
+  end
+
+  def test_find_by_target_and_method_in_chain
+    assert_found 0, :target => :x, :method => :z
+    assert_found 1, :target => :x, :method => :z, :chained => true
+  end
+
+  def test_find_params_and_method_in_chain
+    assert_found 0, :target => :params, :method => :z
+    assert_found 1, :target => :params, :method => :z, :chained => true
   end
 end

--- a/test/tests/call_index.rb
+++ b/test/tests/call_index.rb
@@ -1,13 +1,13 @@
 class CallIndexTests < Test::Unit::TestCase
   def setup
     @calls = [
-      {:method => :hello, :target => :world, :call => {} },
-      {:method => :goodbye, :target => :world, :call => {} },
-      {:method => :foo, :target => :world, :call => {} },
-      {:method => :foo, :target => :the_bar, :call => {} },
-      {:method => :foo, :target => :the_baz, :call => {} },
-      {:method => :do_it, :target => nil, :call => {} },
-      {:method => :do_it_now, :target => nil, :call => {} },
+      {:method => :hello, :target => :world, :call => {}, :nested => false },
+      {:method => :goodbye, :target => :world, :call => {}, :nested => false  },
+      {:method => :foo, :target => :world, :call => {}, :nested => false  },
+      {:method => :foo, :target => :the_bar, :call => {}, :nested => false  },
+      {:method => :foo, :target => :the_baz, :call => {}, :nested => false  },
+      {:method => :do_it, :target => nil, :call => {}, :nested => false  },
+      {:method => :do_it_now, :target => nil, :call => {}, :nested => false  },
     ]
     @call_index = Brakeman::CallIndex.new(@calls)
   end


### PR DESCRIPTION
* Handle searches for chained `params` calls (like matching `params` and `z` to `params[:x].y.z`).
* Make it easier to search for nested calls (e.g. looking for `x.y` and allowing it to match `x.y.z`.
* Fix `CallIndex` tests which were completely broken in at least two ways.