### PR TITLE
Remove nil entries from the Code Climate include_paths

### DIFF
--- a/bin/codeclimate-brakeman
+++ b/bin/codeclimate-brakeman
@@ -13,7 +13,7 @@ end
 command = "/usr/src/app/bin/brakeman --quiet --format codeclimate"
 
 if engine_config["include_paths"]
-  command += " --only-files " + engine_config["include_paths"].join(",").shellescape
+  command += " --only-files " + engine_config["include_paths"].compact.join(",").shellescape
 end
 
 exec command


### PR DESCRIPTION
These can cause the following error:

```
/usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/brakeman-3.2.1/lib/brakeman/app_tree.rb:35:in `block in regex_for_paths': undefined method `end_with?' for nil:NilClass (NoMethodError)
	from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/2.2.0/set.rb:283:in `each_key'
	from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/2.2.0/set.rb:283:in `each'
	from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/brakeman-3.2.1/lib/brakeman/app_tree.rb:32:in `map'
	from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/brakeman-3.2.1/lib/brakeman/app_tree.rb:32:in `regex_for_paths'
	from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/brakeman-3.2.1/lib/brakeman/app_tree.rb:19:in `from_options'
	from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/brakeman-3.2.1/lib/brakeman/scanner.rb:25:in `initialize'
	from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/brakeman-3.2.1/lib/brakeman.rb:332:in `new'
	from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/brakeman-3.2.1/lib/brakeman.rb:332:in `scan'
	from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/brakeman-3.2.1/lib/brakeman.rb:61:in `run'
	from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/brakeman-3.2.1/bin/brakeman:79:in `<top (required)>'
	from /usr/local/var/rbenv/versions/2.2.2/bin/brakeman:23:in `load'
	from /usr/local/var/rbenv/versions/2.2.2/bin/brakeman:23:in `<main>'
```

We shouldn't be passing nil paths into the scanner.