### PR TITLE
Limit slim to < 3.0.8

### DIFF
--- a/gem_common.rb
+++ b/gem_common.rb
@@ -16,7 +16,7 @@ module Brakeman
       spec.add_dependency "erubis", "~>2.6"
       spec.add_dependency "haml", ">=3.0", "<5.0"
       spec.add_dependency "sass", "~>3.0"
-      spec.add_dependency "slim", ">=1.3.6", "<4.0"
+      spec.add_dependency "slim", ">=1.3.6", "<3.0.8"
     end
   end
 end


### PR DESCRIPTION
because 3.0.8 requires Ruby 2.0