### PR TITLE
Add option to prune ignore file with -I

### DIFF
--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -82,6 +82,17 @@ module Brakeman
       (@ignored_fingerprints - @used_fingerprints).to_a
     end
 
+    def prune_obsolete
+      obsolete = obsolete_fingerprints.to_set
+      @ignored_fingerprints -= obsolete
+
+      @already_ignored.reject! do |w|
+        if obsolete.include? w[:fingerprint]
+          @changed = true
+        end
+      end
+    end
+
     # Read configuration to file
     def read_from_file file = @file
       if File.exist? file

--- a/lib/brakeman/report/ignore/interactive.rb
+++ b/lib/brakeman/report/ignore/interactive.rb
@@ -19,6 +19,7 @@ module Brakeman
       @ignore_config.filter_ignored
 
       unless @quit
+        penultimate_menu
         final_menu
       end
 
@@ -65,6 +66,10 @@ module Brakeman
           process_warnings
         end
 
+        m.choice "Prune obsolete ignored warnings" do
+          prune_obsolete
+        end
+
         m.choice "Skip - use current ignore configuration" do
           @quit = true
           @ignore_config.filter_ignored
@@ -101,6 +106,36 @@ q - Quit, do not update ignored warnings
           "?"
         end
       end
+    end
+
+    def penultimate_menu
+      obsolete = @ignore_config.obsolete_fingerprints
+      return unless obsolete.any?
+
+      if obsolete.length > 1
+        plural = 's'
+        verb = 'are'
+      else
+        plural = ''
+        verb = 'is'
+      end
+
+      say "\n#{obsolete.length} fingerprint#{plural} #{verb} unused:", :green
+      obsolete.each do |obs|
+        say obs
+      end
+
+      if yes_or_no "\nRemove fingerprint#{plural}?"
+        @ignore_config.prune_obsolete
+      end
+    end
+
+    def prune_obsolete
+      @ignore_config.filter_ignored
+      obsolete = @ignore_config.obsolete_fingerprints
+      @ignore_config.prune_obsolete
+
+      say "Removed #{obsolete.length} obsolete fingerprint#{'s' if obsolete.length > 1} from ignore config.", :yellow
     end
 
     def final_menu


### PR DESCRIPTION
When running with `-I`, adds option to prune ignore entries that do not match warnings in the current report.

There is an option to just prune:
![image](https://cloud.githubusercontent.com/assets/75613/18257206/f9631f9a-7374-11e6-92bc-94b9d3a635f4.png)

Otherwise, a report with obsolete entries will show this option after going through the warnings:
![image](https://cloud.githubusercontent.com/assets/75613/18257236/6868e726-7375-11e6-8a5b-30b6baed093a.png)

(My terminal shows purple, but by default the text would be yellow.)
