### PR TITLE
Fix gem building for Code Climate engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Justin Collins
 WORKDIR /usr/src/app
 COPY Gemfile* /usr/src/app/
 COPY brakeman.gemspec /usr/src/app/
+COPY gem_common.rb /usr/src/app/
 COPY lib/brakeman/version.rb /usr/src/app/lib/brakeman/
 
 RUN apt-get update && \


### PR DESCRIPTION
The gemspec was refactored a bit with the `3.3.1` release and that broke the Docker configuration.

I think this fixes it, although Docker is broken on my machine so at the moment I can only confirm the engine builds successfully.

/cc @GordonDiggs 