### PR TITLE
Default to skipping check paths in Brakeman config file

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -114,6 +114,14 @@ module Brakeman
         # After parsing the yaml config file for options, convert any string keys into symbols.
         options.keys.select {|k| k.is_a? String}.map {|k| k.to_sym }.each {|k| options[k] = options[k.to_s]; options.delete(k.to_s) }
 
+        unless line_options[:allow_check_paths_in_config]
+          if options.include? :additional_checks_path
+            options.delete :additional_checks_path
+
+            notify "[Notice] Ignoring additional check paths in config file. Use --allow-check-paths-in-config to allow" unless (options[:quiet] || quiet)
+          end
+        end
+
         # notify if options[:quiet] and quiet is nil||false
         notify "[Notice] Using configuration in #{config}" unless (options[:quiet] || quiet)
         options

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -280,6 +280,10 @@ module Brakeman::Options
           end
         end
 
+        opts.on "--allow-check-paths-in-config", "Allow loading checks from configuration file (Unsafe)" do
+          options[:allow_check_paths_in_config] = true
+        end
+
         opts.separator ""
 
         opts.on "-k", "--checks", "List all available vulnerability checks" do

--- a/test/apps/rails5/config/brakeman.yml
+++ b/test/apps/rails5/config/brakeman.yml
@@ -1,0 +1,3 @@
+---
+:additional_checks_path:
+  - "./test/apps/rails5/external_checks"

--- a/test/apps/rails5/external_checks/check_external_check_test.rb
+++ b/test/apps/rails5/external_checks/check_external_check_test.rb
@@ -1,0 +1,11 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckExternalCheckConfigTest < Brakeman::BaseCheck
+  Brakeman::Checks.add_optional self
+
+  @description = "An external check for testing"
+
+  def run_check
+    raise "This should not have been loaded!"
+  end
+end

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -22,7 +22,8 @@ class BrakemanOptionsTest < Minitest::Test
     :show_version           => "-v",
     :show_help              => "-h",
     :force_scan             => "--force-scan",
-    :ensure_latest          => "--ensure-latest"
+    :ensure_latest          => "--ensure-latest",
+    :allow_check_paths_in_config => "--allow-check-paths-in-config",
   }
 
   ALT_OPTION_INPUTS = {


### PR DESCRIPTION
Only honor it when `--allow-check-paths-in-config` is explicitly used.