### PR TITLE
Attempt to get and use Ruby version from app

### DIFF
--- a/lib/brakeman/checks/check_symbol_dos.rb
+++ b/lib/brakeman/checks/check_symbol_dos.rb
@@ -9,6 +9,7 @@ class Brakeman::CheckSymbolDoS < Brakeman::BaseCheck
 
   def run_check
     return if rails_version and rails_version >= "5.0.0"
+    return if tracker.config.ruby_version >= "2.2"
 
     tracker.find_call(:methods => UNSAFE_METHODS, :nested => true).each do |result|
       check_unsafe_symbol_creation(result)

--- a/lib/brakeman/processors/gem_processor.rb
+++ b/lib/brakeman/processors/gem_processor.rb
@@ -21,19 +21,26 @@ class Brakeman::GemProcessor < Brakeman::BasicProcessor
   end
 
   def process_call exp
-    if exp.target == nil and exp.method == :gem
-      gem_name = exp.first_arg
-      return exp unless string? gem_name
+    if exp.target == nil
+      if exp.method == :gem
+        gem_name = exp.first_arg
+        return exp unless string? gem_name
 
-      gem_version = exp.second_arg
+        gem_version = exp.second_arg
 
-      version = if string? gem_version
-                  gem_version.value
-                else
-                  nil
-                end
+        version = if string? gem_version
+                    gem_version.value
+                  else
+                    nil
+                  end
 
-      @tracker.config.add_gem gem_name.value, version, @gemfile, exp.line
+        @tracker.config.add_gem gem_name.value, version, @gemfile, exp.line
+      elsif exp.method == :ruby
+        version = exp.first_arg
+        if string? version
+          @tracker.config.set_ruby_version version.value
+        end
+      end
     end
 
     exp

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -108,6 +108,10 @@ class Brakeman::Scanner
       tracker.config.escape_html = true
       Brakeman.notify "[Notice] Escaping HTML by default"
     end
+
+    if @app_tree.exists? ".ruby-version"
+      tracker.config.set_ruby_version @app_tree.read ".ruby-version"
+    end
   end
 
   def process_config_file file

--- a/lib/brakeman/tracker/config.rb
+++ b/lib/brakeman/tracker/config.rb
@@ -5,7 +5,7 @@ module Brakeman
     include Util
 
     attr_reader :rails, :tracker
-    attr_accessor :rails_version
+    attr_accessor :rails_version, :ruby_version
     attr_writer :erubis, :escape_html
     attr_reader :gems
 
@@ -16,6 +16,7 @@ module Brakeman
       @settings = {}
       @escape_html = nil
       @erubis = nil
+      @ruby_version = ""
     end
 
     def allow_forgery_protection?
@@ -89,6 +90,14 @@ module Brakeman
       if get_gem :rails_xss
         @escape_html = true
         Brakeman.notify "[Notice] Escaping HTML by default"
+      end
+    end
+
+    def set_ruby_version version
+      return unless version.is_a? String
+
+      if version =~ /(\d+\.\d+\.\d+)/
+        self.ruby_version = $1
       end
     end
 


### PR DESCRIPTION
either `.ruby-version` or `Gemfile`

Use to disable Symbol DoS check.

Closes #928

(Note that Brakeman does not assume the Ruby version used to *run* Brakeman is the same used to run the application being scanned.)