### PR TITLE
Add check for MySQL integer issue in dynamic finders

### DIFF
--- a/lib/brakeman/checks/check_dynamic_finders.rb
+++ b/lib/brakeman/checks/check_dynamic_finders.rb
@@ -1,0 +1,49 @@
+require 'brakeman/checks/base_check'
+
+#This check looks for regexes that include user input.
+class Brakeman::CheckDynamicFinders < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = "Check unsafe usage of find_by_*"
+
+  def run_check
+    if tracker.config.has_gem? :mysql and version_between? '2.0.0', '4.1.99'
+      tracker.find_call(:method => /^find_by_/).each do |result|
+        process_result result
+      end
+    end
+  end
+
+  def process_result result
+    return if duplicate? result or result[:call].original_line
+    add_result result
+
+    call = result[:call]
+
+    if potentially_dangerous? call.method
+      call.each_arg do |arg|
+        if params? arg and not safe_call? arg
+          warn :result => result,
+            :warning_type => "SQL Injection",
+            :warning_code => :sql_injection_dynamic_finder,
+            :message => "MySQL integer conversion may cause 0 to match any string",
+            :confidence => CONFIDENCE[:med],
+            :user_input => arg
+
+          break
+        end
+      end
+    end
+  end
+
+  def safe_call? arg
+    return false unless call? arg
+
+    meth = arg.method
+    meth == :to_s or meth == :to_i
+  end
+
+  def potentially_dangerous? method_name
+    method_name.match /^find_by_.*(token|guid|password|api_key|activation|code|private|reset)/
+  end
+end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -93,6 +93,7 @@ module Brakeman::WarningCodes
     :session_key_manipulation => 89,
     :weak_hash_digest => 90,
     :weak_hash_hmac => 91,
+    :sql_injection_dynamic_finder => 92,
   }
 
   def self.code name

--- a/test/apps/rails3.1/Gemfile
+++ b/test/apps/rails3.1/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '3.1.0'
 # Bundle edge Rails instead:
 # gem 'rails',     :git => 'git://github.com/rails/rails.git'
 
-gem 'sqlite3'
+gem 'mysql'
 
 gem 'json'
 

--- a/test/apps/rails3.1/Gemfile.lock
+++ b/test/apps/rails3.1/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       hike (~> 1.2)
       rack (~> 1.0)
       tilt (!= 1.3.0, ~> 1.1)
-    sqlite3 (1.3.4)
+    mysql (2.9.1)
     therubyracer (0.9.4)
       libv8 (~> 3.3.10)
     thor (0.14.6)
@@ -114,6 +114,6 @@ DEPENDENCIES
   json
   rails (= 3.1.0)
   sass-rails (~> 3.1.0)
-  sqlite3
+  mysql
   therubyracer
   uglifier

--- a/test/apps/rails3.1/app/controllers/users_controller.rb
+++ b/test/apps/rails3.1/app/controllers/users_controller.rb
@@ -192,4 +192,10 @@ class UsersController < ApplicationController
   def mass_again
     User.new(stuff, :without_protection => true)
   end
+
+  def dynamic_finders
+    User.find_by_name_and_password(params[:name], params[:pass])
+    User.find_by_reset_code(params[:code])
+    Product.find_by_guid(params[:guid].to_s) # No warn
+  end
 end

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -13,7 +13,7 @@ class Rails31Tests < Test::Unit::TestCase
       :model => 3,
       :template => 23,
       :controller => 4,
-      :generic => 82 }
+      :generic => 84 }
   end
 
   def test_without_protection
@@ -1075,6 +1075,30 @@ class Rails31Tests < Test::Unit::TestCase
       :confidence => 1,
       :relative_path => "app/models/user.rb",
       :user_input => s(:call, nil, :table_name_prefix)
+  end
+
+  def test_sql_injection_dynamic_finders
+    assert_warning :type => :warning,
+      :warning_code => 92,
+      :fingerprint => "911d08b750e5c583e0c1fcfffc229f284d10d69a2bb2f78ac068ef44585f8ae1",
+      :warning_type => "SQL Injection",
+      :line => 197,
+      :message => /^MySQL\ integer\ conversion\ may\ cause\ 0\ to\ /,
+      :confidence => 1,
+      :relative_path => "app/controllers/users_controller.rb",
+      :code => s(:call, s(:const, :User), :find_by_name_and_password, s(:call, s(:params), :[], s(:lit, :name)), s(:call, s(:params), :[], s(:lit, :pass))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :name))
+
+    assert_warning :type => :warning,
+      :warning_code => 92,
+      :fingerprint => "62dce25499ad7885cb6b838c44095707d045c40c474d09e862e82ba206f4837a",
+      :warning_type => "SQL Injection",
+      :line => 198,
+      :message => /^MySQL\ integer\ conversion\ may\ cause\ 0\ to\ /,
+      :confidence => 1,
+      :relative_path => "app/controllers/users_controller.rb",
+      :code => s(:call, s(:const, :User), :find_by_reset_code, s(:call, s(:params), :[], s(:lit, :code))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :code))
   end
 
   def test_validates_format


### PR DESCRIPTION
Per http://www.phenoelit.org/blog/archives/2013/02/05/mysql_madness_and_rails/

Looks for calls like

```ruby
User.find_by_token(params[:user][:token])
```

when app is using MySQL. Since not *all* `find_by_*` calls are bad, there is a short list of possibly dangerous names based on a survey of open source Rails apps.