### PR TITLE
Raise error in CallIndex#find_calls and fix option test

### DIFF
--- a/lib/brakeman/call_index.rb
+++ b/lib/brakeman/call_index.rb
@@ -53,7 +53,7 @@ class Brakeman::CallIndex
     elsif method
       calls = calls_by_method method
     else
-      notify "Invalid arguments to CallCache#find_calls: #{options.inspect}"
+      raise "Invalid arguments to CallCache#find_calls: #{options.inspect}"
     end
 
     return [] if calls.nil?

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -281,7 +281,7 @@ class ConfigTests < Test::Unit::TestCase
 
   def test_output_format_errors_raised
     options = {:output_format => :to_json, :output_files => ['xx.csv', 'xx.xxx']}
-    assert_raises("ArgumentError: Cannot specify output format if multiple output files specified") {Brakeman.get_output_formats(options)}
+    assert_raise(ArgumentError) { Brakeman.get_output_formats(options) }
   end
 
   def test_github_options_raises_error

--- a/test/tests/call_index.rb
+++ b/test/tests/call_index.rb
@@ -96,4 +96,10 @@ class CallIndexTests < Test::Unit::TestCase
   def test_find_class_scope_call_by_method
     assert_found 1, :method => :do_a_thing
   end
+
+  def test_find_error
+    assert_raise do
+      @call_index.find_calls :target => nil, :methods => nil
+    end
+  end
 end


### PR DESCRIPTION
If `CallIndex#find_calls` received invalid arguments, it would call `notify` which should have been `Brakeman.notify` but is probably better as a `raise`.

Also fixes test for argument error when passing in multiple `-o` arguments with `-f`