### PR TITLE
allow failing on error with --exit-on-error

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -90,6 +90,11 @@ begin
       exit Brakeman::Warnings_Found_Exit_Code
     end
   end
+
+  #Return error code if --exit-on-error is used and errors were found
+  if tracker.options[:exit_on_error] and tracker.errors.any?
+    exit Brakeman::Errors_Found_Exit_Code
+  end
 rescue Brakeman::NoApplication => e
   warn e.message
   exit Brakeman::No_App_Found_Exit_Code

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -15,6 +15,10 @@ module Brakeman
   #Exit code returned when user requests non-existent checks
   Missing_Checks_Exit_Code = 6
 
+  #Exit code returned when errors were found and the --exit-on-error
+  #option is set
+  Errors_Found_Exit_Code = 7
+
   @debug = false
   @quiet = false
   @loaded_dependencies = []

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -43,6 +43,10 @@ module Brakeman::Options
           options[:exit_on_warn] = exit_on_warn
         end
 
+        opts.on "--[no-]exit-on-error", "Exit code is non-zero if errors found" do |exit_on_error|
+          options[:exit_on_error] = exit_on_error
+        end
+
         opts.on "--ensure-latest", "Fail when Brakeman is outdated" do
           options[:ensure_latest] = true
         end

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -3,6 +3,7 @@ require 'brakeman/options'
 class BrakemanOptionsTest < Minitest::Test
   EASY_OPTION_INPUTS = {
     :exit_on_warn           => "-z",
+    :exit_on_error          => "--exit-on-error",
     :rails3                 => "-3",
     :run_all_checks         => "-A",
     :assume_all_routes      => "-a",


### PR DESCRIPTION
@presidentbeef 

solves https://github.com/presidentbeef/brakeman/issues/910

tested it with samson and works as expected :)
 - does not fail without flag
 - fails with flag
 - does not fail with flag and no errors

added --no-exit-on-error in case failing on error gets to be the default on day ... not sure if 4.0 would be a good milestone for that ...