### PR TITLE
When possible, output to /dev/stdout

### DIFF
--- a/bin/codeclimate-brakeman
+++ b/bin/codeclimate-brakeman
@@ -13,7 +13,11 @@ end
 command = "/usr/src/app/bin/brakeman --quiet --format codeclimate"
 
 if engine_config["include_paths"]
-  command += " --only-files " + engine_config["include_paths"].compact.join(",").shellescape
+  command << " --only-files #{engine_config["include_paths"].compact.join(",").shellescape}"
+end
+
+if system("test -w /dev/stdout")
+  command << " --output /dev/stdout"
 end
 
 exec command


### PR DESCRIPTION
Older versions of docker have a bug where /dev/stdout is not accessible
by non-root users, but putting this behind a test call will allow us to
fix a bug where Brakeman configurations with output files would cause
the entire engine to error while also supporting older version of Docker
in other cases.

@presidentbeef this is where we landed on the fix for this - we decided that overhauling the whole engine to use Brakeman's classes is a good idea in the longterm, but we need to ship this fix sooner than we can allocate time for that