### PR TITLE
Add support for configurable engines path (updated)

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -146,7 +146,8 @@ module Brakeman
       :relative_path => false,
       :report_progress => true,
       :html_style => "#{File.expand_path(File.dirname(__FILE__))}/brakeman/format/style.css",
-      :output_color => true
+      :output_color => true,
+      :engines_path => ["engines/*"]
     }
   end
 

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -147,7 +147,7 @@ module Brakeman
       :report_progress => true,
       :html_style => "#{File.expand_path(File.dirname(__FILE__))}/brakeman/format/style.css",
       :output_color => true,
-      :engines_path => ["engines/*"]
+      :engine_paths => ["engines/*"]
     }
   end
 

--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -129,9 +129,7 @@ module Brakeman
     end
 
     def glob_files(directory, name, extensions = ".rb")
-      abs_engines = @absolute_engines_path.to_a.join(",")
-      rel_engines = @relative_engines_path.empty? ? "" : "{#{@relative_engines_path.to_a.join("/,")},}/"
-      pattern = "{#{@root},#{abs_engines}}" + "/#{rel_engines}#{directory}/**/#{name}#{extensions}"
+      pattern = "#{root_search_pattern}#{directory}/**/#{name}#{extensions}"
 
       Dir.glob(pattern)
     end
@@ -168,6 +166,16 @@ module Brakeman
       )
 
       files.match(project_relative_path)
+    end
+
+    def root_search_pattern
+      return @root_search_pattern if @root_search_pattern
+      abs = @absolute_engines_path.to_a.map { |path| path.gsub /#{File::SEPARATOR}+$/, '' }
+      rel = @relative_engines_path.to_a.map { |path| path.gsub /#{File::SEPARATOR}+$/, '' }
+
+      roots = ([@root] + abs).join(",")
+      rel_engines = (rel + [""]).join("/,")
+      @root_search_patrern = "{#{roots}}/{#{rel_engines}}"
     end
   end
 end

--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -19,7 +19,7 @@ module Brakeman
         init_options[:only_files] = regex_for_paths(options[:only_files])
       end
       init_options[:additional_libs_path] = options[:additional_libs_path]
-      init_options[:engines_path] = options[:engines_path]
+      init_options[:engine_paths] = options[:engine_paths]
       new(root, init_options)
     end
 
@@ -58,9 +58,9 @@ module Brakeman
       @skip_files = init_options[:skip_files]
       @only_files = init_options[:only_files]
       @additional_libs_path = init_options[:additional_libs_path] || []
-      @engines_path = init_options[:engines_path] || []
-      @absolute_engines_path = @engines_path.select { |path| path.start_with?(File::SEPARATOR) }
-      @relative_engines_path = @engines_path - @absolute_engines_path
+      @engine_paths = init_options[:engine_paths] || []
+      @absolute_engine_paths = @engine_paths.select { |path| path.start_with?(File::SEPARATOR) }
+      @relative_engine_paths = @engine_paths - @absolute_engine_paths
     end
 
     def expand_path(path)
@@ -170,8 +170,8 @@ module Brakeman
 
     def root_search_pattern
       return @root_search_pattern if @root_search_pattern
-      abs = @absolute_engines_path.to_a.map { |path| path.gsub /#{File::SEPARATOR}+$/, '' }
-      rel = @relative_engines_path.to_a.map { |path| path.gsub /#{File::SEPARATOR}+$/, '' }
+      abs = @absolute_engine_paths.to_a.map { |path| path.gsub /#{File::SEPARATOR}+$/, '' }
+      rel = @relative_engine_paths.to_a.map { |path| path.gsub /#{File::SEPARATOR}+$/, '' }
 
       roots = ([@root] + abs).join(",")
       rel_engines = (rel + [""]).join("/,")

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -136,6 +136,11 @@ module Brakeman::Options
           options[:additional_libs_path].merge paths
         end
 
+        opts.on "--add-engines-path path1,path2,etc", Array, "Include these engines in the scan" do |paths|
+          options[:engine_paths] ||= Set.new
+          options[:engine_paths].merge paths
+        end
+
         opts.on "-t", "--test Check1,Check2,etc", Array, "Only run the specified checks" do |checks|
           checks.each_with_index do |s, index|
             if s[0,5] != "Check"
@@ -287,11 +292,6 @@ module Brakeman::Options
 
         opts.on_tail "-h", "--help", "Display this message" do
           options[:show_help] = true
-        end
-
-        opts.on "--engines path1,path2,etc", Array, "Include these engines in the scan." do |paths|
-          options[:engines_path] ||= Set.new
-          options[:engines_path].merge paths
         end
       end
 

--- a/test/apps/rails4_with_engines/alt_engines/admin_stuff/app/controllers/admin_controller.rb
+++ b/test/apps/rails4_with_engines/alt_engines/admin_stuff/app/controllers/admin_controller.rb
@@ -1,0 +1,5 @@
+class AdminController < ApplicationController
+  def debug
+    params[:class].classify.constantize.send(params[:meth])
+  end
+end

--- a/test/apps/rails4_with_engines/alt_engines/admin_stuff/app/helpers/application_helper.rb
+++ b/test/apps/rails4_with_engines/alt_engines/admin_stuff/app/helpers/application_helper.rb
@@ -1,0 +1,2 @@
+module ApplicationHelper
+end

--- a/test/apps/rails4_with_engines/alt_engines/admin_stuff/app/views/admin/debug.html.erb
+++ b/test/apps/rails4_with_engines/alt_engines/admin_stuff/app/views/admin/debug.html.erb
@@ -1,0 +1,1 @@
+<%= raw params[:debug] %>

--- a/test/apps/rails4_with_engines/config/brakeman.yml
+++ b/test/apps/rails4_with_engines/config/brakeman.yml
@@ -1,3 +1,4 @@
 ---
 :engines_path:
   - engines/user_removal
+  - alt_engines/*

--- a/test/apps/rails4_with_engines/config/brakeman.yml
+++ b/test/apps/rails4_with_engines/config/brakeman.yml
@@ -1,4 +1,4 @@
 ---
-:engines_path:
+:engine_paths:
   - engines/user_removal
   - alt_engines/*

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -76,7 +76,7 @@ class BrakemanTests < Minitest::Test
     require 'brakeman/options'
     relative_path = File.expand_path(File.join(TEST_PATH, "/apps/rails4_with_engines"))
     input = ["-p", relative_path.to_s,
-             "--engines", "engine/user_removal"]
+             "--add-engines-path", "engine/user_removal"]
     options, _ = Brakeman::Options.parse input
     at = Brakeman::AppTree.from_options options
 


### PR DESCRIPTION
This is an updated version of #857 with some bug fixes and minor aesthetic changes.

The option to add an engine path is `--add-engines-path` and the config option is `:engine_paths`.

To specify all subdirectories, use `*`. For example `engines/*`