### PR TITLE
Added Support u alias for url_encode

### DIFF
--- a/lib/brakeman/checks/check_content_tag.rb
+++ b/lib/brakeman/checks/check_content_tag.rb
@@ -24,7 +24,7 @@ class Brakeman::CheckContentTag < Brakeman::CheckCrossSiteScripting
                            :hidden_field, :hidden_field_tag, :image_tag, :label,
                            :mail_to, :radio_button, :select,
                            :submit_tag, :text_area, :text_field,
-                           :text_field_tag, :url_encode, :url_for,
+                           :text_field_tag, :url_encode, :u, :url_for,
                            :will_paginate].merge tracker.options[:safe_methods]
 
     @known_dangerous = []

--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -286,7 +286,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
                            :hidden_field, :hidden_field_tag, :image_tag, :label,
                            :link_to, :mail_to, :radio_button, :select,
                            :submit_tag, :text_area, :text_field,
-                           :text_field_tag, :url_encode, :url_for,
+                           :text_field_tag, :url_encode, :u, :url_for,
                            :will_paginate].merge tracker.options[:safe_methods]
 
     @models = tracker.models.keys

--- a/lib/brakeman/checks/check_link_to.rb
+++ b/lib/brakeman/checks/check_link_to.rb
@@ -17,7 +17,7 @@ class Brakeman::CheckLinkTo < Brakeman::CheckCrossSiteScripting
                            :hidden_field, :hidden_field_tag, :image_tag, :label,
                            :mail_to, :radio_button, :select,
                            :submit_tag, :text_area, :text_field,
-                           :text_field_tag, :url_encode, :url_for,
+                           :text_field_tag, :url_encode, :u, :url_for,
                            :will_paginate].merge tracker.options[:safe_methods]
 
     @known_dangerous = []

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -17,7 +17,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
                            :hidden_field, :hidden_field_tag, :image_tag, :label,
                            :mail_to, :polymorphic_url, :radio_button, :select,
                            :submit_tag, :text_area, :text_field,
-                           :text_field_tag, :url_encode, :url_for,
+                           :text_field_tag, :url_encode, :u, :url_for,
                            :will_paginate].merge(tracker.options[:url_safe_methods] || [])
 
     @models = tracker.models.keys

--- a/test/apps/rails2/app/views/home/test_content_tag.html.erb
+++ b/test/apps/rails2/app/views/home/test_content_tag.html.erb
@@ -24,3 +24,6 @@ Should warn
 
 Should warn, medium confidence
 <%= content_tag :div, x(params[:maybe_bad]) %>
+
+Should not warn
+<%= content_tag :span, u(params[:url]) %>

--- a/test/apps/rails2/app/views/home/test_model.html.erb
+++ b/test/apps/rails2/app/views/home/test_model.html.erb
@@ -11,3 +11,5 @@ It's just a model <%= link_to "Hipster ipsum", User.first %>
 It's just a couple of models <%= link_to "Hipster ipsum", [Account.first, User.last] %>
 
 <%= render :partial => 'models', :collection => all_the_things, :as => :model %>
+
+Safe link_to herf fun: <%= link_to "test", u(params[:user_id]) %>

--- a/test/apps/rails2/app/views/home/test_params.html.erb
+++ b/test/apps/rails2/app/views/home/test_params.html.erb
@@ -16,3 +16,5 @@ Dangerous href: <%= link_to "more text", params[:dangerous] %>
 Still dangerous hrefs: <%= link_to "donkey", not_safe(params[:bad_robot]) %>
 
 Not completely safe: <%= link_to "Helvetica hoodie bushwick", h(params[:js_xss]) %>
+
+Should not warn <%= u(params[:w00t]) %>

--- a/test/apps/rails2/app/views/home/test_params.html.erb
+++ b/test/apps/rails2/app/views/home/test_params.html.erb
@@ -18,3 +18,5 @@ Still dangerous hrefs: <%= link_to "donkey", not_safe(params[:bad_robot]) %>
 Not completely safe: <%= link_to "Helvetica hoodie bushwick", h(params[:js_xss]) %>
 
 Should not warn <%= u(params[:w00t]) %>
