### PR TITLE
Support multiple newlines between ruby expressions in ERB files

### DIFF
--- a/lib/brakeman/parsers/rails3_erubis.rb
+++ b/lib/brakeman/parsers/rails3_erubis.rb
@@ -9,8 +9,8 @@ class Brakeman::Rails3Erubis < ::Erubis::Eruby
 
   #This is different from Rails 3 - fixes some line number issues
   def add_text(src, text)
-    if text == "\n"
-      src << "\n"
+    if text =~ /\A\n+\z/
+      src << text
     elsif text.include? "\n"
       lines = text.split("\n")
       if text.match(/\n\z/)

--- a/test/apps/rails3/app/views/home/test_multiple_newlines.html.erb
+++ b/test/apps/rails3/app/views/home/test_multiple_newlines.html.erb
@@ -1,0 +1,7 @@
+<% if @name %>
+
+
+  <% if @indirect %>
+    Dangerous hrefs in nested logic with multiple newlines: <%= link_to "so many newlines", params[:dangerous] %>
+  <% end %>
+<% end %>

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -13,7 +13,7 @@ class Rails3Tests < Test::Unit::TestCase
     @expected ||= {
       :controller => 1,
       :model => 9,
-      :template => 38,
+      :template => 39,
       :generic => 74
     }
 
@@ -562,6 +562,19 @@ class Rails3Tests < Test::Unit::TestCase
       :confidence => 1,
       :file => /test_params\.html\.erb/            
   end  
+
+  # Brakeman previously mishandled multiple newlines between nested ruby
+  # expressions incorrectly. This test verifies that multiple newlines
+  # between ruby expressions does not lead to incorrect line numbers in
+  # warnings.
+  def test_multiple_newlines_in_nested_logic
+    assert_warning :type => :template,
+      :warning_type => "Cross Site Scripting",
+      :line => 5,
+      :message => /^Unsafe parameter value in link_to href/,
+      :confidence => 0,
+      :file => /test_multiple_newlines\.html\.erb/
+  end
 
   def test_polymorphic_url_in_href
     assert_no_warning :type => :template,

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -563,7 +563,7 @@ class Rails3Tests < Test::Unit::TestCase
       :file => /test_params\.html\.erb/            
   end  
 
-  # Brakeman previously mishandled multiple newlines between nested ruby
+  # Brakeman previously handled multiple newlines between nested ruby
   # expressions incorrectly. This test verifies that multiple newlines
   # between ruby expressions does not lead to incorrect line numbers in
   # warnings.


### PR DESCRIPTION
We ran into a recurring issue where line numbers within ERB files were incorrect. They were usually one or two lines off, but it wasn't super clear why. Upon looking at the issue it seems that Brakeman's overrides in erubis for handling newlines is flawed. The conditional has no branch that handles more than a single newline correctly. If you have a run of several newlines such as `\n\n\n\n` the old logic would process it like this:

* does `text == "\n"`? - Nope
* elsif `text.include? "\n"`? - Yup

But, the issue is that when that branch is taken, we end up with this:

``` ruby
text = "\n\n\n\n"
lines = text.split("\n")
=> []
```

As a result, there is nothing to iterate over inside that branch. This is semi-unexpected (at least by me) since adding any non-newline character completely changes that split.

``` ruby
text = "\n\n\n\n "
lines = text.split("\n")
=> ["", "", "", "", " "]
```

So, we need to handle runs of newlines explicitly. Luckily we can just change the original `text == "\n"` to a regex for one or more newlines. 

/cc @gregose 