### PR TITLE
Sync ERB handling up with rails/rails from Rails 5

### DIFF
--- a/lib/brakeman/parsers/rails3_erubis.rb
+++ b/lib/brakeman/parsers/rails3_erubis.rb
@@ -1,45 +1,74 @@
 Brakeman.load_brakeman_dependency 'erubis'
 
-#This is from Rails 3 version of the Erubis handler
+# This is from Rails 5 version of the Erubis handler
+# https://github.com/rails/rails/blob/ec608107801b1e505db03ba76bae4a326a5804ca/actionview/lib/action_view/template/handlers/erb.rb#L7-L73
 class Brakeman::Rails3Erubis < ::Erubis::Eruby
 
   def add_preamble(src)
-    # src << "_buf = ActionView::SafeBuffer.new;\n"
+    @newline_pending = 0
+    src << "@output_buffer = output_buffer || ActionView::OutputBuffer.new;"
   end
 
-  #This is different from Rails 3 - fixes some line number issues
   def add_text(src, text)
-    lines = text.lines
-    lines.each do |line|
-      if line == "\n"
-        src << line
-      else
-        newline = line.end_with?("\n") ? "\n" : nil
-        src << "@output_buffer << ('" << escape_text(line.chomp) << "'.html_safe!);#{newline}"
-      end
+    return if text.empty?
+
+    if text == "\n"
+      @newline_pending += 1
+    else
+      src << "@output_buffer.safe_append='"
+      src << "\n" * @newline_pending if @newline_pending > 0
+      src << escape_text(text)
+      src << "'.freeze;"
+
+      @newline_pending = 0
+    end
+  end
+
+  # Erubis toggles <%= and <%== behavior when escaping is enabled.
+  # We override to always treat <%== as escaped.
+  def add_expr(src, code, indicator)
+    case indicator
+    when '=='
+      add_expr_escaped(src, code)
+    else
+      super
     end
   end
 
   BLOCK_EXPR = /\s*((\s+|\))do|\{)(\s*\|[^|]*\|)?\s*\Z/
 
   def add_expr_literal(src, code)
+    flush_newline_if_pending(src)
     if code =~ BLOCK_EXPR
       src << '@output_buffer.append= ' << code
     else
-      src << '@output_buffer.append= (' << code << ');'
+      src << '@output_buffer.append=(' << code << ');'
     end
   end
 
   def add_expr_escaped(src, code)
+    flush_newline_if_pending(src)
     if code =~ BLOCK_EXPR
-      src << "@output_buffer.safe_append= " << code
+      src << "@output_buffer.safe_expr_append= " << code
     else
-      src << "@output_buffer.safe_append= (" << code << ");"
+      src << "@output_buffer.safe_expr_append=(" << code << ");"
     end
   end
 
-  #Add code to output buffer.
+  def add_stmt(src, code)
+    flush_newline_if_pending(src)
+    super
+  end
+
   def add_postamble(src)
-    # src << '_buf.to_s'
+    flush_newline_if_pending(src)
+    src << '@output_buffer.to_s'
+  end
+
+  def flush_newline_if_pending(src)
+    if @newline_pending > 0
+      src << "@output_buffer.safe_append='#{"\n" * @newline_pending}'.freeze;"
+      @newline_pending = 0
+    end
   end
 end


### PR DESCRIPTION
Per your comment in https://github.com/presidentbeef/brakeman/pull/873#issuecomment-217929880, this PR syncs up ERB handling with Rails 5 from upstream. The one caveat here is that upstream uses `@output_buffer.safe_expr_append` during code generation. Given this is all being analyzed statically, I'm not sure that matters or not if we are analyzing a rails 3 app. Since it is all just an intermediate format used for analysis anyway, I tend to think it doesn't matter. But, I'll leave it up to you if you would like to override that change from upstream or not. 