+
+Should not warn <%= link_to u(params[:w00t]), "some_url" %>

--- a/test/apps/rails3/app/views/home/test_content_tag.html.erb
+++ b/test/apps/rails3/app/views/home/test_content_tag.html.erb
@@ -33,3 +33,6 @@ Should warn
 
 Should warn
 <%= content_tag @user.preferred_markup, "Seriously" %>
+
+Should not warn
+<%= content_tag :span, "test", { u(params[:class]) => "display:none" } %>

--- a/test/apps/rails3/app/views/home/test_model.html.erb
+++ b/test/apps/rails3/app/views/home/test_model.html.erb
@@ -10,3 +10,5 @@ Not a problem in Rails 3: <%= link_to User.first.name, "some url" %>
 It's just a model <%= link_to "Hipster ipsum", User.first %>
 
 It's just a couple of models <%= link_to "Hipster ipsum", [Account.first, User.last] %>
+
+Safe link_to herf fun: <%= link_to "test", u(params[:user_id]) %>

--- a/test/apps/rails3/app/views/home/test_params.html.erb
+++ b/test/apps/rails3/app/views/home/test_params.html.erb
@@ -18,3 +18,5 @@ Still dangerous hrefs: <%= link_to "donkey", not_safe(params[:bad_robot]) %>
 Not completely safe: <%= link_to "Helvetica hoodie bushwick", h(params[:js_xss]) %>
 
 Request parameters: <%= raw request.parameters %>
+
+Should not warn <%= raw u(params[:w00t]) %>

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -559,6 +559,19 @@ class Rails2Tests < Test::Unit::TestCase
       :relative_path => "app/views/home/test_model.html.erb"
   end
 
+  def test_cross_site_scripting_alias_u_for_link_to_href
+    assert_no_warning :type => :template,
+      :warning_code => 4,
+      :fingerprint => "395a4782d1e015e32c62aff7b3811533d91015935bc1b4258ad17b264dcdf6fe",
+      :warning_type => "Cross Site Scripting",
+      :line => 15,
+      :message => /^Unsafe\ parameter\ value\ in\ link_to\ href/,
+      :confidence => 0,
+      :relative_path => "app/views/home/test_model.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, "test"), s(:call, s(:params), :[], s(:lit, :user_id))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :user_id))
+  end
+
   def test_unescaped_body_in_link_to
     assert_warning :type => :template,
       :warning_type => "Cross Site Scripting",

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -505,6 +505,19 @@ class Rails2Tests < Test::Unit::TestCase
       :relative_path => "app/views/home/test_params.html.erb"
   end
 
+  def test_cross_site_scripting_alias_u_for_link_to
+    assert_no_warning :type => :template,
+      :warning_code => 3,
+      :fingerprint => "1803557ac730919bef3de68329461c47d5bee2a6bcdc8f467e6ee896504e6355",
+      :warning_type => "Cross Site Scripting",
+      :line => 22,
+      :message => /^Unescaped\ parameter\ value\ in\ link_to/,
+      :confidence => 0,
+      :relative_path => "app/views/home/test_params.html.erb",
+      :code => s(:call, nil, :link_to, s(:call, s(:params), :[], s(:lit, :w00t)), s(:str, "some_url")),
+      :user_input => s(:call, s(:params), :[], s(:lit, :w00t))
+  end
+
   def test_encoded_href_parameter_in_link_to
     assert_no_warning :type => :template,
       :warning_type => "Cross Site Scripting",

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -441,6 +441,19 @@ class Rails2Tests < Test::Unit::TestCase
       :relative_path => "app/views/home/test_params.html.erb"
   end
 
