### PR TITLE
Fix finding calls with :targets => nil

### DIFF
--- a/lib/brakeman/call_index.rb
+++ b/lib/brakeman/call_index.rb
@@ -45,7 +45,7 @@ class Brakeman::CallIndex
 
     #Find calls with no explicit target
     #with either :target => nil or :target => false
-    elsif options.key? :target and not target and method
+    elsif (options.key? :target or options.key? :targets) and not target and method
       calls = calls_by_method method
       calls = filter_by_target calls, nil
 

--- a/test/tests/call_index.rb
+++ b/test/tests/call_index.rb
@@ -10,6 +10,7 @@ class CallIndexTests < Test::Unit::TestCase
       {:method => :foo, :target => :the_baz, :call => {}, :nested => false  },
       {:method => :do_it, :target => nil, :call => {}, :nested => false  },
       {:method => :do_it_now, :target => nil, :call => {}, :nested => false  },
+      {:method => :with_target, :target => :blah, :call => {}, :nested => false  },
     ]
 
     meth_src = Brakeman::AliasProcessor.new.process RubyParser.new.parse <<-RUBY
@@ -75,6 +76,7 @@ class CallIndexTests < Test::Unit::TestCase
 
   def test_find_by_no_target_and_method
     assert_found 1, :target => nil, :method => :do_it
+    assert_found 0, :targets => nil, :method => :with_target
   end
 
   def test_find_by_no_target_and_methods


### PR DESCRIPTION
`:target` works just fine but not `:targets`. :dart: 