### PR TITLE
Fix CodeClimate include_paths behavior

### DIFF
--- a/bin/codeclimate-brakeman
+++ b/bin/codeclimate-brakeman
@@ -12,10 +12,6 @@ end
 command = "/usr/src/app/bin/brakeman --quiet --format codeclimate"
 
 if engine_config["include_paths"]
-  engine_config["include_paths"].each do |path|
-    path.chop! while path[-1] == "/"
-  end
-
   command += " --only-files " + engine_config["include_paths"].join(",")
 end
 


### PR DESCRIPTION
The chopping we did on these paths was leading to unexpected results against master. Probably related to changes in 656db4bbdb7fd7: since we always add `/` to the end of directories when we construct `include_paths` before we run the engine, we can now pass through `include_paths` from `/config.json` effectively unmodified.