### PR TITLE
Add check for CVE-2016-0752

### DIFF
--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -100,6 +100,7 @@ module Brakeman::WarningCodes
     :CVE_2015_7578 => 96,
     :CVE_2015_7580 => 97,
     :CVE_2015_7579 => 98,
+    :dynamic_render_path_rce => 99,
   }
 
   def self.code name

--- a/test/tests/cves.rb
+++ b/test/tests/cves.rb
@@ -197,7 +197,7 @@ class CVETests < Test::Unit::TestCase
       replace "Gemfile", "rails', '4.0.0'", "rails', '4.2.5.1'"
     end
 
-    assert_new 0
+    assert_new 2 # RCE to Dynamic renders, unrelated
     assert_version "4.2.5.1"
     assert_no_warning type: :model, :warning_code => 95
   end

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -145,12 +145,15 @@ class Rails2Tests < Test::Unit::TestCase
 
   def test_dynamic_render_path_high_confidence
     assert_warning :type => :warning,
-      :warning_type => "Dynamic Render Path",
+      :warning_code => 99,
+      :fingerprint => "556d3b084d138ff8df7be13e71609b3d86a15f587fd0fc4c82dadffae7709c6e",
+      :warning_type => "Remote Code Execution",
       :line => 77,
-      :message => /^Render path contains parameter value near line 77: render/,
+      :message => /^Passing\ query\ parameters\ to\ render/,
       :confidence => 0,
-      :file => /home_controller\.rb/,
-      :relative_path => "app/controllers/home_controller.rb"
+      :relative_path => "app/controllers/home_controller.rb",
+      :code => s(:render, :action, s(:call, s(:params), :[], s(:lit, :action)), s(:hash)),
+      :user_input => s(:call, s(:params), :[], s(:lit, :action))
   end
 
   def test_file_access

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -356,25 +356,27 @@ class Rails4Tests < Test::Unit::TestCase
 
   def test_dynamic_render_path_with_before_action
     assert_warning :type => :warning,
-      :warning_code => 15,
-      :fingerprint => "5b2267a68b4bfada283b59bdb9f453489111a5f2c335737588f88135d99426fa",
-      :warning_type => "Dynamic Render Path",
+      :warning_code => 99,
+      :fingerprint => "4b5d8c35b22fbdfbfabfd07343c8466ec941d5b78afbd574cf6ce76c68080c85",
+      :warning_type => "Remote Code Execution",
       :line => 14,
-      :message => /^Render\ path\ contains\ parameter\ value/,
+      :message => /^Passing\ query\ parameters\ to\ render/,
       :confidence => 0,
       :relative_path => "app/controllers/users_controller.rb",
+      :code => s(:render, :action, s(:call, s(:params), :[], s(:lit, :page)), s(:hash)),
       :user_input => s(:call, s(:params), :[], s(:lit, :page))
   end
 
   def test_dynamic_render_path_with_prepend_before_action
     assert_warning :type => :warning,
-      :warning_code => 15,
-      :fingerprint => "fa1ad77b62059d1aeeb48217a94cc03a0109b1f17d8332c0e3a5718360de9a8c",
-      :warning_type => "Dynamic Render Path",
+      :warning_code => 99,
+      :fingerprint => "dd7110db0e7948d5e7047029e73ad570435e62e3ef8f3091eef57e15a11b6654",
+      :warning_type => "Remote Code Execution",
       :line => 19,
-      :message => /^Render\ path\ contains\ parameter\ value/,
+      :message => /^Passing\ query\ parameters\ to\ render/,
       :confidence => 0,
       :relative_path => "app/controllers/users_controller.rb",
+      :code => s(:render, :action, s(:call, s(:params), :[], s(:lit, :page)), s(:hash)),
       :user_input => s(:call, s(:params), :[], s(:lit, :page))
   end
 


### PR DESCRIPTION
Change dynamic render path warnings with just `params` to RCE instead for affected versions.