### PR TITLE
Fail on missing checks

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -93,4 +93,7 @@ begin
 rescue Brakeman::NoApplication => e
   warn e.message
   exit Brakeman::No_App_Found_Exit_Code
+rescue Brakeman::MissingChecksError => e
+  warn e.message
+  exit Brakeman::Missing_Checks_Exit_Code
 end

--- a/lib/brakeman/checks.rb
+++ b/lib/brakeman/checks.rb
@@ -37,6 +37,24 @@ class Brakeman::Checks
     end
   end
 
+  def self.missing_checks included_checks, excluded_checks
+    included_checks = included_checks.map(&:to_s).to_set
+    excluded_checks = excluded_checks.map(&:to_s).to_set
+
+    if included_checks == Set['CheckNone']
+      return []
+    else
+      loaded = self.checks.map { |name| name.to_s.gsub('Brakeman::', '') }.to_set
+      missing = (included_checks - loaded) + (excluded_checks - loaded)
+
+      unless missing.empty?
+        return missing
+      end
+    end
+
+    []
+  end
+
   #No need to use this directly.
   def initialize options = { }
     if options[:min_confidence]


### PR DESCRIPTION
Raise an exception when checks are specified with `-t` or `-x` that do not exist.

Additionally, `-t None` may be used to run no checks.