### PR TITLE
Report end lines in Code Climate issues

### DIFF
--- a/lib/brakeman/report/report_codeclimate.rb
+++ b/lib/brakeman/report/report_codeclimate.rb
@@ -26,7 +26,8 @@ class Brakeman::Report::CodeClimate < Brakeman::Report::Base
       location: {
         path: warning.relative_path,
         lines: {
-          begin: warning.line || 1
+          begin: warning.line || 1,
+          end: warning.line || 1,
         }
       },
       content: {

--- a/test/tests/codeclimate_output.rb
+++ b/test/tests/codeclimate_output.rb
@@ -17,6 +17,7 @@ class TestCodeClimateOutput < Test::Unit::TestCase
     @@issues.each do |issue|
       assert issue["location"]["path"].length > 0
       assert issue["location"]["lines"]["begin"] >= 1
+      assert issue["location"]["lines"]["end"] >= 1
     end
   end
 


### PR DESCRIPTION
Our spec requires both beginning and ending lines, so this should
include both, even if they are the same.

Spec reference:
https://github.com/codeclimate/spec/blob/master/SPEC.md#locations