### PR TITLE
Add support for in-file-comment whitelisting.

### DIFF
--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -277,6 +277,10 @@ module Brakeman::Options
           options[:show_version] = true
         end
 
+        opts.on "--ignore-file-only", "Do not generate report, only update ignore file." do
+          options[:ignore_file_only] = true
+        end
+
         opts.on "--force-scan", "Scan application even if rails is not detected" do
           options[:force_scan] = true
         end

--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -103,8 +103,13 @@ module Brakeman
         w
       end.sort_by { |w| w[:fingerprint] }
 
+      # For each white listed entry, we check if it's already in the ignored list, if not,
+      # we write them out.
+      @total_ignored ||= @already_ignored
+      warnings.reject! { |r| @ignored_fingerprints.include? r[:fingerprint] }
+      @total_ignored += warnings
       output = {
-        :ignored_warnings => warnings,
+        :ignored_warnings => @total_ignored,
         :updated => Time.now.to_s,
         :brakeman_version => Brakeman::Version
       }
@@ -112,11 +117,12 @@ module Brakeman
       File.open file, "w" do |f|
         f.puts JSON.pretty_generate(output)
       end
+
     end
 
     # Save old ignored warnings and newly ignored ones
-    def save_with_old
-      warnings = @ignored_warnings.dup
+    def save_with_old warning = nil, changed = false
+      warnings = warning || @ignored_warnings.dup
 
       # Only add ignored warnings not already ignored
       @already_ignored.each do |w|
@@ -127,7 +133,7 @@ module Brakeman
         end
       end
 
-      if @changed
+      if @changed or changed
         save_to_file warnings
       end
     end

--- a/lib/brakeman/report/report_base.rb
+++ b/lib/brakeman/report/report_base.rb
@@ -83,7 +83,7 @@ class Brakeman::Report::Base
     render_warnings generic_warnings,
                     :warning,
                     'security_warnings',
-                    ["Confidence", "Class", "Method", "Warning Type", "Message"],
+                    ["Confidence", "Class", "Method", "Warning Type", "Message", 'Fingerprint'],
                     'Class'
   end
 
@@ -92,7 +92,7 @@ class Brakeman::Report::Base
     render_warnings template_warnings,
                     :template,
                     'view_warnings',
-                    ['Confidence', 'Template', 'Warning Type', 'Message'],
+                    ['Confidence', 'Template', 'Warning Type', 'Message', 'Fingerprint'],
                     'Template'
 
   end
@@ -102,7 +102,7 @@ class Brakeman::Report::Base
     render_warnings model_warnings,
                     :model,
                     'model_warnings',
-                    ['Confidence', 'Model', 'Warning Type', 'Message'],
+                    ['Confidence', 'Model', 'Warning Type', 'Message', 'Fingerprint'],
                     'Model'
   end
 
@@ -111,7 +111,7 @@ class Brakeman::Report::Base
     render_warnings controller_warnings,
                     :controller,
                     'controller_warnings',
-                    ['Confidence', 'Controller', 'Warning Type', 'Message'],
+                    ['Confidence', 'Controller', 'Warning Type', 'Message', 'Fingerprint'],
                     'Controller'
   end
 
@@ -119,13 +119,14 @@ class Brakeman::Report::Base
     render_warnings ignored_warnings,
                     :ignored,
                     'ignored_warnings',
-                    ['Confidence', 'Warning Type', 'File', 'Message'],
+                    ['Confidence', 'Warning Type', 'File', 'Message', 'Fingerprint'],
                     'Warning Type'
   end
 
   def render_warnings warnings, type, template, cols, sort_col
     unless warnings.empty?
       rows = sort(convert_to_rows(warnings, type), sort_col)
+      return "" if @tracker.options[:ignore_file_only]
 
       values = rows.collect { |row| row.values_at(*cols) }
 
@@ -159,6 +160,7 @@ class Brakeman::Report::Base
   def convert_warning warning, original
     warning["Confidence"] = TEXT_CONFIDENCE[warning["Confidence"]]
     warning["Message"] = text_message original, warning["Message"]
+    return [] if warning["Message"].nil?
     warning
   end
 

