### PR TITLE
Support bare extensions on template files

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -101,7 +101,8 @@ module Brakeman
     end
 
     def template_paths
-      @template_paths ||= find_paths("app/**/views", "*.{#{VIEW_EXTENSIONS}}")
+      @template_paths ||= find_paths("app/**/views", "*.{#{VIEW_EXTENSIONS}}") +
+                          find_paths("app/**/views", "*.{erb,haml,slim}").reject { |path| path.count(".") > 1 }
     end
 
     def layout_exists?(name)

--- a/test/apps/rails5/app/views/widget/no_html.haml
+++ b/test/apps/rails5/app/views/widget/no_html.haml
@@ -1,0 +1,1 @@
+%h1= params[:x].html_safe

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -12,7 +12,7 @@ class Rails5Tests < Minitest::Test
     @@expected ||= {
       :controller => 0,
       :model => 0,
-      :template => 8,
+      :template => 9,
       :generic => 10
     }
   end
@@ -206,6 +206,19 @@ class Rails5Tests < Minitest::Test
       :confidence => 0,
       :relative_path => "app/views/layouts/users.html.erb",
       :code => s(:call, s(:call, s(:const, :User), :new), :name),
+      :user_input => nil
+  end
+
+  def test_cross_site_scripting_in_template_with_no_html_extension
+    assert_warning :type => :template,
+      :warning_code => 2,
+      :fingerprint => "dba79beeea8871929d0f5191b1df66822689d2e8cfffa4a58e45e07cb4c6ea43",
+      :warning_type => "Cross Site Scripting",
+      :line => 1,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/views/widget/no_html.haml",
+      :code => s(:call, s(:call, nil, :params), :[], s(:lit, :x)),
       :user_input => nil
   end
 


### PR DESCRIPTION
Sometimes people have views without `.html.`, just `.erb` or `.haml`, etc.

Sometimes these templates aren't actually HTML and this will cause a few false positives, but I think that is justified by fixing the false negatives.