### PR TITLE
Load options including config_file options

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -42,6 +42,8 @@ unless options[:app_path]
   end
 end
 
+options = Brakeman.default_options.merge(Brakeman.load_options(options)).merge(options)
+
 trap("INT") do
   $stderr.puts "\nInterrupted - exiting."
 


### PR DESCRIPTION
An example fix for Issue: https://github.com/presidentbeef/brakeman/issues/770

Previously, the config_file options were not being loaded inside the
bin/brakeman context.

This is probably not as clean as it could be - but demonstrates a fix to the issue.