### PR TITLE
Check forgery setting in all direct subclasses of ActionController::Base

### DIFF
--- a/lib/brakeman/checks/check_forgery_setting.rb
+++ b/lib/brakeman/checks/check_forgery_setting.rb
@@ -7,67 +7,69 @@ require 'brakeman/checks/base_check'
 class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
   Brakeman::Checks.add self
 
-  @description = "Verifies that protect_from_forgery is enabled in ApplicationController"
+  @description = "Verifies that protect_from_forgery is enabled in direct subclasses of ActionController::Base"
 
   def run_check
-    app_controller = tracker.controllers[:ApplicationController]
-    return unless app_controller and app_controller.ancestor? :"ActionController::Base"
+    tracker.controllers
+        .select { |_, controller| controller.parent == :"ActionController::Base" }
+        .each do |name, controller|
 
-    if tracker.config.allow_forgery_protection?
-      warn :controller => :ApplicationController,
-        :warning_type => "Cross-Site Request Forgery",
-        :warning_code => :csrf_protection_disabled,
-        :message => "Forgery protection is disabled",
-        :confidence => CONFIDENCE[:high],
-        :file => app_controller.file
+      if tracker.config.allow_forgery_protection?
+        warn :controller => name,
+             :warning_type => "Cross-Site Request Forgery",
+             :warning_code => :csrf_protection_disabled,
+             :message => "Forgery protection is disabled",
+             :confidence => CONFIDENCE[:high],
+             :file => controller.file
 
-    elsif app_controller and not app_controller.protect_from_forgery?
+      elsif controller and not controller.protect_from_forgery?
 
-      warn :controller => :ApplicationController,
-        :warning_type => "Cross-Site Request Forgery",
-        :warning_code => :csrf_protection_missing,
-        :message => "'protect_from_forgery' should be called in ApplicationController",
-        :confidence => CONFIDENCE[:high],
-        :file => app_controller.file,
-        :line => app_controller.top_line
+        warn :controller => name,
+             :warning_type => "Cross-Site Request Forgery",
+             :warning_code => :csrf_protection_missing,
+             :message => "'protect_from_forgery' should be called in #{name}",
+             :confidence => CONFIDENCE[:high],
+             :file => controller.file,
+             :line => controller.top_line
 
-    elsif version_between? "2.1.0", "2.3.10"
+      elsif version_between? "2.1.0", "2.3.10"
 
-      warn :controller => :ApplicationController,
-        :warning_type => "Cross-Site Request Forgery",
-        :warning_code => :CVE_2011_0447,
-        :message => "CSRF protection is flawed in unpatched versions of Rails #{rails_version} (CVE-2011-0447). Upgrade to 2.3.11 or apply patches as needed",
-        :confidence => CONFIDENCE[:high],
-        :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/LZWjzCPgNmU/discussion"
+        warn :controller => name,
+             :warning_type => "Cross-Site Request Forgery",
+             :warning_code => :CVE_2011_0447,
+             :message => "CSRF protection is flawed in unpatched versions of Rails #{rails_version} (CVE-2011-0447). Upgrade to 2.3.11 or apply patches as needed",
+             :confidence => CONFIDENCE[:high],
+             :gem_info => gemfile_or_environment,
+             :link_path => "https://groups.google.com/d/topic/rubyonrails-security/LZWjzCPgNmU/discussion"
 
-    elsif version_between? "3.0.0", "3.0.3"
+      elsif version_between? "3.0.0", "3.0.3"
 
-      warn :controller => :ApplicationController,
-        :warning_type => "Cross-Site Request Forgery",
-        :warning_code => :CVE_2011_0447,
-        :message => "CSRF protection is flawed in unpatched versions of Rails #{rails_version} (CVE-2011-0447). Upgrade to 3.0.4 or apply patches as needed",
-        :confidence => CONFIDENCE[:high],
-        :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/LZWjzCPgNmU/discussion"
-    elsif version_between? "4.0.0", "100.0.0" and forgery_opts = app_controller.options[:protect_from_forgery]
+        warn :controller => name,
+             :warning_type => "Cross-Site Request Forgery",
+             :warning_code => :CVE_2011_0447,
+             :message => "CSRF protection is flawed in unpatched versions of Rails #{rails_version} (CVE-2011-0447). Upgrade to 3.0.4 or apply patches as needed",
+             :confidence => CONFIDENCE[:high],
+             :gem_info => gemfile_or_environment,
+             :link_path => "https://groups.google.com/d/topic/rubyonrails-security/LZWjzCPgNmU/discussion"
+      elsif version_between? "4.0.0", "100.0.0" and forgery_opts = controller.options[:protect_from_forgery]
 
