### PR TITLE
Add optional check for secrets in source code

### DIFF
--- a/lib/brakeman/checks/check_secrets.rb
+++ b/lib/brakeman/checks/check_secrets.rb
@@ -1,0 +1,40 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckSecrets < Brakeman::BaseCheck
+  Brakeman::Checks.add_optional self
+
+  @description = "Checks for secrets stored in source code"
+
+  def run_check
+    check_constants
+  end
+
+  def check_constants
+    @warned = Set.new
+
+    @tracker.constants.each do |constant|
+      name = constant.name.last
+      value = constant.value
+
+      if string? value and not value.value.empty? and looks_like_secret? name
+        match = [name, value, value.line]
+
+        unless @warned.include? match
+          @warned << match
+
+          warn :warning_code => :secret_in_source,
+            :warning_type => "Authentication",
+            :message => "Hardcoded value for #{name} in source code",
+            :confidence => CONFIDENCE[:med],
+            :file => constant.file,
+            :line => constant.line
+        end
+      end
+    end
+  end
+
+  def looks_like_secret? name
+    # REST_AUTH_SITE_KEY is the pepper in Devise
+    name.match /password|secret|(rest_auth_site|api)_key$/i
+  end
+end

--- a/lib/brakeman/processors/base_processor.rb
+++ b/lib/brakeman/processors/base_processor.rb
@@ -179,7 +179,18 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
   end
 
   def process_cdecl exp
-    @tracker.add_constant exp.lhs, exp.rhs if @tracker
+    file = case
+           when @file_name
+             @file_name
+           when @current_class.is_a?(Brakeman::Collection)
+             @current_class.file
+           when @current_module.is_a?(Brakeman::Collection)
+             @current_module.file
+           else
+             nil
+           end
+
+    @tracker.add_constant exp.lhs, exp.rhs, :file => file if @tracker
     exp
   end
 

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -102,6 +102,7 @@ module Brakeman::WarningCodes
     :CVE_2015_7579 => 98,
     :dynamic_render_path_rce => 99,
     :CVE_2015_7581 => 100,
+    :secret_in_source => 101,
   }
 
   def self.code name

--- a/test/apps/rails5/config/initializers/secrets.rb
+++ b/test/apps/rails5/config/initializers/secrets.rb
@@ -1,0 +1,1 @@
+DB_PASSWORD = "sup3rs3cr37"

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -13,7 +13,7 @@ class Rails5Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 0,
       :template => 2,
-      :generic => 5
+      :generic => 6
     }
   end
 
@@ -54,6 +54,18 @@ class Rails5Tests < Test::Unit::TestCase
       :relative_path => "app/controllers/users_controller.rb",
       :code => s(:call, s(:call, s(:params), :[], s(:lit, :x)), :to_sym),
       :user_input => s(:call, s(:params), :[], s(:lit, :x))
+  end
+
+  def test_secrets_in_source
+    assert_warning :type => :warning,
+      :warning_code => 101,
+      :fingerprint => "eefde7320af81299c41d50840750b5cb509a1fe454ba9179076955bf53b6d966",
+      :warning_type => "Authentication",
+      :line => 1,
+      :message => /^Hardcoded\ value\ for\ DB_PASSWORD\ in\ sourc/,
+      :confidence => 1,
+      :user_input => nil,
+      :relative_path => "config/initializers/secrets.rb"
   end
 
   def test_cross_site_scripting_CVE_2015_7578


### PR DESCRIPTION
This is an initial cut at a check for secrets in constants. Optional for now, may make default in a couple releases.

Closes #201 (yes, from 2012).