### PR TITLE
Improvements to SQL injection detection

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -16,10 +16,6 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
   def run_check
     narrow_targets = [:exists?, :select]
 
-    if version_between?("2.0.0", "4.0.99")
-      narrow_targets << :find
-    end
-
     @sql_targets = [:average, :calculate, :count, :count_by_sql, :delete_all, :destroy_all,
                     :find_by_sql, :maximum, :minimum, :pluck, :sum, :update_all]
     @sql_targets.concat [:from, :group, :having, :joins, :lock, :order, :reorder, :where] if tracker.options[:rails3]
@@ -27,6 +23,10 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
 
     if version_between?("2.0.0", "3.9.9")
       @sql_targets << :first << :last << :all
+    end
+
+    if version_between?("2.0.0", "4.0.99")
+      @sql_targets << :find
     end
 
     @connection_calls = [:delete, :execute, :insert, :select_all, :select_one,

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -29,9 +29,8 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     end
 
     Brakeman.debug "Finding possible SQL calls on models"
-    calls = tracker.find_call :targets => active_record_models.keys,
-      :methods => @sql_targets,
-      :chained => true
+    calls = tracker.find_call :methods => @sql_targets,
+      :nested => true
 
     Brakeman.debug "Finding possible SQL calls with no target"
     calls.concat tracker.find_call(:target => nil, :methods => @sql_targets)

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -451,7 +451,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
       unsafe_sql? exp.then_clause or unsafe_sql? exp.else_clause
     when :call
       unless IGNORE_METHODS_IN_SQL.include? exp.method
-        if has_immediate_user_input? exp or has_immediate_model? exp
+        if has_immediate_user_input? exp
           exp
         elsif exp.method == :to_s
           find_dangerous_value exp.target, ignore_hash
@@ -468,7 +468,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     when :block, :rlist
       unsafe_sql? exp.last
     else
-      if has_immediate_user_input? exp or has_immediate_model? exp
+      if has_immediate_user_input? exp
         exp
       else
         nil

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -20,10 +20,14 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
       narrow_targets << :find
     end
 
-    @sql_targets = [:all, :average, :calculate, :count, :count_by_sql, :delete_all, :destroy_all,
-                    :find_by_sql, :first, :last, :maximum, :minimum, :pluck, :sum, :update_all]
+    @sql_targets = [:average, :calculate, :count, :count_by_sql, :delete_all, :destroy_all,
+                    :find_by_sql, :maximum, :minimum, :pluck, :sum, :update_all]
     @sql_targets.concat [:from, :group, :having, :joins, :lock, :order, :reorder, :where] if tracker.options[:rails3]
     @sql_targets << :find_by << :find_by! if tracker.options[:rails4]
+
+    if version_between?("2.0.0", "3.9.9")
+      @sql_targets << :first << :last << :all
+    end
 
     @connection_calls = [:delete, :execute, :insert, :select_all, :select_one,
       :select_rows, :select_value, :select_values]

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -206,7 +206,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
         user_input = dangerous_value
       end
 
-      if result[:call].target and not @expected_targets.include? result[:chain].first
+      if result[:call].target and result[:chain] and not @expected_targets.include? result[:chain].first
         confidence = case confidence
                      when CONFIDENCE[:high]
                        CONFIDENCE[:med]

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -14,11 +14,15 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
   @description = "Check for SQL injection"
 
   def run_check
-    narrow_targets = [:exists?]
+    narrow_targets = [:exists?, :select]
+
+    if version_between?("2.0.0", "4.0.99")
+      narrow_targets << :find
+    end
 
     @sql_targets = [:all, :average, :calculate, :count, :count_by_sql, :delete_all, :destroy_all,
-      :find, :find_by_sql, :first, :last, :maximum, :minimum, :pluck, :sum, :update_all]
-    @sql_targets.concat [:from, :group, :having, :joins, :lock, :order, :reorder, :select, :where] if tracker.options[:rails3]
+                    :find_by_sql, :first, :last, :maximum, :minimum, :pluck, :sum, :update_all]
+    @sql_targets.concat [:from, :group, :having, :joins, :lock, :order, :reorder, :where] if tracker.options[:rails3]
     @sql_targets << :find_by << :find_by! if tracker.options[:rails4]
 
     @connection_calls = [:delete, :execute, :insert, :select_all, :select_one,

--- a/test/apps/rails5/app/models/user.rb
+++ b/test/apps/rails5/app/models/user.rb
@@ -15,4 +15,8 @@ class User < ApplicationRecord
 
   has_many :things,
     -> { where(Thing.canadian.where_values_hash) }
+
+  def self.all_that_jazz(user)
+    User.where(User.access_condition(user))
+  end
 end

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -14,7 +14,7 @@ class Rails3Tests < Minitest::Test
       :controller => 1,
       :model => 9,
       :template => 42,
-      :generic => 75
+      :generic => 76
     }
 
     if RUBY_PLATFORM == 'java'
@@ -375,12 +375,16 @@ class Rails3Tests < Minitest::Test
   end
 
   def test_sql_injection_non_active_record_model
-    assert_no_warning :type => :warning,
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "f804d0d9f3f0ecddf8cec14aa7bdc0020db864252cd2e7d7e3a7081c45363a7d",
       :warning_type => "SQL Injection",
       :line => 30,
       :message => /^Possible\ SQL\ injection/,
-      :confidence => 0,
-      :file => /other_controller\.rb/
+      :confidence => 1,
+      :relative_path => "app/controllers/other_controller.rb",
+      :code => s(:call, s(:const, :Noticia), :where, s(:call, s(:params), :[], s(:lit, :bad_stuff))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :bad_stuff))
   end
 
   def test_csrf_protection

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -286,6 +286,18 @@ class Rails5Tests < Minitest::Test
       :user_input => s(:call, s(:call, s(:const, :Thing), :canadian), :where_values_hash)
   end
 
+  def test_sql_injection_from_model_call_fp
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "dcfa0c30b2d303c58bde5b376f423cff6282bbc71ed460077478ca97e1f4d0f7",
+      :warning_type => "SQL Injection",
+      :line => 20,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/models/user.rb",
+      :code => s(:call, s(:const, :User), :where, s(:call, s(:const, :User), :access_condition, s(:lvar, :user))),
+      :user_input => s(:call, s(:const, :User), :access_condition, s(:lvar, :user))
+  end
 
   def test_cross_site_scripting_CVE_2015_7578
     assert_warning :type => :warning,

--- a/test/tests/rescanner.rb
+++ b/test/tests/rescanner.rb
@@ -187,7 +187,7 @@ class RescannerTests < Minitest::Test
     before_rescan_of model do
       add_method model, <<-'RUBY'
       def bad_sql input
-        find(:all, :conditions => "x > #{input}")
+        User.find(:all, :conditions => "x > #{input}")
       end
       RUBY
     end


### PR DESCRIPTION
* Once again warn about SQL injection even if Brakeman isn't sure the method is being called on an ActiveRecord model (but at lower confidence)
* Do not warn about `all`, `first`, or `last` after Rails 4.0
* Do not warn about models in SQL (almost always false positives)