-      unless forgery_opts.is_a?(Array) and sexp?(forgery_opts.first) and
-          access_arg = hash_access(forgery_opts.first.first_arg, :with) and symbol? access_arg and
-          access_arg.value == :exception
+        unless forgery_opts.is_a?(Array) and sexp?(forgery_opts.first) and
+            access_arg = hash_access(forgery_opts.first.first_arg, :with) and symbol? access_arg and
+            access_arg.value == :exception
 
-        args = {
-          :controller => :ApplicationController,
-          :warning_type => "Cross-Site Request Forgery",
-          :warning_code => :csrf_not_protected_by_raising_exception,
-          :message => "protect_from_forgery should be configured with 'with: :exception'",
-          :confidence => CONFIDENCE[:med],
-          :file => app_controller.file
-        }
+          args = {
+              :controller => name,
+              :warning_type => "Cross-Site Request Forgery",
+              :warning_code => :csrf_not_protected_by_raising_exception,
+              :message => "protect_from_forgery should be configured with 'with: :exception'",
+              :confidence => CONFIDENCE[:med],
+              :file => controller.file
+          }
 
-        args.merge!(:code => forgery_opts.first) if forgery_opts.is_a?(Array)
+          args.merge!(:code => forgery_opts.first) if forgery_opts.is_a?(Array)
 
-        warn args
+          warn args
+        end
       end
     end
   end

--- a/lib/brakeman/checks/check_forgery_setting.rb
+++ b/lib/brakeman/checks/check_forgery_setting.rb
@@ -10,65 +10,55 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
   @description = "Verifies that protect_from_forgery is enabled in direct subclasses of ActionController::Base"
 
   def run_check
-    tracker.controllers
-        .select { |_, controller| controller.parent == :"ActionController::Base" }
-        .each do |name, controller|
+    cve_2011_0447_warning = {
+        :warning_type => "Cross-Site Request Forgery",
+        :warning_code => :CVE_2011_0447,
+        :confidence => CONFIDENCE[:high],
+        :gem_info => gemfile_or_environment,
+        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/LZWjzCPgNmU/discussion"
+    }
 
-      if tracker.config.allow_forgery_protection?
-        warn :controller => name,
-             :warning_type => "Cross-Site Request Forgery",
-             :warning_code => :csrf_protection_disabled,
-             :message => "Forgery protection is disabled",
-             :confidence => CONFIDENCE[:high],
-             :file => controller.file
+    if tracker.config.allow_forgery_protection?
+      warn :warning_type => "Cross-Site Request Forgery",
+           :warning_code => :csrf_protection_disabled,
+           :message => "Forgery protection is disabled",
+           :confidence => CONFIDENCE[:high]
+    elsif version_between? "2.1.0", "2.3.10"
+      cve_2011_0447_warning[:message] = "CSRF protection is flawed in unpatched versions of Rails #{rails_version} (CVE-2011-0447). Upgrade to 2.3.11 or apply patches as needed"
+      warn cve_2011_0447_warning
+    elsif version_between? "3.0.0", "3.0.3"
+      cve_2011_0447_warning[:message] = "CSRF protection is flawed in unpatched versions of Rails #{rails_version} (CVE-2011-0447). Upgrade to 3.0.4 or apply patches as needed"
+      warn cve_2011_0447_warning
+    else
+      tracker.controllers
+          .select { |_, controller| controller.parent == :"ActionController::Base" }
+          .each do |name, controller|
+        if controller and not controller.protect_from_forgery?
+          warn :controller => name,
+               :warning_type => "Cross-Site Request Forgery",
+               :warning_code => :csrf_protection_missing,
+               :message => "'protect_from_forgery' should be called in #{name}",
+               :confidence => CONFIDENCE[:high],
+               :file => controller.file,
+               :line => controller.top_line
+        elsif version_between? "4.0.0", "100.0.0" and forgery_opts = controller.options[:protect_from_forgery]
+          unless forgery_opts.is_a?(Array) and sexp?(forgery_opts.first) and
+              access_arg = hash_access(forgery_opts.first.first_arg, :with) and symbol? access_arg and
+              access_arg.value == :exception
 
