### PR TITLE
Avoid warning about hashes in `link_to` hrefs

### DIFF
--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -45,7 +45,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     if input = has_immediate_user_input?(url_arg)
       message = "Unsafe #{friendly_type_of input} in link_to href"
 
-      unless duplicate? result
+      unless duplicate? result or call_on_params? url_arg
         add_result result
         warn :result => result,
           :warning_type => "Cross Site Scripting", 
@@ -74,7 +74,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     elsif @matched
       if @matched.type == :model and not tracker.options[:ignore_model_output]
         message = "Unsafe model attribute in link_to href"
-      elsif @matched.type == :params
+      elsif @matched.type == :params and not call_on_params? @matched.match
         message = "Unsafe parameter value in link_to href"
       end
 
@@ -111,5 +111,11 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
 
     MODEL_METHODS.include? exp.method or
       exp.method.to_s =~ /^find_by_/
+  end
+
+  def call_on_params? exp
+    call? exp and
+    params? exp.target and
+    exp.method != :[]
   end
 end

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -17,7 +17,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
                            :hidden_field, :hidden_field_tag, :image_tag, :label,
                            :mail_to, :polymorphic_url, :radio_button, :select, :slice,
                            :submit_tag, :text_area, :text_field,
-                           :text_field_tag, :url_encode, :u, :url_for,
+                           :text_field_tag, :url_encode, :u,
                            :will_paginate].merge(tracker.options[:url_safe_methods] || [])
 
     @models = tracker.models.keys
@@ -35,6 +35,10 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     call = result[:call] = result[:call].dup
     @matched = false
     url_arg = process call.second_arg
+
+    if call? url_arg and url_arg.method == :url_for
+      url_arg = url_arg.first_arg
+    end
 
     #Ignore situations where the href is an interpolated string
     #with something before the user input

--- a/test/apps/rails5/app/views/users/show.html.erb
+++ b/test/apps/rails5/app/views/users/show.html.erb
@@ -4,3 +4,4 @@
 <%= link_to 'Back', users_path %>
 
 <%= link_to("good", params.merge(:page => 2)) %>
+<%= link_to("xss", url_for(params[:bad])) %>

--- a/test/apps/rails5/app/views/users/show.html.erb
+++ b/test/apps/rails5/app/views/users/show.html.erb
@@ -2,3 +2,5 @@
 
 <%= link_to 'Edit', edit_user_path(@user) %> |
 <%= link_to 'Back', users_path %>
+
+<%= link_to("good", params.merge(:page => 2)) %>

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -12,7 +12,7 @@ class Rails5Tests < Test::Unit::TestCase
     @@expected ||= {
       :controller => 0,
       :model => 0,
-      :template => 3,
+      :template => 4,
       :generic => 8
     }
   end
@@ -168,6 +168,19 @@ class Rails5Tests < Test::Unit::TestCase
       :relative_path => "app/views/users/show.html.erb",
       :code => s(:call, nil, :link_to, s(:str, "good"), s(:call, s(:call, nil, :params), :merge, s(:hash, s(:lit, :page), s(:lit, 2)))),
       :user_input => s(:call, s(:call, nil, :params), :merge, s(:hash, s(:lit, :page), s(:lit, 2)))
+  end
+
+  def test_cross_site_scripting_link_to_url_for
+    assert_warning :type => :template,
+      :warning_code => 4,
+      :fingerprint => "03fcddff701f15c976a229c2a814c817f81463b733c6d4925253488879d907e3",
+      :warning_type => "Cross Site Scripting",
+      :line => 7,
+      :message => /^Unsafe\ parameter\ value\ in\ link_to\ href/,
+      :confidence => 0,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, "xss"), s(:call, nil, :url_for, s(:call, s(:params), :[], s(:lit, :bad)))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :bad))
   end
 
   def test_if_expression_in_templates

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -157,6 +157,19 @@ class Rails5Tests < Test::Unit::TestCase
       :user_input => s(:call, s(:params), :slice, s(:lit, :url))
   end
 
+  def test_cross_site_scripting_with_merge_in_link_to
+    assert_no_warning :type => :template,
+      :warning_code => 4,
+      :fingerprint => "54043efc2da20930f636dedfef5b1e77dfed0957ebb0c285f0c0a71b68e046c5",
+      :warning_type => "Cross Site Scripting",
+      :line => 6,
+      :message => /^Unsafe\ parameter\ value\ in\ link_to\ href/,
+      :confidence => 0,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, "good"), s(:call, s(:call, nil, :params), :merge, s(:hash, s(:lit, :page), s(:lit, 2)))),
+      :user_input => s(:call, s(:call, nil, :params), :merge, s(:hash, s(:lit, :page), s(:lit, 2)))
+  end
+
   def test_if_expression_in_templates
     assert_warning :type => :template,
       :warning_code => 2,


### PR DESCRIPTION
and also check argument to `url_for` if used in `link_to`.