### PR TITLE
Adds obsolete ignore filter identification functionality

### DIFF
--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -11,6 +11,7 @@ module Brakeman
       @new_warnings = new_warnings
       @already_ignored = []
       @ignored_fingerprints = Set.new
+      @used_fingerprints = Set.new
       @notes = {}
       @shown_warnings = @ignored_warnings = nil
       @changed = false
@@ -43,6 +44,7 @@ module Brakeman
 
     # Determine if warning should be ignored
     def ignored? warning
+      @used_fingerprints << warning.fingerprint
       @ignored_fingerprints.include? warning.fingerprint
     end
 
@@ -73,6 +75,11 @@ module Brakeman
       end
 
       nil
+    end
+
+    # The set of unused ignore entries
+    def obsolete_fingerprints
+      (@ignored_fingerprints - @used_fingerprints).to_a
     end
 
     # Read configuration to file

--- a/lib/brakeman/report/report_base.rb
+++ b/lib/brakeman/report/report_base.rb
@@ -79,6 +79,11 @@ class Brakeman::Report::Base
     render_array('error_overview', ['Error', 'Location'], values, {:tracker => tracker})
   end
 
+  def generate_obsolete
+    values = tracker.unused_fingerprints.collect{|fingerprint| [fingerprint] }
+    render_array('obsolete_ignore_entries', ['fingerprint'], values, {:tracker => tracker})
+  end
+
   def generate_warnings
     render_warnings generic_warnings,
                     :warning,

--- a/lib/brakeman/report/report_json.rb
+++ b/lib/brakeman/report/report_json.rb
@@ -2,6 +2,8 @@ class Brakeman::Report::JSON < Brakeman::Report::Base
   def generate_report
     errors = tracker.errors.map{|e| { :error => e[:error], :location => e[:backtrace][0] }}
 
+    obsolete = tracker.unused_fingerprints
+
     warnings = convert_to_hashes all_warnings
 
     ignored = convert_to_hashes ignored_warnings
@@ -26,7 +28,8 @@ class Brakeman::Report::JSON < Brakeman::Report::Base
       :scan_info => scan_info,
       :warnings => warnings,
       :ignored_warnings => ignored,
-      :errors => errors
+      :errors => errors,
+      :obsolete => obsolete
     }
 
     JSON.pretty_generate report_info

--- a/lib/brakeman/report/report_table.rb
+++ b/lib/brakeman/report/report_table.rb
@@ -25,6 +25,7 @@ class Brakeman::Report::Table < Brakeman::Report::Base
       truncate_table(generate_templates.to_s) << "\n"
     end
 
+    output_table("+Obsolete Ignore Entries+", generate_obsolete, out)
     output_table("+Errors+", generate_errors, out)
     output_table("+SECURITY WARNINGS+", generate_warnings, out)
     output_table("Controller Warnings:", generate_controller_warnings, out)

--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -185,6 +185,11 @@ class Brakeman::Tracker
     end
   end
 
+  def unused_fingerprints
+    return [] unless self.ignored_filter
+    self.ignored_filter.obsolete_fingerprints
+  end
+
   def add_constant name, value, context = nil
     @constants.add name, value, context unless @options[:disable_constant_tracking]
   end

--- a/test/apps/rails4/config/brakeman.ignore
+++ b/test/apps/rails4/config/brakeman.ignore
@@ -17,6 +17,24 @@
       "user_input": null,
       "confidence": "High",
       "note": "skipping this for a test"
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 60,
+      "fingerprint": "abcdef01234567890ba28050e7faf1d54f218dfa9435c3f65f47cb378c18cf98",
+      "message": "Potentially dangerous attribute available for mass assignment",
+      "file": "app/models/account.rb",
+      "line": null,
+      "link": "http://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": ":admin",
+      "render_path": null,
+      "location": {
+        "type": "model",
+        "model": "Account"
+      },
+      "user_input": null,
+      "confidence": "High",
+      "note": "this error should be detected as obsolete"
     }
   ],
   "updated": "2013-12-20 22:14:42 +0200",

