### PR TITLE
Add `--no-output-files` option

### DIFF
--- a/bin/codeclimate-brakeman
+++ b/bin/codeclimate-brakeman
@@ -10,7 +10,7 @@ else
   engine_config = {}
 end
 
-command = "/usr/src/app/bin/brakeman --quiet --format codeclimate"
+command = "/usr/src/app/bin/brakeman --quiet --no-output-files --format codeclimate"
 
 if engine_config["include_paths"]
   command += " --only-files " + engine_config["include_paths"].compact.join(",").shellescape

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -211,8 +211,15 @@ module Brakeman::Options
         end
 
         opts.on "-o", "--output FILE", "Specify files for output. Defaults to stdout. Multiple '-o's allowed" do |file|
-          options[:output_files] ||= []
-          options[:output_files].push(file)
+          unless options[:no_output_files]
+            options[:output_files] ||= []
+            options[:output_files].push(file)
+          end
+        end
+
+        opts.on "--no-output-files", "Ignore any output files specified in config. Overrides any '-o' arguments" do
+          options[:no_output_files] = true
+          options[:output_files] = nil
         end
 
         opts.on "--[no-]separate-models", "Warn on each model without attr_accessible (Default)" do |separate|

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -252,6 +252,14 @@ class BrakemanOptionsTest < Test::Unit::TestCase
     assert_equal ["output1.rb,output2.rb"], options[:output_files]
   end
 
+  def test_no_output_files_option
+    options = setup_options_from_input("--no-output-files")
+    assert_equal nil, options[:output_files]
+
+    options = setup_options_from_input("--no-output-files", "--output", "output1.rb,output2.rb")
+    assert_equal nil, options[:output_files]
+  end
+
   def test_sperate_models_option
     options = setup_options_from_input("--separate-models")
     assert !options[:collapse_mass_assignment]


### PR DESCRIPTION
Permits a user to override output options in Brakeman config from command line, and run Brakeman without writing files to system.

This change lets Code Climate run with a line-item ignore of that part of a user's Brakeman config.

Authored with @gordondiggs