### PR TITLE
Avoid warning on `popen` with array argument

### DIFF
--- a/lib/brakeman/checks/check_execute.rb
+++ b/lib/brakeman/checks/check_execute.rb
@@ -43,6 +43,10 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
     first_arg = call.first_arg
 
     case call.method
+    when :popen
+      unless array? first_arg
+        failure = include_user_input?(args) || dangerous_interp?(args)
+      end
     when :system, :exec
       failure = include_user_input?(first_arg) || dangerous_interp?(first_arg)
     else

--- a/test/apps/rails4/lib/sweet_lib.rb
+++ b/test/apps/rails4/lib/sweet_lib.rb
@@ -4,8 +4,8 @@ class SweetLib
   end
 
   def test_command_injection_in_lib
-    #Should warn about command injection
-    system("rm #{@bad}")
+    IO.popen(['ls', params[:id]]) #Should not warn
+    system("rm #{@bad}") #Should warn about command injection
   end
 
   def test_net_http_start_ssl


### PR DESCRIPTION
fixes #851