### PR TITLE
Add ability to bypass the "is this a rails app" check

### DIFF
--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -276,6 +276,10 @@ module Brakeman::Options
           options[:show_version] = true
         end
 
+        opts.on "--force-scan", "Scan application even if rails is not detected" do
+          options[:force_scan] = true
+        end
+
         opts.on_tail "-h", "--help", "Display this message" do
           options[:show_help] = true
         end

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -24,7 +24,7 @@ class Brakeman::Scanner
     @options = options
     @app_tree = Brakeman::AppTree.from_options(options)
 
-    if !@app_tree.root || !@app_tree.exists?("app")
+    if (!@app_tree.root || !@app_tree.exists?("app")) && !options[:force_scan]
       raise Brakeman::NoApplication, "Please supply the path to a Rails application."
     end
 

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -7,6 +7,12 @@ class BrakemanTests < Test::Unit::TestCase
     end
   end
 
+  def test_exception_no_on_no_application_if_forced
+    assert_nothing_raised Brakeman::NoApplication do
+      Brakeman.run :app_path => "/tmp#{rand}", :force_scan => true #better not exist
+    end
+  end
+
   def test_app_tree_root_is_absolute
     require 'brakeman/options'
     relative_path = Pathname.new(File.dirname(__FILE__)).relative_path_from(Pathname.getwd)

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -21,7 +21,8 @@ class BrakemanOptionsTest < Test::Unit::TestCase
     :list_optional_checks   => "--optional-checks",
     :install_rake_task      => "--rake",
     :show_version           => "-v",
-    :show_help              => "-h"
+    :show_help              => "-h",
+    :force_scan             => "--force-scan"
   }
 
   ALT_OPTION_INPUTS = {


### PR DESCRIPTION
I would not call this "sinatra support", but at least we can get results for junk in lib. This change caught a bug in a non-rails app.

/to @presidentbeef 
/cc @ptoomey3 @gregose 

