### PR TITLE
Return value improvements

### DIFF
--- a/lib/brakeman/processors/lib/find_return_value.rb
+++ b/lib/brakeman/processors/lib/find_return_value.rb
@@ -97,7 +97,7 @@ class Brakeman::FindReturnValue
           true_branch or false_branch
         end
       end
-    when :lasgn, :iasgn, :op_asgn_or
+    when :lasgn, :iasgn, :op_asgn_or, :attrasgn
       last_value exp.rhs
     when :rescue
       values = []

--- a/lib/brakeman/processors/lib/find_return_value.rb
+++ b/lib/brakeman/processors/lib/find_return_value.rb
@@ -65,7 +65,7 @@ class Brakeman::FindReturnValue
       @uses_ivars = true if node_type? current, :ivar
 
       if node_type? current, :return
-        @return_values << current.value unless current.value.nil?
+        @return_values << last_value(current.value) unless current.length < 2
       elsif sexp? current
         todo = current[1..-1].concat todo
       end
@@ -100,7 +100,11 @@ class Brakeman::FindReturnValue
     when :lasgn, :iasgn, :op_asgn_or
       last_value exp.rhs
     when :return
-      exp.value
+      if exp.length > 1
+        last_value exp.value
+      else
+        nil
+      end
     else
       exp.original_line = exp.line unless exp.original_line
       exp

--- a/lib/brakeman/processors/lib/find_return_value.rb
+++ b/lib/brakeman/processors/lib/find_return_value.rb
@@ -97,8 +97,8 @@ class Brakeman::FindReturnValue
           true_branch or false_branch
         end
       end
-    when :lasgn, :iasgn
-      exp.rhs
+    when :lasgn, :iasgn, :op_asgn_or
+      last_value exp.rhs
     when :return
       exp.value
     else

--- a/lib/brakeman/processors/lib/find_return_value.rb
+++ b/lib/brakeman/processors/lib/find_return_value.rb
@@ -129,6 +129,8 @@ class Brakeman::FindReturnValue
       else
         nil
       end
+    when :nil
+      nil
     else
       exp.original_line = exp.line unless exp.original_line
       exp

--- a/lib/brakeman/processors/lib/find_return_value.rb
+++ b/lib/brakeman/processors/lib/find_return_value.rb
@@ -65,7 +65,7 @@ class Brakeman::FindReturnValue
       @uses_ivars = true if node_type? current, :ivar
 
       if node_type? current, :return
-        @return_values << last_value(current.value) unless current.length < 2
+        @return_values << last_value(current.value) if current.value
       elsif sexp? current
         todo = current[1..-1].concat todo
       end
@@ -100,7 +100,7 @@ class Brakeman::FindReturnValue
     when :lasgn, :iasgn, :op_asgn_or
       last_value exp.rhs
     when :return
-      if exp.length > 1
+      if exp.value
         last_value exp.value
       else
         nil

--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -3,7 +3,7 @@
 #of a Sexp.
 class Sexp
   attr_accessor :original_line, :or_depth
-  ASSIGNMENT_BOOL = [:gasgn, :iasgn, :lasgn, :cvdecl, :cvasgn, :cdecl, :or, :and, :colon2]
+  ASSIGNMENT_BOOL = [:gasgn, :iasgn, :lasgn, :cvdecl, :cvasgn, :cdecl, :or, :and, :colon2, :op_asgn_or]
 
   def method_missing name, *args
     #Brakeman does not use this functionality,

--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -51,7 +51,7 @@ class Sexp
 
   def value
     raise WrongSexpError, "Sexp#value called on multi-item Sexp", caller[1..-1] if size > 2
-    last
+    self[1]
   end
 
   def value= exp

--- a/test/tests/find_return_value.rb
+++ b/test/tests/find_return_value.rb
@@ -132,4 +132,20 @@ class FindReturnValueTests < Test::Unit::TestCase
       end
     RUBY
   end
+
+  def test_or_asgn_value
+    assert_returns "1", <<-RUBY
+      def x
+        @x ||= 1
+      end
+    RUBY
+  end
+
+  def test_return_value_value
+    assert_returns "1", <<-RUBY
+      def x
+        return (@y = 1)
+      end
+    RUBY
+  end
 end

--- a/test/tests/find_return_value.rb
+++ b/test/tests/find_return_value.rb
@@ -160,6 +160,7 @@ class FindReturnValueTests < Test::Unit::TestCase
   def test_return_begin_value
     assert_returns '(blah1 or blah2) or blah4', <<-RUBY
       def x
+        return nil if stuff
         begin
           doing_some_stuff
           blah1

--- a/test/tests/find_return_value.rb
+++ b/test/tests/find_return_value.rb
@@ -148,4 +148,23 @@ class FindReturnValueTests < Test::Unit::TestCase
       end
     RUBY
   end
+
+  def test_return_begin_value
+    assert_returns '(blah1 or blah2) or blah4', <<-RUBY
+      def x
+        begin
+          doing_some_stuff
+          blah1
+        rescue Thing
+          blah2
+        rescue That
+          blah3
+          blah4
+        rescue Stuff
+          nil
+        rescue
+        end
+      end
+    RUBY
+  end
 end

--- a/test/tests/find_return_value.rb
+++ b/test/tests/find_return_value.rb
@@ -149,6 +149,14 @@ class FindReturnValueTests < Test::Unit::TestCase
     RUBY
   end
 
+  def test_return_value_attrasgn
+    assert_returns "1", <<-RUBY
+      def x
+        return (y[:x] = 1)
+      end
+    RUBY
+  end
+
   def test_return_begin_value
     assert_returns '(blah1 or blah2) or blah4', <<-RUBY
       def x

--- a/test/tests/sexp.rb
+++ b/test/tests/sexp.rb
@@ -389,4 +389,12 @@ class SexpTests < Test::Unit::TestCase
     s << s
     assert_equal "s(:s, s(...))", s.inspect
   end
+
+  def test_value
+    assert_equal 1, s(:lit, 1).value
+    assert_nil s(:blah).value
+    assert_raises do
+      s(:blah, 1, 2).value
+    end
+  end
 end


### PR DESCRIPTION
For methods like

```ruby
def x
  @x ||= blah
end
```
Brakeman will now treat the return value as `blah` and not `@x ||= blah`.

Also explicit returns will be processed the same as implicit to get at the best "real" return value.