### PR TITLE
Better handling of case expressions

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -616,6 +616,75 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     exp
   end
 
+  def simple_when? exp
+    node_type? exp[1], :array and
+      not node_type? exp[1][1], :splat, :array and
+      (exp[1].length == 2 or
+       exp[1].all? { |e| e.is_a? Symbol or node_type? e, :lit, :str })
+  end
+
+  def process_case exp
+    if @ignore_ifs.nil?
+      @ignore_ifs = @tracker && @tracker.options[:ignore_ifs]
+    end
+
+    if @ignore_ifs
+      process_default exp
+      return exp
+    end
+
+    branch_scopes = []
+    was_inside = @inside_if
+    @inside_if = true
+
+    exp[1] = process exp[1] if exp[1]
+
+    case_value = if node_type? exp[1], :lvar, :ivar, :call
+      exp[1].deep_clone
+    end
+
+    exp.each_sexp do |e|
+      if node_type? e, :when
+        scope do
+          @branch_env = env.current
+
+          # set value of case var if possible
+          if case_value and simple_when? e
+            @branch_env[case_value] = e[1][1]
+          end
+
+          # when blocks aren't blocks, they are lists of expressions
+          process_default e
+
+          branch_scopes << env.current
+
+          @branch_env = nil
+        end
+      end
+    end
+
+    # else clause
+    if sexp? exp.last
+      scope do
+        @branch_env = env.current
+
+        process_default exp[-1]
+
+        branch_scopes << env.current
+
+        @branch_env = nil
+      end
+    end
+
+    @inside_if = was_inside
+
+    branch_scopes.each do |s|
+      merge_if_branch s
+    end
+
+    exp
+  end
+
   def process_if_branch exp
     if sexp? exp
       if block? exp
@@ -934,6 +1003,36 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     end
   end
 
+  def value_from_case exp
+    result = []
+
+    exp.each do |e|
+      if node_type? e, :when
+        result << e.last
+      end
+    end
+
+    result << exp.last if exp.last # else
+
+    result.reduce do |c, e|
+      if c.nil?
+        e
+      elsif node_type? e, :if
+        c.combine(value_from_if e)
+      elsif raise? e
+        c # ignore exceptions
+      elsif e
+        c.combine e
+      else # when e is nil
+        c
+      end
+    end
+  end
+
+  def raise? exp
+    call? exp and exp.method == :raise
+  end
+
   #Set variable to given value.
   #Creates "branched" versions of values when appropriate.
   #Avoids creating multiple branched versions inside same
@@ -941,6 +1040,8 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   def set_value var, value
     if node_type? value, :if
       value = value_from_if(value)
+    elsif node_type? value, :case
+      value = value_from_case(value)
     end
 
     if @ignore_ifs or not @inside_if

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -852,4 +852,106 @@ class AliasProcessorTests < Minitest::Test
     params[:x].presence
     OUTPUT
   end
+
+  def test_case_basic
+    assert_output <<-INPUT, <<-OUTPUT
+      z = 3
+
+      case x
+      when 1
+        y = 1
+      when 2
+        y = 2
+      else
+        z = z + 1
+        y = z
+      end
+
+      p y
+    INPUT
+      z = 3
+
+      case x
+      when 1
+        y = 1
+      when 2
+        y = 2
+      else
+        z = 4
+        y = 4
+      end
+
+      p(((1 or 2) or 4))
+    OUTPUT
+  end
+
+  def test_case_assignment
+    assert_output <<-INPUT, <<-OUTPUT
+      y = case x
+      when 1
+        1
+      when 2
+        2
+      else
+        3
+      end
+
+      p y
+    INPUT
+      y = case x
+      when 1
+        1
+      when 2
+        2
+      else
+        3
+      end
+
+      p(((1 or 2) or 3))
+    OUTPUT
+  end
+
+  def test_case_value
+    assert_output <<-INPUT, <<-OUTPUT
+      y = case x
+      when 1
+        x + 1
+      when 2
+        x + 2
+      else
+        x + 3
+      end
+
+      p y
+    INPUT
+      y = case x
+      when 1
+        2
+      when 2
+        4
+      else
+        x + 3
+      end
+
+      p(((2 or 4) or (x + 3)))
+    OUTPUT
+  end
+
+  def test_case_value_params
+    assert_output <<-INPUT, <<-OUTPUT
+      case params[:x]
+      when 1
+        y(params[:x])
+      when 2
+        z(params[:x])
+      end
+    INPUT
+      case params[:x]
+      when 1
+        y(1)
+      when 2
+        z(2)
+      end
+    OUTPUT
+  end
 end


### PR DESCRIPTION
Handles branches in `case` expressions as well as their return values. For simple `when` clauses, also manages the `case` value (what is that called?) inside the clause.