### PR TITLE
Key instance and class methods differently

### DIFF
--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -90,12 +90,7 @@ class Brakeman::Tracker
       set.each do |set_name, collection|
         collection.each_method do |method_name, definition|
           src = definition[:src]
-          if src.node_type == :defs
-            method_name = "#{src[1]}.#{method_name}"
-          end
-
           yield src, set_name, method_name, definition[:file]
-
         end
       end
     end
@@ -254,10 +249,6 @@ class Brakeman::Tracker
       set.each do |set_name, info|
         info.each_method do |method_name, definition|
           src = definition[:src]
-          if src.node_type == :defs
-            method_name = "#{src[1]}.#{method_name}"
-          end
-
           finder.process_source src, :class => set_name, :method => method_name, :file => definition[:file]
         end
       end

--- a/lib/brakeman/tracker/collection.rb
+++ b/lib/brakeman/tracker/collection.rb
@@ -45,6 +45,10 @@ module Brakeman
     end
 
     def add_method visibility, name, src, file_name
+      if src.node_type == :defs
+        name = :"#{src[1]}.#{name}"
+      end
+
       @methods[visibility][name] = { :src => src, :file => file_name }
     end
 

--- a/test/apps/rails5/app/models/user.rb
+++ b/test/apps/rails5/app/models/user.rb
@@ -1,4 +1,12 @@
 class User < ApplicationRecord
+  def self.evaluate_user_input
+    eval(params)
+  end
+
+  def evaluate_user_input
+    self.class.evaluate_user_input
+  end
+
   def test_stuff
     if Rails.env.test?
       User.where(params)

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -698,7 +698,7 @@ class Rails2Tests < Test::Unit::TestCase
   def test_sql_injection_active_record_base_connection
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "9aab1347248beb5a3bec91e84b133dcd8fc1bd2b113b744e2df59acf9085cd81",
+      :fingerprint => "4918bccd67257c7f691718b4bb10bbbf176bc4bd3ad80cce9df11032cc73515d",
       :warning_type => "SQL Injection",
       :line => 31,
       :message => /^Possible\ SQL\ injection/,

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -1045,7 +1045,7 @@ class Rails31Tests < Test::Unit::TestCase
   def test_sql_injection_with_interpolated_value
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "d877102aa3a7f1c5a6074d9486e6c850dd9dab23cab4f149a9bd674b440bda49",
+      :fingerprint => "b4dff795ce1504c9273a13add535c895ceb920e9091ddfff614fd2ea4c3696ed",
       :warning_type => "SQL Injection",
       :line => 33,
       :message => /^Possible\ SQL\ injection/,

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -263,7 +263,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_sql_injection_exec_query
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "f99145dd8cfb1abca2ff36722b4bd136382d86ffd2bb28eb5ac6d064677c845f",
+      :fingerprint => "52da65996b98cd05c8a515f9cee489bb086448be56b7aa87a20d513afe47d7b8",
       :warning_type => "SQL Injection",
       :line => 12,
       :message => /^Possible\ SQL\ injection/,
@@ -532,7 +532,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_weak_hash_password_variable_nested
     assert_warning :type => :warning,
       :warning_code => 90,
-      :fingerprint => "2b147d27348729419872dcaa48c6cbb3881bc8f283e5c03a47fc6bed11d72ced",
+      :fingerprint => "db7bbef4391043f40b09a052829d71540e6edbd9c89ea7b9e17e10e8c63cdc98",
       :warning_type => "Weak Hash",
       :line => 42,
       :message => /^Weak\ hashing\ algorithm\ \(MD5\)\ used/,
@@ -946,7 +946,7 @@ class Rails4Tests < Test::Unit::TestCase
   def test_sql_injection_with_to_s_on_string_interp
     assert_warning :type => :warning,
       :warning_code => 0,
-      :fingerprint => "76279bb48be9716ee4618dbd0a3cda08a63fc1053484c4f29c0214940a57a202",
+      :fingerprint => "06f9f76470ed1d4559c28258f29cab4ec28817a5414121a23b90ea6e9a564374",
       :warning_type => "SQL Injection",
       :line => 39,
       :message => /^Possible\ SQL\ injection/,

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -13,7 +13,7 @@ class Rails5Tests < Test::Unit::TestCase
       :controller => 0,
       :model => 0,
       :template => 2,
-      :generic => 6
+      :generic => 7
     }
   end
 
@@ -205,5 +205,18 @@ class Rails5Tests < Test::Unit::TestCase
       :confidence => 0,
       :relative_path => "Gemfile.lock",
       :user_input => nil
+  end
+
+  def test_dangerous_eval_in_prior_class_method_with_same_name
+    assert_warning :type => :warning,
+      :warning_code => 13,
+      :fingerprint => "7fe3142d1d11b7118463e45a82b4b7a2b5b5bac95cf8904050c101fae16b8168",
+      :warning_type => "Dangerous Eval",
+      :line => 3,
+      :message => /User input in eval near line 3/,
+      :method => :"User.evaluate_user_input",
+      :confidence => 0,
+      :relative_path => "app/models/user.rb",
+      :user_input => s(:params)
   end
 end


### PR DESCRIPTION
If a collection had a class method and an instance method that shared
the same name, one would overwrite the other since they are keyed by
name only.

This change keys the class methods prefixed with this class. Since the
tracker does this in a couple of different places anyway, it can now
just rely on the key to return the method name.

Since fingerprints are based partly on this key, a few tests had to be
updated that checked for this.

Fixes https://github.com/presidentbeef/brakeman/issues/880