### PR TITLE
Provide the location brakeman attempted to scan when no app is found.

### DIFF
--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -23,7 +23,7 @@ class Brakeman::Scanner
     @app_tree = Brakeman::AppTree.from_options(options)
 
     if (!@app_tree.root || !@app_tree.exists?("app")) && !options[:force_scan]
-      raise Brakeman::NoApplication, "Please supply the path to a Rails application."
+      raise Brakeman::NoApplication, "Please supply the path to a Rails application (looking in #{@app_tree.root})."
     end
 
     @processor = processor || Brakeman::Processor.new(@app_tree, options)


### PR DESCRIPTION
This is less useful for CLI users, but when integrating brakeman into things it would be useful to know where brakeman tried to look. 

/cc @presidentbeef 