### PR TITLE
Raise errors for files with commas in their name

### DIFF
--- a/bin/codeclimate-brakeman
+++ b/bin/codeclimate-brakeman
@@ -19,8 +19,17 @@ if debug && debug.to_s.downcase == "true"
   command << " --debug --no-progress"
 end
 
+IncompatibleFilenameError = Class.new(StandardError)
+
 if engine_config["include_paths"]
-  command << " --only-files #{engine_config["include_paths"].compact.join(",").shellescape}"
+  paths = engine_config["include_paths"].compact.select do |path|
+    if path.include?(",")
+      raise IncompatibleFilenameError, "Can't analyze #{path.inspect} because it has a comma in its filename. Please remove this file or exclude it in your .codeclimate.yml"
+    else
+      path
+    end
+  end
+  command << " --only-files #{paths.join(",").shellescape}"
 end
 
 if system("test -w /dev/stdout")


### PR DESCRIPTION
We received a report that analysis was failing for a repo and tracked it
down to the fact that there was a file in the repo whose filename ended
in a comma. This leads to a fairly confusing error.

This change surfaces an error which explains to the user what is going
on, and what they can do about it.

If there is a comma in the middle of the filename, that doesn't lead to
a runtime error currently, but it does lead to misbehavior, so I think
an error is also appropriate for those files.