### PR TITLE
Add support for configurable engines path

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -19,6 +19,7 @@ module Brakeman
         init_options[:only_files] = regex_for_paths(options[:only_files])
       end
       init_options[:additional_libs_path] = options[:additional_libs_path]
+      init_options[:engines_path] = options[:engines_path]
       new(root, init_options)
     end
 
@@ -56,6 +57,9 @@ module Brakeman
       @skip_files = init_options[:skip_files]
       @only_files = init_options[:only_files]
       @additional_libs_path = init_options[:additional_libs_path] || []
+      @engines_path = init_options[:engines_path] || []
+      @absolute_engines_path = @engines_path.select { |path| path.start_with?(File::SEPARATOR) }
+      @relative_engines_path = @engines_path - @absolute_engines_path
     end
 
     def expand_path(path)
@@ -100,8 +104,7 @@ module Brakeman
     end
 
     def layout_exists?(name)
-      pattern = "#{@root}/{engines/*/,}app/views/layouts/#{name}.html.{erb,haml,slim}"
-      !Dir.glob(pattern).empty?
+      !find_file("app/views/layouts", name, "{.erb, .haml, .slim}").empty?
     end
 
     def lib_paths
@@ -115,10 +118,16 @@ module Brakeman
       @additional_libs_path.collect{ |path| find_paths path }.flatten
     end
 
-    def find_paths(directory, extensions = "*.rb")
-      pattern = @root + "/{engines/*/,}#{directory}/**/#{extensions}"
+    def find_paths(directory, extensions = ".rb")
+      select_files(find_file(directory, "*", extensions).sort)
+    end
 
-      select_files(Dir.glob(pattern).sort)
+    def find_file(directory, name, extensions = ".rb")
+      abs_engines = @absolute_engines_path.to_a.join(",")
+      rel_engines = @relative_engines_path.empty? ? "" : "{#{@relative_engines_path.to_a.join("/,")},}/"
+      pattern = "{#{@root},#{abs_engines}}" + "/#{rel_engines}#{directory}/**/#{name}#{extensions}"
+
+      Dir.glob(pattern)
     end
 
     def select_files(paths)

--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -104,7 +104,7 @@ module Brakeman
     end
 
     def layout_exists?(name)
-      !find_file("app/views/layouts", name, "{.erb, .haml, .slim}").empty?
+      !glob_files("app/views/layouts", name, "{.erb, .haml, .slim}").empty?
     end
 
     def lib_paths
@@ -119,10 +119,10 @@ module Brakeman
     end
 
     def find_paths(directory, extensions = ".rb")
-      select_files(find_file(directory, "*", extensions).sort)
+      select_files(glob_files(directory, "*", extensions).sort)
     end
 
-    def find_file(directory, name, extensions = ".rb")
+    def glob_files(directory, name, extensions = ".rb")
       abs_engines = @absolute_engines_path.to_a.join(",")
       rel_engines = @relative_engines_path.empty? ? "" : "{#{@relative_engines_path.to_a.join("/,")},}/"
       pattern = "{#{@root},#{abs_engines}}" + "/#{rel_engines}#{directory}/**/#{name}#{extensions}"

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -279,6 +279,11 @@ module Brakeman::Options
         opts.on_tail "-h", "--help", "Display this message" do
           options[:show_help] = true
         end
+
+        opts.on "--engines path1,path2,etc", Array, "Include these engines in the scan." do |paths|
+          options[:engines_path] ||= Set.new
+          options[:engines_path].merge paths
+        end
       end
 
       if destructive

--- a/test/apps/rails4_with_engines/config/brakeman.yml
+++ b/test/apps/rails4_with_engines/config/brakeman.yml
@@ -1,0 +1,3 @@
+---
+:engines_path:
+  - engines/user_removal

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -65,6 +65,19 @@ class BrakemanTests < Test::Unit::TestCase
     assert contains_foo_model
     assert contains_foo_view
   end
+
+  def test_engines_path
+    require 'brakeman/options'
+    relative_path = File.expand_path(File.join(TEST_PATH, "/apps/rails4_with_engines"))
+    input = ["-p", relative_path.to_s]
+    options, _ = Brakeman::Options.parse input
+    options[:engines_path] = ['engines/user_removal']
+    at = Brakeman::AppTree.from_options options
+
+    expected_controllers = %w{application_controller.rb removal_controller.rb users_controller.rb}
+    basename = Proc.new { |path| File.basename path }
+    assert (at.controller_paths.map(&basename) - expected_controllers).empty?
+  end
 end
 
 class UtilTests < Test::Unit::TestCase

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -69,9 +69,9 @@ class BrakemanTests < Test::Unit::TestCase
   def test_engines_path
     require 'brakeman/options'
     relative_path = File.expand_path(File.join(TEST_PATH, "/apps/rails4_with_engines"))
-    input = ["-p", relative_path.to_s]
+    input = ["-p", relative_path.to_s,
+             "--engines", "engine/user_removal"]
     options, _ = Brakeman::Options.parse input
-    options[:engines_path] = ['engines/user_removal']
     at = Brakeman::AppTree.from_options options
 
     expected_controllers = %w{application_controller.rb removal_controller.rb users_controller.rb}


### PR DESCRIPTION
This PR is to add support for scanning engines that are not on the `engines/` path.

This is the first step needed to fix #664. See https://github.com/presidentbeef/brakeman/issues/664#issuecomment-112504060.

> The next step would probably be adding an option so you could point it at the engine directory - that would allow for pointing it at gems too.

This PR adds an `engines_path` option to brakeman to allow users to add engines that the application uses. The path to the engines can either be absolute or relative to the project root. For example, if the `brakeman.yml` config file contains this:

```
:engines_path:
  - engines/user_removal
```

Brakeman will scan the `engines/user_removal` directory relative to the project root. If the path starts with a forward slash, we assume that the path is relative. Like so:

```
:engines_path:
  - /path/to/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/administrate-0.1.4
```