### PR TITLE
Don't try to output results to a specific file from CC binary

### DIFF
--- a/bin/codeclimate-brakeman
+++ b/bin/codeclimate-brakeman
@@ -10,7 +10,7 @@ else
   engine_config = {}
 end
 
-command = "/usr/src/app/bin/brakeman --quiet --format codeclimate"
+command = "/usr/src/app/bin/brakeman --quiet --format codeclimate --output /dev/stdout"
 
 if engine_config["include_paths"]
   command += " --only-files " + engine_config["include_paths"].compact.join(",").shellescape


### PR DESCRIPTION
These files are not writeable when running Brakeman as a Code Climate
Engine, nor will they be useful after analyzing the repo, so we force
writing to STDOUT.

@ABaldwinHunter @pbrisbin @jpignata @wfleming @dblandin 