### PR TITLE
Handle module names properly on defs

### DIFF
--- a/lib/brakeman/processors/controller_processor.rb
+++ b/lib/brakeman/processors/controller_processor.rb
@@ -208,11 +208,11 @@ class Brakeman::ControllerProcessor < Brakeman::BaseProcessor
   def process_defs exp
     name = exp.method_name
 
-    if exp[1].node_type == :self
+    if node_type? exp[1], :self
       if @current_class
         target = @current_class.name
       elsif @current_module
-        target = @current_module
+        target = @current_module.name
       else
         target = nil
       end

--- a/lib/brakeman/processors/model_processor.rb
+++ b/lib/brakeman/processors/model_processor.rb
@@ -163,11 +163,11 @@ class Brakeman::ModelProcessor < Brakeman::BaseProcessor
     return exp unless @current_class
     name = exp.method_name
 
-    if exp[1].node_type == :self
+    if node_type? exp[1], :self
       if @current_class
         target = @current_class.name
       elsif @current_module
-        target = @current_module
+        target = @current_module.name
       else
         target = nil
       end

--- a/test/apps/rails4/app/controllers/mixed_controller.rb
+++ b/test/apps/rails4/app/controllers/mixed_controller.rb
@@ -1,0 +1,3 @@
+class MixedController < ApplicationController
+    include ProxyThing::Proxied
+end

--- a/test/apps/rails4/app/controllers/mixed_in_proxy.rb
+++ b/test/apps/rails4/app/controllers/mixed_in_proxy.rb
@@ -1,0 +1,8 @@
+module ProxyThing
+  class X; end
+
+  module Proxied
+    def self.included(controller)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #785.

We really shouldn't be setting the method target to a symbol anyway, it should be an `Sexp` to match normal RubyParser output.