### PR TITLE
Warning when `protected_from_forgery` is mixed in.

### DIFF
--- a/test/apps/rails5/app/controllers/concerns/forgery_protection.rb
+++ b/test/apps/rails5/app/controllers/concerns/forgery_protection.rb
@@ -1,0 +1,7 @@
+module ForgeryProtection
+  extend ActiveSupport::Concern
+
+  included do
+    protect_from_forgery with: :exception
+  end
+end

--- a/test/apps/rails5/app/controllers/mixed_controller.rb
+++ b/test/apps/rails5/app/controllers/mixed_controller.rb
@@ -1,0 +1,4 @@
+class BaseController < ActionController::Base
+  # No protect_from_forgery call, but one mixed in
+  include ForgeryProtection
+end

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -410,4 +410,12 @@ class Rails5Tests < Minitest::Test
       :code => s(:call, nil, :link_to, s(:str, "Email!"), s(:dstr, "mailto:", s(:evstr, s(:call, s(:params), :[], s(:lit, :x))))),
       :user_input => s(:call, s(:params), :[], s(:lit, :x))
   end
+
+  def test_mixed_in_csrf_protection
+    assert_no_warning :type => :controller,
+      :warning_type => "Cross-Site Request Forgery",
+      :line => 1,
+      :message => /^'protect_from_forgery'\ should\ be\ called\ /,
+      :relative_path => "app/controllers/mixed_controller.rb"
+  end
 end


### PR DESCRIPTION
Hi! since https://github.com/presidentbeef/brakeman/pull/953 was merged in, we started to see `'protect_from_forgery' should be called in ...` in our controllers that were not inheriting from the `ApplicationController`. 

I had a look, and it seems that it's because we are mixin in the `protect_form_forgery` in those controllers. I added a failing test case that should normally not generate a warning. My knowledge of the Brakeman codebase was not enough for me to create a fix.

Let me know if I can do anything else to help!