### PR TITLE
MultiJson is not a brakeman dependency

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,7 @@
 #Adjust path in case called directly and not through gem
 $:.unshift "#{File.expand_path(File.dirname(__FILE__))}/../lib"
 
+require 'json'
 require 'brakeman'
 require 'brakeman/options'
 require 'brakeman/version'
@@ -62,12 +63,12 @@ begin
 
     if options[:comparison_output_file]
       File.open options[:comparison_output_file], "w" do |f|
-        f.puts MultiJson.dump(vulns, :pretty => true)
+        f.puts Json.dump(vulns, :pretty => true)
       end
 
       Brakeman.notify "Comparison saved in '#{options[:comparison_output_file]}'"
     else
-      puts MultiJson.dump(vulns, :pretty => true)
+      puts Json.dump(vulns, :pretty => true)
     end
 
     if options[:exit_on_warn] && vulns[:new].count > 0


### PR DESCRIPTION
Using it in the `bin/brakeman` causes installs outside of the Gemfile to also install `multi_json`

It is a transient dependency of the test apps via JBuilder via Rails.

This is causing failures in https://travis-ci.org/rubygems/rubygems.org/builds/111655610

ref: https://github.com/rubygems/rubygems.org/pull/1201