### PR TITLE
Add check for CVE-2015-7576

### DIFF
--- a/lib/brakeman/checks/check_basic_auth_timing_attack.rb
+++ b/lib/brakeman/checks/check_basic_auth_timing_attack.rb
@@ -1,0 +1,54 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckBasicAuthTimingAttack < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = "Check for timing attack in basic auth (CVE-2015-7576)"
+
+  def run_check
+    @upgrade = case
+               when version_between?("0.0.0", "3.2.22")
+                 "3.2.22.1"
+               when version_between?("4.0.0", "4.1.14")
+                 "4.1.14.1"
+               when version_between?("4.2.0", "4.2.5")
+                 "4.2.5.1"
+               else
+                 return
+               end
+
+    check_basic_auth_filter
+    check_basic_auth_call
+  end
+
+  def check_basic_auth_filter
+    controllers = tracker.controllers.select do |name, c|
+      c.options[:http_basic_authenticate_with]
+    end
+
+    Hash[controllers].each do |name, controller|
+      controller.options[:http_basic_authenticate_with].each do |call|
+        warn :controller => name,
+          :warning_type => "Timing Attack",
+          :warning_code => :CVE_2015_7576,
+          :message => "Basic authentication in Rails #{rails_version} is vulnerable to timing attacks. Upgrade to #@upgrade",
+          :code => call,
+          :confidence => CONFIDENCE[:high],
+          :file => controller.file,
+          :link => "https://groups.google.com/d/msg/rubyonrails-security/ANv0HDHEC3k/mt7wNGxbFQAJ"
+      end
+    end
+  end
+
+  def check_basic_auth_call
+    # This is relatively unusual, but found in the wild
+    tracker.find_call(target: nil, method: :http_basic_authenticate_with).each do |result|
+      warn :result => result,
+        :warning_type => "Timing Attack",
+        :warning_code => :CVE_2015_7576,
+        :message => "Basic authentication in Rails #{rails_version} is vulnerable to timing attacks. Upgrade to #@upgrade",
+        :confidence => CONFIDENCE[:high],
+        :link => "https://groups.google.com/d/msg/rubyonrails-security/ANv0HDHEC3k/mt7wNGxbFQAJ"
+    end
+  end
+end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -94,6 +94,7 @@ module Brakeman::WarningCodes
     :weak_hash_digest => 90,
     :weak_hash_hmac => 91,
     :sql_injection_dynamic_finder => 92,
+    :CVE_2015_7576 => 93,
   }
 
   def self.code name

--- a/test/tests/cves.rb
+++ b/test/tests/cves.rb
@@ -171,4 +171,14 @@ class CVETests < Test::Unit::TestCase
     assert_new 0
     assert_fixed 1
   end
+
+  def test_CVE_2015_7576
+    before_rescan_of "Gemfile.lock", "rails3.1" do
+      replace "Gemfile.lock", " rails (3.1.0)", " rails (3.2.22.1)"
+    end
+
+    assert_new 0
+    assert_version "3.2.22.1"
+    assert_no_warning type: :controller, :warning_code => 93
+  end
 end

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -12,7 +12,7 @@ class Rails31Tests < Test::Unit::TestCase
     @expected ||= {
       :model => 3,
       :template => 23,
-      :controller => 4,
+      :controller => 5,
       :generic => 84 }
   end
 
@@ -903,6 +903,19 @@ class Rails31Tests < Test::Unit::TestCase
       :message => /^Rails\ 3\.1\.0\ is\ vulnerable\ to\ denial\ of\ s/,
       :confidence => 1,
       :relative_path => "Gemfile.lock",
+      :user_input => nil
+  end
+
+  def test_basic_auth_CVE_2015_7576
+    assert_warning :type => :controller,
+      :warning_code => 93,
+      :fingerprint => "331d393d362efd9c1e65526886afdbcc0ffca838e3ad00d5a9920e8920f2a7d7",
+      :warning_type => "Timing Attack",
+      :line => 4,
+      :message => /^Basic\ authentication\ in\ Rails\ 3\.1\.0\ is\ v/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :code => s(:call, nil, :http_basic_authenticate_with, s(:hash, s(:lit, :name), s(:str, "superduperadmin"), s(:lit, :password), s(:str, "superdupersecret"), s(:lit, :only), s(:lit, :create))),
       :user_input => nil
   end
 


### PR DESCRIPTION
Timing attacks when using basic auth.

Should extend this to include password checks with `==` in the future.