-      elsif controller and not controller.protect_from_forgery?
+            args = {
+                :controller => name,
+                :warning_type => "Cross-Site Request Forgery",
+                :warning_code => :csrf_not_protected_by_raising_exception,
+                :message => "protect_from_forgery should be configured with 'with: :exception'",
+                :confidence => CONFIDENCE[:med],
+                :file => controller.file
+            }
 
-        warn :controller => name,
-             :warning_type => "Cross-Site Request Forgery",
-             :warning_code => :csrf_protection_missing,
-             :message => "'protect_from_forgery' should be called in #{name}",
-             :confidence => CONFIDENCE[:high],
-             :file => controller.file,
-             :line => controller.top_line
+            args.merge!(:code => forgery_opts.first) if forgery_opts.is_a?(Array)
 
-      elsif version_between? "2.1.0", "2.3.10"
-
-        warn :controller => name,
-             :warning_type => "Cross-Site Request Forgery",
-             :warning_code => :CVE_2011_0447,
-             :message => "CSRF protection is flawed in unpatched versions of Rails #{rails_version} (CVE-2011-0447). Upgrade to 2.3.11 or apply patches as needed",
-             :confidence => CONFIDENCE[:high],
-             :gem_info => gemfile_or_environment,
-             :link_path => "https://groups.google.com/d/topic/rubyonrails-security/LZWjzCPgNmU/discussion"
-
-      elsif version_between? "3.0.0", "3.0.3"
-
-        warn :controller => name,
-             :warning_type => "Cross-Site Request Forgery",
-             :warning_code => :CVE_2011_0447,
-             :message => "CSRF protection is flawed in unpatched versions of Rails #{rails_version} (CVE-2011-0447). Upgrade to 3.0.4 or apply patches as needed",
-             :confidence => CONFIDENCE[:high],
-             :gem_info => gemfile_or_environment,
-             :link_path => "https://groups.google.com/d/topic/rubyonrails-security/LZWjzCPgNmU/discussion"
-      elsif version_between? "4.0.0", "100.0.0" and forgery_opts = controller.options[:protect_from_forgery]
-
-        unless forgery_opts.is_a?(Array) and sexp?(forgery_opts.first) and
-            access_arg = hash_access(forgery_opts.first.first_arg, :with) and symbol? access_arg and
-            access_arg.value == :exception
-
-          args = {
-              :controller => name,
-              :warning_type => "Cross-Site Request Forgery",
-              :warning_code => :csrf_not_protected_by_raising_exception,
-              :message => "protect_from_forgery should be configured with 'with: :exception'",
-              :confidence => CONFIDENCE[:med],
-              :file => controller.file
-          }
-
-          args.merge!(:code => forgery_opts.first) if forgery_opts.is_a?(Array)
-
-          warn args
+            warn args
+          end
         end
       end
     end

--- a/test/apps/rails4_with_engines/engines/user_removal/app/controllers/base_controller.rb
+++ b/test/apps/rails4_with_engines/engines/user_removal/app/controllers/base_controller.rb
@@ -1,0 +1,3 @@
+class BaseController < ActionController::Base
+  # missing protect_from_forgery call
+end

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -3,7 +3,7 @@ abort "Please run using test/test.rb" unless defined? BrakemanTester
 class Rails3Tests < Test::Unit::TestCase
   include BrakemanTester::FindWarning
   include BrakemanTester::CheckExpected
-  
+
   def report
     @@report ||= BrakemanTester.run_scan "rails3", "Rails 3", :rails3 => true,
       :config_file => File.join(TEST_PATH, "apps", "rails3", "config", "brakeman.yml")
@@ -11,10 +11,10 @@ class Rails3Tests < Test::Unit::TestCase
 
   def expected
     @expected ||= {
-      :controller => 1,
+      :controller => 0,
       :model => 9,
       :template => 38,
-      :generic => 74
+      :generic => 75
     }
 
     if RUBY_PLATFORM == 'java'
@@ -384,11 +384,15 @@ class Rails3Tests < Test::Unit::TestCase
   end
 
   def test_csrf_protection
-    assert_warning :type => :controller,
+    assert_warning :type => :warning,
+      :warning_code => 33,
+      :fingerprint => "cc7397ad174bf0da4629bf721183207781fa674909e811965fcde139eb177447",
       :warning_type => "Cross-Site Request Forgery",
-      :message => /^'protect_from_forgery' should be called /,
+      :line => 49,
+      :message => /^CSRF\ protection\ is\ flawed\ in\ unpatched\ v/,
       :confidence => 0,
