### PR TITLE
fix NoMethodError exception using --compare flag

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -89,12 +89,13 @@ begin
     if tracker.options[:exit_on_warn] and not tracker.filtered_warnings.empty?
       exit Brakeman::Warnings_Found_Exit_Code
     end
+
+    #Return error code if --exit-on-error is used and errors were found
+    if tracker.options[:exit_on_error] and tracker.errors.any?
+      exit Brakeman::Errors_Found_Exit_Code
+    end
   end
 
-  #Return error code if --exit-on-error is used and errors were found
-  if tracker.options[:exit_on_error] and tracker.errors.any?
-    exit Brakeman::Errors_Found_Exit_Code
-  end
 rescue Brakeman::NoApplication => e
   warn e.message
   exit Brakeman::No_App_Found_Exit_Code


### PR DESCRIPTION
Fixes #1023 

In [brakeman#L95](https://github.com/presidentbeef/brakeman/blob/5788041f662b1e4a3d3bc0fecdb0c480cc06afc2/bin/brakeman#L95), `tracker` is used twice outside the block in which it's defined. I think you intended to have this conditional block inside the `else` block immediately above it.