### PR TITLE
Fix CodeClimate construction of --only-files

### DIFF
--- a/bin/codeclimate-brakeman
+++ b/bin/codeclimate-brakeman
@@ -2,6 +2,7 @@
 $:.unshift "#{File.expand_path(File.dirname(__FILE__))}/../lib"
 
 require "json"
+require "shellwords"
 
 if File.exist?("/config.json")
   engine_config = JSON.parse(File.read("/config.json"))
@@ -16,7 +17,7 @@ if engine_config["include_paths"]
     path.chop! while path[-1] == "/"
   end
 
-  command += " --only-files " + engine_config["include_paths"].join(",")
+  command += " --only-files " + engine_config["include_paths"].join(",").shellescape
 end
 
 exec command


### PR DESCRIPTION
Our construction of this string was naive and didn't account for path
names that might contain characters like spaces. This would result in
`bin/brakeman` getting arguments that would be parsed as pointing at an
invalid app root.

Shell-escaping the entire string of paths avoids this.