-      :file => /application_controller\.rb/
+      :relative_path => "Gemfile.lock",
+      :user_input => nil
   end
 
   def test_attribute_restriction
@@ -538,8 +542,8 @@ class Rails3Tests < Test::Unit::TestCase
       :message => /^Unsafe parameter value in link_to href/,
       :confidence => 0,
       :file => /test_params\.html\.erb/
-  end  
- 
+  end
+
   def test_href_parameter_in_link_to
     assert_warning :type => :template,
       :warning_type => "Cross Site Scripting",
@@ -547,21 +551,21 @@ class Rails3Tests < Test::Unit::TestCase
       :message => /^Unsafe parameter value in link_to href/,
       :confidence => 0,
       :file => /test_params\.html\.erb/
- 
+
     assert_warning :type => :template,
       :warning_type => "Cross Site Scripting",
       :line => 16,
       :message => /^Unsafe parameter value in link_to href/,
       :confidence => 1,
-      :file => /test_params\.html\.erb/      
- 
+      :file => /test_params\.html\.erb/
+
     assert_warning :type => :template,
       :warning_type => "Cross Site Scripting",
       :line => 18,
       :message => /^Unsafe parameter value in link_to href/,
       :confidence => 1,
-      :file => /test_params\.html\.erb/            
-  end  
+      :file => /test_params\.html\.erb/
+  end
 
   def test_polymorphic_url_in_href
     assert_no_warning :type => :template,
@@ -569,14 +573,14 @@ class Rails3Tests < Test::Unit::TestCase
       :line => 10,
       :message => /^Unsafe parameter value in link_to href/,
       :confidence => 1,
-      :file => /test_model\.html\.erb/  
+      :file => /test_model\.html\.erb/
 
     assert_no_warning :type => :template,
       :warning_type => "Cross Site Scripting",
       :line => 12,
       :message => /^Unsafe parameter value in link_to href/,
       :confidence => 1,
-      :file => /test_model\.html\.erb/  
+      :file => /test_model\.html\.erb/
   end
 
 
@@ -933,7 +937,7 @@ class Rails3Tests < Test::Unit::TestCase
       :message => /^Unescaped\ model\ attribute\ in\ content_tag/,
       :confidence => 0,
       :file => /test_content_tag\.html\.erb/
-  end 
+  end
 
   def test_xss_content_tag_in_tag_name
     assert_warning :type => :template,
@@ -1110,7 +1114,7 @@ class Rails3Tests < Test::Unit::TestCase
       :message => /^Rails\ 3\.0\.3\ has\ a\ serious\ JSON\ parsing\ v/,
       :confidence => 0,
       :file => /Gemfile/
-  end 
+  end
 
   def test_denial_of_service_CVE_2013_0269
     assert_warning :type => :warning,

--- a/test/tests/rails4_with_engines.rb
+++ b/test/tests/rails4_with_engines.rb
@@ -6,7 +6,7 @@ class Rails4WithEnginesTests < Test::Unit::TestCase
 
   def expected
     @expected ||= {
-      :controller => 1,
+      :controller => 2,
       :model => 5,
       :template => 11,
       :generic => 10 }

--- a/test/tests/rails4_with_engines.rb
+++ b/test/tests/rails4_with_engines.rb
@@ -284,6 +284,18 @@ class Rails4WithEnginesTests < Test::Unit::TestCase
       :relative_path => "app/controllers/application_controller.rb"
   end
 
+  def test_csrf_in_engine
+    assert_warning :type => :controller,
+      :warning_code => 7,
+      :fingerprint => "bdd5f4f1cdd2e9fb24adc4e9333f2b2eb1d0325badcab7c0b89c25952a2454e8",
+      :warning_type => "Cross-Site Request Forgery",
+      :line => 1,
+      :message => /^'protect_from_forgery'\ should\ be\ called\ /,
+      :confidence => 0,
+      :relative_path => "engines/user_removal/app/controllers/base_controller.rb",
+      :user_input => nil
+  end
+
   def test_xml_dos_CVE_2015_3227
     assert_warning :type => :warning,
       :warning_code => 88,


### PR DESCRIPTION
This fixes #848. This is the second part to fix #664. Instead of just scanning controllers named `ApplicationController`, we scan direct subclasses of `ActionController::Base` instead.

Once we have both this PR and #857 merged, we can close #664. :wink: 