### PR TITLE
Properly parse multiple array push on configs

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -847,7 +847,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
 
   #Finds the inner most call target which is not the target of a call to <<
   def find_push_target exp
-    if call? exp and exp.method == :<<
+    if call? exp
       find_push_target exp.target
     else
       exp

--- a/test/apps/rails3.2/config/application.rb
+++ b/test/apps/rails3.2/config/application.rb
@@ -38,6 +38,9 @@ module Rails32
 
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
+    config.filter_parameters << :password2
+    config.filter_parameters << :password3
+    config.filter_parameters << :password4
 
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -122,6 +122,20 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
+  def test_call_array_append
+    assert_output <<-INPUT, <<-OUTPUT
+      config.x += [1]
+      config.x << 2
+      config.x << 3
+      config.x << 4
+    INPUT
+      config.x += [1]
+      config.x << 2
+      config.x << 3
+      config.x << 4
+    OUTPUT
+  end
+
   def test_array_new_append
     assert_alias '[1, 2, 3]', <<-RUBY
       x = Array.new


### PR DESCRIPTION
On an environment having the following code in config/application.rb

```
config.filter_parameters += [:password]
config.filter_parameters << :password2
config.filter_parameters << :password3
config.filter_parameters << :password4
 
config.active_support.escape_html_entities_in_json = true
```

tracker.config.rails becomes this

```
{:encoding=>s(:str, "utf-8"),
 :filter_parameters=>
  {:<<=>
    {:active_support=>{:escape_html_entities_in_json=>s(:true)},
     :active_record=>{:whitelist_attributes=>s(:false)},
     :assets=>{:enabled=>s(:true), :version=>s(:str, "1.0")},
     :mess_things_up_in_prod=>
      s(:call, s(:colon2, s(:const, :ActiveSupport), :OrderedOptions), :new),
     :actually_a_hash=>s(:hash)}},
 :cache_classes=>s(:true),
 :consider_all_requests_local=>s(:false),
 :action_controller=>{:perform_caching=>s(:true)},
 :serve_static_assets=>s(:false),
 :assets=>{:compress=>s(:true), :compile=>s(:false), :digest=>s(:true)},
 :i18n=>{:fallbacks=>s(:true)},
 :active_support=>{:deprecation=>s(:lit, :notify)},
 :active_record=>{:whitelist_attributes=>s(:true)},
 :mess_things_up_in_prod=>{:right_here=>s(:lit, :nope_ignored)},
 :actually_a_hash=>{:[]=>s(:lit, :thing)}}
```

See that active_support.escape_html_entities_in_json is misplaced, preventing detection of the config, causing reporting false issues. Noticed on Rails 3 but will probably affect later versions if user does similar configuration there, or there may be other scenarios affected by this.
