### PR TITLE
Removed false positive for redirect_to in Rails 4

### DIFF
--- a/lib/brakeman/checks/check_redirect.rb
+++ b/lib/brakeman/checks/check_redirect.rb
@@ -119,6 +119,17 @@ class Brakeman::CheckRedirect < Brakeman::BaseCheck
     return call_has_param(arg, :to_unsafe_hash) || call_has_param(arg, :to_unsafe_h)
   end
 
+  def call_has_param arg, key
+    if call? arg and call? arg.target
+      target = arg.target
+      method = target.method
+
+      node_type? target.target, :params and method == key
+    else
+      false
+    end
+  end
+
   def has_only_path? arg
     if value = hash_access(arg, :only_path)
       return true if true?(value)

--- a/lib/brakeman/checks/check_redirect.rb
+++ b/lib/brakeman/checks/check_redirect.rb
@@ -105,11 +105,23 @@ class Brakeman::CheckRedirect < Brakeman::BaseCheck
     arg = call.first_arg
 
     if hash? arg
-      if value = hash_access(arg, :only_path)
-        return true if true?(value)
-      end
+      return has_only_path? arg
     elsif call? arg and arg.method == :url_for
       return check_url_for(arg)
+    elsif call? arg and hash? arg.first_arg and use_unsafe_hash_method? arg
+      return has_only_path? arg.first_arg
+    end
+
+    false
+  end
+
+  def use_unsafe_hash_method? arg
+    return call_has_param(arg, :to_unsafe_hash) || call_has_param(arg, :to_unsafe_h)
+  end
+
+  def has_only_path? arg
+    if value = hash_access(arg, :only_path)
+      return true if true?(value)
     end
 
     false

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -129,9 +129,6 @@ module Brakeman::Util
       key = Sexp.new(:call, s(:params), key)
     end
 
-      # p call
-      # p call.find_index(key)
-
     if index = call.find_index(key)
       return true
     end

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -124,6 +124,21 @@ module Brakeman::Util
     nil
   end
 
+  def call_has_param call, key
+    if key.is_a? Symbol
+      key = Sexp.new(:call, s(:params), key)
+    end
+
+      # p call
+      # p call.find_index(key)
+
+    if index = call.find_index(key)
+      return true
+    end
+
+    false
+  end
+
   #These are never modified
   PARAMS_SEXP = Sexp.new(:params)
   SESSION_SEXP = Sexp.new(:session)

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -124,18 +124,6 @@ module Brakeman::Util
     nil
   end
 
-  def call_has_param call, key
-    if key.is_a? Symbol
-      key = Sexp.new(:call, s(:params), key)
-    end
-
-    if index = call.find_index(key)
-      return true
-    end
-
-    false
-  end
-
   #These are never modified
   PARAMS_SEXP = Sexp.new(:params)
   SESSION_SEXP = Sexp.new(:session)

--- a/test/apps/rails3/app/controllers/home_controller.rb
+++ b/test/apps/rails3/app/controllers/home_controller.rb
@@ -154,6 +154,10 @@ class HomeController < ApplicationController
     POSIX::Spawn::spawn params[:cmd]
   end
 
+  def test_only_path_also_correct
+    redirect_to(params.merge(:only_path => true, :display => nil))
+  end
+
   private
 
   def filter_it

--- a/test/apps/rails4/app/controllers/application_controller.rb
+++ b/test/apps/rails4/app/controllers/application_controller.rb
@@ -29,4 +29,16 @@ class ApplicationController < ActionController::API
   def set_bad_thing
     @bad_thing = params[:x]
   end
+
+  def wrong_redirect_only_path
+    redirect_to(params.bla.merge(:only_path => true, :display => nil))
+  end
+
+  def redirect_only_path_with_unsafe_hash
+    redirect_to(params.to_unsafe_hash.merge(:only_path => true, :display => nil))
+  end
+
+  def redirect_only_path_with_unsafe_h
+    redirect_to(params.to_unsafe_h.merge(:only_path => true, :display => nil))
+  end
 end

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -297,6 +297,15 @@ class Rails3Tests < Minitest::Test
       :file => /home_controller\.rb/
   end
 
+  def test_redirect_url_only_path
+    assert_no_warning :type => :warning,
+      :warning_type => "Redirect",
+      :line => 158,
+      :message => /^Possible unprotected redirect near line 159: redirect_to\(params\[/,
+      :confidence => 0,
+      :file => /home_controller\.rb/
+  end
+
   def test_render_path
     assert_warning :type => :warning,
       :warning_type => "Dynamic Render Path",

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Minitest::Test
       :controller => 0,
       :model => 3,
       :template => 8,
-      :generic => 80
+      :generic => 81
     }
   end
 
@@ -71,6 +71,34 @@ class Rails4Tests < Minitest::Test
       :confidence => 0,
       :relative_path => "app/controllers/friendly_controller.rb",
       :user_input => s(:params, s(:lit, :host), s(:call, s(:params), :[], s(:lit, :host)))
+  end
+
+  def test_redirect_with_only_path_in_wrong_method
+    assert_warning :type => :warning,
+    :warning_code => 18,
+    :warning_type => "Redirect",
+    :line => 34,
+    :message => /^Possible\ unprotected\ redirect/,
+    :confidence => 0,
+    :relative_path => "app/controllers/application_controller.rb"
+  end
+
+  def test_redirect_with_unsafe_hash_and_only_path_do_not_warn
+    assert_no_warning :type => :warning,
+      :warning_code => 18,
+      :warning_type => "Redirect",
+      :line => 38,
+      :message => /^Possible\ unprotected\ redirect/,
+      :confidence => 0,
+      :relative_path => "app/controllers/application_controller.rb"
+
+    assert_no_warning :type => :warning,
+      :warning_code => 18,
+      :warning_type => "Redirect",
+      :line => 42,
+      :message => /^Possible\ unprotected\ redirect/,
+      :confidence => 0,
+      :relative_path => "app/controllers/application_controller.rb"
   end
 
   def test_session_secret_token


### PR DESCRIPTION
Fixes #1028 

Not sure if this PR is correct, this is my first contribution to `Breakeman`. Hopefully is good enough to start a discussion and then move it to the right direction.

Rails 4 has changed how to get the hash of an ActionController::Parameter.
If the user needs the all hash parameters it needs to use the method to_unsafe_hash or to_unsafe_h.
Brakeman now recognizes those method as safe as long as they are followed by :only_path

More details: https://github.com/rails/rails/blob/4-2-stable/actionpack/CHANGELOG.md#rails-420-december-20-2014