### PR TITLE
Avoiding warning about `params.permit` in SQL

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -264,8 +264,10 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     end
 
     if request_value? arg
-      # Model.where(params[:where])
-      arg
+      unless call? arg and params? arg.target and arg.method == :permit
+        # Model.where(params[:where])
+        arg
+      end
     elsif hash? arg
       #This is generally going to be a hash of column names and values, which
       #would escape the values. But the keys _could_ be user input.

--- a/test/apps/rails4/app/controllers/users_controller.rb
+++ b/test/apps/rails4/app/controllers/users_controller.rb
@@ -114,4 +114,10 @@ class UsersController < ApplicationController
   def without
     User.new({username: "jjconti", admin: false}, without_protection: true)
   end
+
+  def permit_in_sql
+    User.find_by(params.permit(:OMG)) # Don't warn
+    User.find_by(params.permit(:OMG)[:OMG]) # Warn
+    User.where("#{params.permit(:OMG)}") # Warn
+  end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 2,
       :template => 8,
-      :generic => 75
+      :generic => 77
     }
   end
 
@@ -977,6 +977,41 @@ class Rails4Tests < Test::Unit::TestCase
       :relative_path => "app/controllers/friendly_controller.rb",
       :code => s(:call, s(:const, :User), :where, s(:hash, s(:call, s(:params), :[], s(:lit, :key)), s(:call, s(:params), :[], s(:lit, :stuff)))),
       :user_input => s(:call, s(:params), :[], s(:lit, :key))
+  end
+
+  def test_sql_injection_with_permit
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "195c3ab08dd4b4f11a29afabb704cefe1d8987a9a7690e7c8299900c9e888a94",
+      :warning_type => "SQL Injection",
+      :line => 119,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :code => s(:call, s(:const, :User), :find_by, s(:call, s(:params), :permit, s(:lit, :OMG))),
+      :user_input => s(:call, s(:params), :permit, s(:lit, :OMG))
+
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "1f92b0ca5290f5c4de78cfa33a72c2f845604062fa0d5c31f1800111cf191f36",
+      :warning_type => "SQL Injection",
+      :line => 120,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :code => s(:call, s(:const, :User), :find_by, s(:call, s(:call, s(:params), :permit, s(:lit, :OMG)), :[], s(:lit, :OMG))),
+      :user_input => s(:call, s(:call, s(:params), :permit, s(:lit, :OMG)), :[], s(:lit, :OMG))
+
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "420d307a7e184dab8298c445acbf12df7cd106d38bc60886d9e2583972f3a6f5",
+      :warning_type => "SQL Injection",
+      :line => 121,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :code => s(:call, s(:const, :User), :where, s(:dstr, "", s(:evstr, s(:call, s(:params), :permit, s(:lit, :OMG))))),
+      :user_input => s(:call, s(:params), :permit, s(:lit, :OMG))
   end
  
   def test_format_validation_model_alias_processing


### PR DESCRIPTION
Fixes #669 

Should still warn if values are pulled out of the params hash.