### PR TITLE
Vendor all dependencies when building gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 Gemfile.lock
-.rbx
-**/.rbx
 coverage/
 test/coverage/
 .bundle
+bundle

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec :name => "brakeman"
 
-gem "rake", "< 10.2.0"
-
-gem "codeclimate-test-reporter", group: :test, require: nil
+unless ENV['BM_PACKAGE']
+  gem "rake", "< 10.2.0"
+  gem "codeclimate-test-reporter", group: :test, require: nil
+end

--- a/brakeman.gemspec
+++ b/brakeman.gemspec
@@ -14,14 +14,19 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.cert_chain  = ['brakeman-public_cert.pem']
   s.signing_key = gem_priv_key if File.exist? gem_priv_key and $0 =~ /gem\z/
-  s.add_development_dependency "test-unit"
-  s.add_dependency "ruby_parser", "~>3.8.1"
-  s.add_dependency "ruby2ruby", "~>2.3.0"
-  s.add_dependency "terminal-table", "~>1.4"
-  s.add_dependency "highline", ">=1.6.20", "<2.0"
-  s.add_dependency "erubis", "~>2.6"
-  s.add_dependency "haml", ">=3.0", "<5.0"
-  s.add_dependency "sass", "~>3.0"
-  s.add_dependency "slim", ">=1.3.6", "<4.0"
-  s.add_dependency "safe_yaml", ">= 1.0"
+
+  if File.exist? 'bundle/load.rb'
+    s.files += Dir['bundle/ruby/*/gems/**/*'] + ['bundle/load.rb']
+  else
+    s.add_development_dependency "test-unit" unless ENV['BM_PACKAGE']
+    s.add_dependency "ruby_parser", "~>3.8.1"
+    s.add_dependency "ruby2ruby", "~>2.3.0"
+    s.add_dependency "terminal-table", "~>1.4"
+    s.add_dependency "highline", ">=1.6.20", "<2.0"
+    s.add_dependency "erubis", "~>2.6"
+    s.add_dependency "haml", ">=3.0", "<5.0"
+    s.add_dependency "sass", "~>3.0"
+    s.add_dependency "slim", ">=1.3.6", "<4.0"
+    s.add_dependency "safe_yaml", ">= 1.0"
+  end
 end

--- a/build.rb
+++ b/build.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+puts 'Packaging Brakeman gem...'
+
+system 'rm -rf bundle Gemfile.lock brakeman-*.gem' and
+system 'BM_PACKAGE=true bundle install --standalone'
+
+abort "No bundle installed" unless Dir.exist? 'bundle'
+
+File.delete "bundle/bundler/setup.rb"
+Dir.delete "bundle/bundler"
+
+File.open "bundle/load.rb", "w" do |f|
+  f.puts "path = File.expand_path('../..', __FILE__)"
+
+  Dir["bundle/ruby/**/lib"].each do |dir|
+    f.puts %Q[$:.unshift "\#{path}/#{dir}"]
+  end
+end
+
+system "BM_PACKAGE=true gem build brakeman.gemspec"

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -1,5 +1,10 @@
-require 'rubygems'
 require 'set'
+
+path_load = "#{File.expand_path(File.dirname(__FILE__))}/../bundle/load.rb"
+
+if File.exist? path_load
+  require path_load
+end
 
 module Brakeman
 


### PR DESCRIPTION
Avoid dependency problems when people put Brakeman in their Gemfiles or have `gem` problems.