### PR TITLE
Fix #840 Ensure sexp is not a multi-item sexp

### DIFF
--- a/lib/brakeman/checks/check_forgery_setting.rb
+++ b/lib/brakeman/checks/check_forgery_setting.rb
@@ -53,7 +53,7 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
     elsif version_between? "4.0.0", "100.0.0" and forgery_opts = app_controller.options[:protect_from_forgery]
 
       unless forgery_opts.is_a?(Array) and sexp?(forgery_opts.first) and
-          access_arg = hash_access(forgery_opts.first.first_arg, :with) and access_arg.size == 1 and
+          access_arg = hash_access(forgery_opts.first.first_arg, :with) and symbol? access_arg and
           access_arg.value == :exception
 
         args = {

--- a/lib/brakeman/checks/check_forgery_setting.rb
+++ b/lib/brakeman/checks/check_forgery_setting.rb
@@ -13,7 +13,7 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
     app_controller = tracker.controllers[:ApplicationController]
     return unless app_controller and app_controller.ancestor? :"ActionController::Base"
 
-    if tracker.config.allow_forgery_protection? 
+    if tracker.config.allow_forgery_protection?
       warn :controller => :ApplicationController,
         :warning_type => "Cross-Site Request Forgery",
         :warning_code => :csrf_protection_disabled,
@@ -53,7 +53,8 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
     elsif version_between? "4.0.0", "100.0.0" and forgery_opts = app_controller.options[:protect_from_forgery]
 
       unless forgery_opts.is_a?(Array) and sexp?(forgery_opts.first) and
-          access_arg = hash_access(forgery_opts.first.first_arg, :with) and access_arg.value == :exception
+          access_arg = hash_access(forgery_opts.first.first_arg, :with) and access_arg.size == 1 and
+          access_arg.value == :exception
 
         args = {
           :controller => :ApplicationController,


### PR DESCRIPTION
See #840. This PR silences the exception when the `with:` argument is not a single value s-expression.