### PR TITLE
Use `#hash` as a cache key instead of SHA1 to improve performance

### DIFF
--- a/lib/brakeman/processors/lib/render_helper.rb
+++ b/lib/brakeman/processors/lib/render_helper.rb
@@ -70,7 +70,7 @@ module Brakeman::RenderHelper
     #Hash the environment and the source of the template to avoid
     #pointlessly processing templates, which can become prohibitively
     #expensive in terms of time and memory.
-    digest = Digest::SHA1.new.update(template_env.instance_variable_get(:@env).to_a.sort.to_s << name).to_s.to_sym
+    digest = template_env.instance_variable_get(:@env).to_a.sort.push(name).hash
 
     if @tracker.template_cache.include? digest
       #Already processed this template with identical environment
@@ -130,7 +130,7 @@ module Brakeman::RenderHelper
       #TODO: Add in :locals => { ... } to environment
       src = Brakeman::TemplateAliasProcessor.new(@tracker, template, called_from).process_safely(template.src, template_env)
 
-      digest = Digest::SHA1.new.update(name + src.to_s).to_s.to_sym
+      digest = [name, src].hash
 
       if @tracker.template_cache.include? digest
         return


### PR DESCRIPTION
By this change, `brakeman` command will be faster around 14%.

------

Currently, `template_cache` key is a SHA1 of a string that is a stringfield sexp.
The stringifying process is very slow. It calls `Sexp#inspect`, ant the method calls itself recursively.

I've replaced it with `Sexp#hash`. This method is faster than `#inspect`.

Benchmarking
=============

```ruby
require 'benchmark'

def dev # Patched brakeman is installed as version 3.6.1.dev
  system 'brakeman _3.6.1.dev_ > /dev/null 2>&1'
end

def master # origin/master is installed as version 3.6.1
  system 'brakeman _3.6.1_ > /dev/null 2>&1'
end

n = 5

Benchmark.bm(16) do |x|
  x.report('dev'){   n.times{dev}}
  x.report('master'){n.times{master}}
end
```

I've tested in gitlab repository.
https://github.com/gitlabhq/gitlabhq

```bash
$ cd path/to/gitlab
$ ruby bench.rb
                       user     system      total        real
dev                0.000000   0.000000 144.030000 (143.694241)
master             0.000000   0.000000 168.080000 (167.729224)
```