### PR TITLE
Remove WARNING_TYPES from gemspecs

### DIFF
--- a/brakeman-lib.gemspec
+++ b/brakeman-lib.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary = "Security vulnerability scanner for Ruby on Rails."
   s.description = "Brakeman detects security vulnerabilities in Ruby on Rails applications via static analysis. This package declares gem dependencies instead of bundling them."
   s.homepage = "http://brakemanscanner.org"
-  s.files = ["bin/brakeman", "CHANGES", "WARNING_TYPES", "FEATURES", "README.md"] + Dir["lib/**/*"]
+  s.files = ["bin/brakeman", "CHANGES", "FEATURES", "README.md"] + Dir["lib/**/*"]
   s.executables = ["brakeman"]
   s.license = "MIT"
   s.cert_chain  = ['brakeman-public_cert.pem']

--- a/brakeman-min.gemspec
+++ b/brakeman-min.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary = "Security vulnerability scanner for Ruby on Rails."
   s.description = "Brakeman detects security vulnerabilities in Ruby on Rails applications via static analysis. This version of the gem only requires the minimum number of dependencies. Use the 'brakeman' gem for a full install."
   s.homepage = "http://brakemanscanner.org"
-  s.files = ["bin/brakeman", "CHANGES", "WARNING_TYPES", "FEATURES", "README.md"] + Dir["lib/**/*"]
+  s.files = ["bin/brakeman", "CHANGES", "FEATURES", "README.md"] + Dir["lib/**/*"]
   s.executables = ["brakeman"]
   s.license = "MIT"
   s.cert_chain  = ['brakeman-public_cert.pem']

--- a/brakeman.gemspec
+++ b/brakeman.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary = "Security vulnerability scanner for Ruby on Rails."
   s.description = "Brakeman detects security vulnerabilities in Ruby on Rails applications via static analysis."
   s.homepage = "http://brakemanscanner.org"
-  s.files = ["bin/brakeman", "CHANGES", "WARNING_TYPES", "FEATURES", "README.md"] + Dir["lib/**/*"]
+  s.files = ["bin/brakeman", "CHANGES", "FEATURES", "README.md"] + Dir["lib/**/*"]
   s.executables = ["brakeman"]
   s.license = "MIT"
   s.cert_chain  = ['brakeman-public_cert.pem']


### PR DESCRIPTION
It doesn't exist since #964.