### PR TITLE
Update ruby_parser gem

### DIFF
--- a/gem_common.rb
+++ b/gem_common.rb
@@ -5,7 +5,7 @@ module Brakeman
     end
 
     def self.base_dependencies spec
-      spec.add_dependency "ruby_parser", "~>3.8.1"
+      spec.add_dependency "ruby_parser", "~>3.8.3"
       spec.add_dependency "ruby2ruby", "~>2.3.0"
       spec.add_dependency "safe_yaml", ">= 1.0"
     end


### PR DESCRIPTION
Updating to 3.8.3 allows brakeman to parse and analyze Rails apps with imaginary and rational literals. (I have one Rails app with rational literal!)

* Announcement: http://www.zenspider.com/releases/2016/10/ruby_parser-version-3-8-3-has-been-released.html
* Changes from 3.8.1: https://github.com/seattlerb/ruby_parser/blob/master/History.txt#L1-L19