+  def test_cross_site_scripting_alias_u
+    assert_no_warning :type => :template,
+      :warning_code => 2,
+      :fingerprint => "a1f78b7e1ff25f81054b5ed38d04457e76278ba38444cb65f93cd559f9545bd9",
+      :warning_type => "Cross Site Scripting",
+      :line => 20,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/views/home/test_params.html.erb",
+      :code => s(:call, s(:params), :[], s(:lit, :w00t)),
+      :user_input => nil
+  end
+
   def test_model_attribute_from_controller
     assert_warning :type => :template,
       :warning_type => "Cross Site Scripting",

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -888,6 +888,19 @@ class Rails2Tests < Test::Unit::TestCase
       :relative_path => "app/views/home/test_content_tag.html.erb"
   end
 
+  def test_cross_site_scripting_u_alias_for_content_tag
+    assert_no_warning :type => :template,
+      :warning_code => 53,
+      :fingerprint => "e0279d86dea74b0da8c9cf5fce0b38c1023c1c407e84671d03ce0ca3440f03da",
+      :warning_type => "Cross Site Scripting",
+      :line => 29,
+      :message => /^Unescaped\ parameter\ value\ in\ content_tag/,
+      :confidence => 0,
+      :relative_path => "app/views/home/test_content_tag.html.erb",
+      :code => s(:call, nil, :content_tag, s(:lit, :span), s(:call, s(:params), :[], s(:lit, :url))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :url))
+  end
+
   #Uh...maybe this shouldn't be a warning
   def test_cross_site_scripting_in_sanitize_method
     assert_warning :type => :template,

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -579,6 +579,18 @@ class Rails3Tests < Test::Unit::TestCase
       :file => /test_model\.html\.erb/  
   end
 
+  def test_cross_site_scripting_alias_u_for_link_to_href
+    assert_no_warning :type => :template,
+      :warning_code => 4,
+      :fingerprint => "395a4782d1e015e32c62aff7b3811533d91015935bc1b4258ad17b264dcdf6fe",
+      :warning_type => "Cross Site Scripting",
+      :line => 14,
+      :message => /^Unsafe\ parameter\ value\ in\ link_to\ href/,
+      :confidence => 0,
+      :relative_path => "app/views/home/test_model.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, "test"), s(:call, s(:params), :[], s(:lit, :user_id))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :user_id))
+  end
 
   def test_file_access_in_template
     assert_warning :type => :template,

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -652,6 +652,19 @@ class Rails3Tests < Test::Unit::TestCase
       :file => /test_params\.html\.erb/
   end
 
+  def test_cross_site_scripting_alias_u
+    assert_no_warning :type => :template,
+      :warning_code => 2,
+      :fingerprint => "a1f78b7e1ff25f81054b5ed38d04457e76278ba38444cb65f93cd559f9545bd9",
+      :warning_type => "Cross Site Scripting",
+      :line => 22,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/views/home/test_params.html.erb",
+      :code => s(:call, s(:params), :[], s(:lit, :w00t)),
+      :user_input => nil
+  end
+
   def test_sql_injection_in_template
     #SQL injection in controllers should not warn again in views
     assert_no_warning :type => :template,

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -969,6 +969,19 @@ class Rails3Tests < Test::Unit::TestCase
       :file => /test_content_tag\.html\.erb/
   end
 
+  def test_cross_site_scripting_u_alias_for_content_tag
+    assert_no_warning :type => :template,
+      :warning_code => 53,
+      :fingerprint => "2bfdd98472f9f235b3ea683a4d911749b0c1b7ae169be697657304724d780595",
+      :warning_type => "Cross Site Scripting",
+      :line => 38,
+      :message => /^Unescaped\ parameter\ value\ in\ content_tag/,
+      :confidence => 0,
+      :relative_path => "app/views/home/test_content_tag.html.erb",
+      :code => s(:call, nil, :content_tag, s(:lit, :span), s(:str, "test"), s(:hash, s(:call, s(:params), :[], s(:lit, :class)), s(:str, "display:none"))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :class))
+  end
+
   def test_cross_site_scripting_prepend_filter
     assert_warning :type => :template,
       :warning_type => "Cross Site Scripting",


### PR DESCRIPTION
XSS will no longer be warned for `:u` alias of `:url_encode` as per request #847