### PR TITLE
Handle template paths with periods better

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -102,7 +102,7 @@ module Brakeman
 
     def template_paths
       @template_paths ||= find_paths("app/**/views", "*.{#{VIEW_EXTENSIONS}}") +
-                          find_paths("app/**/views", "*.{erb,haml,slim}").reject { |path| path.count(".") > 1 }
+                          find_paths("app/**/views", "*.{erb,haml,slim}").reject { |path| File.basename(path).count(".") > 1 }
     end
 
     def layout_exists?(name)


### PR DESCRIPTION
When finding templates missing `.html`.

For example, `/asdasd.asd.asd/app/views/blah/blah.haml` would be missed otherwise