### PR TITLE
Emit brakeman's native fingerprints for Code Climate engine.

### DIFF
--- a/lib/brakeman/report/report_codeclimate.rb
+++ b/lib/brakeman/report/report_codeclimate.rb
@@ -19,6 +19,7 @@ class Brakeman::Report::CodeClimate < Brakeman::Report::Base
       type: "Issue",
       check_name: warning_code_name,
       description: warning.message,
+      fingerprint: warning.fingerprint,
       categories: ["Security"],
       severity: severity_level_for(warning.confidence),
       remediation_points: remediation_points_for(warning_code_name),

--- a/test/tests/codeclimate_output.rb
+++ b/test/tests/codeclimate_output.rb
@@ -5,8 +5,8 @@ class TestCodeClimateOutput < Test::Unit::TestCase
   end
 
   def test_for_expected_keys
-    expected = ["type", "check_name", "description", "categories", "severity",
-                "remediation_points", "location", "content"]
+    expected = ["type", "check_name", "description", "fingerprint", "categories",
+                "severity", "remediation_points", "location", "content"]
 
     @@issues.each do |issue|
       assert (issue.keys - expected).empty?


### PR DESCRIPTION
Code Climate has fallback fingerprints for issues emitted by engines,
but it's much preferable to use the fingerprints that brakeman
itself creates. The fingerprints take into account a lot more
criteria, are maintained and may be already used by customers
in their brakeman.ignore file.

/c @codeclimate/review