--- a/test/tests/json_output.rb
+++ b/test/tests/json_output.rb
@@ -2,7 +2,7 @@ require 'json'
 
 class JSONOutputTests < Minitest::Test
   def setup
-    @@json ||= JSON.parse(Brakeman.run("#{TEST_PATH}/apps/rails3.2").report.to_json)
+    @@json ||= JSON.parse(Brakeman.run("#{TEST_PATH}/apps/rails4").report.to_json)
   end
 
   def test_for_render_path
@@ -13,7 +13,7 @@ class JSONOutputTests < Minitest::Test
   end
 
   def test_for_expected_keys
-    assert (@@json.keys - ["warnings", "ignored_warnings", "scan_info", "errors"]).empty?
+    assert (@@json.keys - ["warnings", "ignored_warnings", "scan_info", "errors", "obsolete"]).empty?
   end
 
   def test_for_scan_info_keys
@@ -35,6 +35,10 @@ class JSONOutputTests < Minitest::Test
 
   def test_for_errors
     assert @@json["errors"].is_a? Array
+  end
+
+  def test_for_obsolete
+    assert_equal ["abcdef01234567890ba28050e7faf1d54f218dfa9435c3f65f47cb378c18cf98"], @@json["obsolete"]
   end
 
   def test_paths

--- a/test/tests/report_generation.rb
+++ b/test/tests/report_generation.rb
@@ -2,7 +2,7 @@ require 'json'
 
 class TestReportGeneration < Minitest::Test
   def setup
-    @@tracker||= Brakeman.run(:app_path => "#{TEST_PATH}/apps/rails3.2", :quiet => true, :report_routes => true)
+    @@tracker||= Brakeman.run(:app_path => "#{TEST_PATH}/apps/rails4", :quiet => true, :report_routes => true)
     @@report ||= @@tracker.report
   end
 
@@ -47,6 +47,13 @@ class TestReportGeneration < Minitest::Test
     assert_nothing_raised do
       Brakeman.run(:app_path => "#{TEST_PATH}/apps/rails4_non_standard_structure", :quiet => true, :report_routes => true).report.to_csv
     end
+  end
+
+  def test_obsolete_reporting
+    report = @@report.to_s
+
+    assert report.include? "+Obsolete Ignore Entries+"
+    assert report.include? "abcdef01234567890ba28050e7faf1d54f218dfa9435c3f65f47cb378c18cf98"
   end
 
   def test_tabs_sanity


### PR DESCRIPTION
@presidentbeef - re https://github.com/presidentbeef/brakeman/issues/893

wasn't too sure about the tests... wanted to spike on this to assess our own situation,  figured it might help give you some inspiration, feel free to disregard, tear it apart, whateva :)

Outputs something like:

```
+SUMMARY+

+-------------------+-------+
| Scanned/Reported  | Total |
+-------------------+-------+
| Controllers       | 123   |
| Models            | 321   |
| Templates         | 234   |
| Errors            | 1     |
| Security Warnings | 0 (0) |
| Ignored Warnings  | 128   |
+-------------------+-------+


+Obsolete Ignore Entries+
+------------------------------------------------------------------+
| fingerprint                                                      |
+------------------------------------------------------------------+
| 26e7d2ae32aad50f0daaff757412b46619b99345533eb156a175c0b3734713d0 |
| 3d7db177b95dd7ab42bb830fd340638a26950f6cd98677735cc0eb3793ad3ecb |
| b2d8456d8bfe5d3c5e945ce92a8eb474af5f20e62af48bd1fd2468aeca8b66f2 |
| c9af0ab4e9fa302ac14cc32b4ba8b63a75d5c6559ecca9cfd2d081c87086d816 |
| ed8407625864e4fce50f5754b1322cf1d873da8f7cd79dfc0b9dd6e3f985b389 |
| ff2b76e22c9fd2bc3930f9a935124b9ed9f6ea710bbb5bc7c51505d70ca0f2d5 |
+------------------------------------------------------------------+

+Errors+
etc.
```