--- a/lib/brakeman/report/templates/controller_warnings.html.erb
+++ b/lib/brakeman/report/templates/controller_warnings.html.erb
@@ -6,6 +6,7 @@
       <th>Controller</th>
       <th>Warning Type</th>
       <th>Message</th>
+      <th>Finger-print</td>
     </tr>
   </thead>
   <tbody>
@@ -15,6 +16,7 @@
       <td><%= warning['Controller']%></td>
       <td><%= warning['Warning Type']%></td>
       <td><%= warning['Message']%></td>
+      <td><%= warning['Fingerprint']%></td>
     </tr>
   <% end %>
   </tbody>

--- a/lib/brakeman/report/templates/model_warnings.html.erb
+++ b/lib/brakeman/report/templates/model_warnings.html.erb
@@ -6,6 +6,7 @@
       <th>Model</th>
       <th>Warning Type</th>
       <th>Message</th>
+      <th>Finger-print</th>
     </tr>
   </thead>
   <tbody>
@@ -15,6 +16,7 @@
       <td><%= warning['Model']%></td>
       <td><%= warning['Warning Type']%></td>
       <td><%= warning['Message']%></td>
+      <td><%= warning['Fingerprint']%></td>
     </tr>
   <% end %>
   </tbody>

--- a/lib/brakeman/report/templates/security_warnings.html.erb
+++ b/lib/brakeman/report/templates/security_warnings.html.erb
@@ -7,6 +7,7 @@
       <th>Method</th>
       <th>Warning Type</th>
       <th>Message</th>
+      <th>Finger-print</td>
     </tr>
   </thead>
   <tbody>
@@ -17,6 +18,7 @@
       <td><%= warning['Method']%></td>
       <td><%= warning['Warning Type']%></td>
       <td><%= warning['Message']%></td>
+      <td><%= warning['Fingerprint']%></td>
     </tr>
   <% end %>
   </tbody>

--- a/lib/brakeman/report/templates/view_warnings.html.erb
+++ b/lib/brakeman/report/templates/view_warnings.html.erb
@@ -6,6 +6,7 @@
       <th>Template</th>
       <th>Warning Type</th>
       <th>Message</th>
+      <th>Finger-print</td>
     </tr>
   </thead>
   <tbody>
@@ -28,6 +29,7 @@
       </td>
       <td><%= warning['Warning Type']%></td>
       <td><%= warning['Message']%></td>
+      <td><%= warning['Fingerprint']%></td>
     </tr>
   <% end %>
   </tbody>

--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -172,7 +172,8 @@ class Brakeman::Warning
   def to_row type = :warning
     @row = { "Confidence" => self.confidence,
       "Warning Type" => self.warning_type.to_s,
-      "Message" => self.format_message }
+      "Message" => self.format_message,
+      "Fingerprint" => self.fingerprint }
 
     case type
     when :template

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -22,7 +22,8 @@ class BrakemanOptionsTest < Minitest::Test
     :install_rake_task      => "--rake",
     :show_version           => "-v",
     :show_help              => "-h",
-    :force_scan             => "--force-scan"
+    :force_scan             => "--force-scan",
+    :ignore_file_only       => "--ignore-file-only",
   }
 
   ALT_OPTION_INPUTS = {


### PR DESCRIPTION
The downside of the -I option for interactive warning white-listing is that the ignore file can get big and out of date, also the reason for whitelisting is not easy to parse. This pull request addresses these issues, but of course add some other downsides.

Ideal use case:
You get a brakeman report with some warnings you'd like to fix, you fix them then add "Brakeman safe: #{fingerprint}: #{note}" within 5 lines of the warning (top and bottom). Run the brakeman like:

brakeman -o report.html -i config/brakeman.ignore --ignore-file-only
// 1. has to use .html report format to trigger the scanning for the flag (the commenting line)
// 2. --ignore-file-only: to speed things up, optional.

The .ignore file will be updated, including the note.

You push the code change and/or the ignore file. You or someone else pull the change, and sees the comments and realizes that warning line has been whitelisted.

Downside:
Could not find a easy way to tease out the context scanning functionality of the html report, so basically the brakeman has to run twice: once to fill the .ignore file, another time to take in the ignore file.

Tests:
Minimal.

Documentation:
Minimal.

Please advise.