### PR TITLE
Fix `link_to` href warnings if not at beginning of string

### DIFF
--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -1,14 +1,14 @@
 require 'brakeman/checks/check_cross_site_scripting'
 
 #Checks for calls to link_to which pass in potentially hazardous data
-#to the second argument.  While this argument must be html_safe to not break 
-#the html, it must also be url safe as determined by calling a 
-#:url_safe_method.  This prevents attacks such as javascript:evil() or 
+#to the second argument.  While this argument must be html_safe to not break
+#the html, it must also be url safe as determined by calling a
+#:url_safe_method.  This prevents attacks such as javascript:evil() or
 #data:<encoded XSS> which is html_safe, but not safe as an href
 #Props to Nick Green for the idea.
 class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
   Brakeman::Checks.add self
-                        
+
   @description = "Checks to see if values used for hrefs are sanitized using a :url_safe_method to protect against javascript:/data: XSS"
 
   def run_check
@@ -23,7 +23,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     @models = tracker.models.keys
     @inspect_arguments = tracker.options[:check_arguments]
 
-    methods = tracker.find_call :target => false, :method => :link_to 
+    methods = tracker.find_call :target => false, :method => :link_to
     methods.each do |call|
       process_result call
     end
@@ -48,7 +48,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
       unless duplicate? result or call_on_params? url_arg or ignore_interpolation? url_arg, input.match
         add_result result
         warn :result => result,
-          :warning_type => "Cross Site Scripting", 
+          :warning_type => "Cross Site Scripting",
           :warning_code => :xss_link_to_href,
           :message => message,
           :user_input => input,
@@ -57,19 +57,19 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
       end
     elsif has_immediate_model? url_arg or model_find_call? url_arg
 
-      # Decided NOT warn on models.  polymorphic_path is called it a model is 
+      # Decided NOT warn on models.  polymorphic_path is called it a model is
       # passed to link_to (which passes it to url_for)
 
     elsif array? url_arg
-      # Just like models, polymorphic path/url is called if the argument is 
-      # an array      
+      # Just like models, polymorphic path/url is called if the argument is
+      # an array
 
     elsif hash? url_arg
 
       # url_for uses the key/values pretty carefully and I don't see a risk.
       # IF you have default routes AND you accept user input for :controller
-      # and :only_path, then MAYBE you could trigger a javascript:/data: 
-      # attack. 
+      # and :only_path, then MAYBE you could trigger a javascript:/data:
+      # attack.
 
     elsif @matched
       if @matched.type == :model and not tracker.options[:ignore_model_output]
@@ -80,8 +80,8 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
 
       if message and not duplicate? result and not ignore_interpolation? url_arg, @matched.match
         add_result result
-        warn :result => result, 
-          :warning_type => "Cross Site Scripting", 
+        warn :result => result,
+          :warning_type => "Cross Site Scripting",
           :warning_code => :xss_link_to_href,
           :message => message,
           :user_input => @matched,

--- a/test/apps/rails5/app/views/widget/show.html.erb
+++ b/test/apps/rails5/app/views/widget/show.html.erb
@@ -1,1 +1,4 @@
 <%= params[:x].html_safe unless this_is_a_bad_idea? %>
+
+<%= link_to("Thing", "#{ENV['SOME_URL']}#{params[:x]}") %>
+<%= link_to("Email!", "mailto:#{params[:x]}") %>

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -359,4 +359,28 @@ class Rails5Tests < Minitest::Test
       :relative_path => "app/models/user.rb",
       :user_input => s(:params)
   end
+
+  def test_link_to_href_safe_interpolation
+    assert_no_warning :type => :template,
+      :warning_code => 4,
+      :fingerprint => "840e79fc7cc526a9e744b8a3d49f6689aa572941f46b030d14cdec01f3675a4a",
+      :warning_type => "Cross Site Scripting",
+      :line => 3,
+      :message => /^Unsafe\ parameter\ value\ in\ link_to\ href/,
+      :confidence => 0,
+      :relative_path => "app/views/widget/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, "Thing"), s(:dstr, "", s(:evstr, s(:call, s(:const, :ENV), :[], s(:str, "SOME_URL"))), s(:evstr, s(:call, s(:params), :[], s(:lit, :x))))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :x))
+
+    assert_no_warning :type => :template,
+      :warning_code => 4,
+      :fingerprint => "ea91f7cfb339ae9522f00fb1f3bc176f789110b6e0cbc4f8704e95d0999b0e71",
+      :warning_type => "Cross Site Scripting",
+      :line => 4,
+      :message => /^Unsafe\ parameter\ value\ in\ link_to\ href/,
+      :confidence => 0,
+      :relative_path => "app/views/widget/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, "Email!"), s(:dstr, "mailto:", s(:evstr, s(:call, s(:params), :[], s(:lit, :x))))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :x))
+  end
 end


### PR DESCRIPTION
There was already code to do this, but it did not work if the first thing in the interpolated string was an interpolated value, like `"#{x}#{params[:y]}"`