### PR TITLE
Allow extended regexp into validate format

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+* Allow multile line regex in validates_format_of
+
 # 3.3.0
 
 * Skip processing obviously false if branches (more broadly)

--- a/test/apps/rails4/app/models/phone.rb
+++ b/test/apps/rails4/app/models/phone.rb
@@ -1,0 +1,12 @@
+class Phone < ActiveRecord::Base
+  PHONE_NUMBER_REGEXP = %r{
+    \A
+    +\d+ # counter prefix
+    \ * # space
+    \(\d+\) # city code
+    \ * # space
+    (\d+-)*\d+
+    \z
+  }x
+  validates_format_of :number, with: PHONE_NUMBER_REGEXP
+end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -1063,7 +1063,7 @@ class Rails4Tests < Test::Unit::TestCase
       :code => s(:call, s(:const, :User), :where, s(:dstr, "", s(:evstr, s(:call, s(:params), :permit, s(:lit, :OMG))))),
       :user_input => s(:call, s(:params), :permit, s(:lit, :OMG))
   end
- 
+
   def test_format_validation_model_alias_processing
     assert_warning :type => :model,
       :warning_code => 30,
@@ -1074,6 +1074,15 @@ class Rails4Tests < Test::Unit::TestCase
       :confidence => 0,
       :relative_path => "app/models/email.rb",
       :user_input => nil
+  end
+
+  def test_format_validation_with_multiline
+    assert_no_warning :type => :model,
+      :warning_type => "Format Validation",
+      :line => 11,
+      :message => /^Insufficient\ validation\ for\ 'number/,
+      :confidence => 0,
+      :file => /phone\.rb/
   end
 
   def test_additional_libs_option


### PR DESCRIPTION
Hi!

I just want to apologize for my English. I use Google Translate for this message.

I add support of extended regexes into checking of validate format.

I like to write complex regular expressions in a multiline format, but the brakeman displays false warnings on these regular expressions.

In tests I've added an example of such a regular expression.