### PR TITLE
Handle simple guards using return

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -675,6 +675,10 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
             env.current[var] = condition.target[1]
             exp[branch_index] = process_if_branch branch
             env.current[var] = previous_value
+          elsif i == 1 and array_include_all_literals? condition and node_type? branch, :return
+            var = condition.first_arg
+            env.current[var] = condition.target[1]
+            exp[branch_index] = process_if_branch branch
           else
             exp[branch_index] = process_if_branch branch
           end

--- a/test/apps/rails5/app/controllers/widget_controller.rb
+++ b/test/apps/rails5/app/controllers/widget_controller.rb
@@ -73,6 +73,14 @@ class WidgetController < ApplicationController
   def no_html
     @x = params[:x].html_safe
   end
+
+  def guard_with_return
+    goto = params[:goto]
+    event = params[:event]
+    return redirect_to user_path unless %w[comment subscribe].include?(goto)
+
+    redirect_to send("#{goto}_event_path", event) # should not warn
+  end
 end
 
 IDENTIFIER_NAMESPACE = 'apis'

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -853,6 +853,16 @@ class AliasProcessorTests < Minitest::Test
     OUTPUT
   end
 
+  def test_branch_array_include_return
+    assert_output <<-INPUT, <<-OUTPUT
+    return unless ['a', 'b'].include? x
+    x
+    INPUT
+    return unless ['a', 'b'].include? x
+    'a'
+    OUTPUT
+  end
+
   def test_case_basic
     assert_output <<-INPUT, <<-OUTPUT
       z = 3

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -144,6 +144,19 @@ class Rails5Tests < Minitest::Test
       :user_input => s(:call, s(:params), :slice, s(:lit, :back_to))
   end
 
+  def test_redirect_with_return_guard
+    assert_no_warning :type => :warning,
+      :warning_code => 23,
+      :fingerprint => "208deedcfef17a235e5c2139c74bbb408b2a948334880be58fcc441c09b9d799",
+      :warning_type => "Dangerous Send",
+      :line => 82,
+      :message => /^User\ controlled\ method\ execution/,
+      :confidence => 0,
+      :relative_path => "app/controllers/widget_controller.rb",
+      :code => s(:call, nil, :send, s(:dstr, "", s(:evstr, s(:call, s(:params), :[], s(:lit, :goto))), s(:str, "_event_path")), s(:call, s(:params), :[], s(:lit, :event))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :goto))
+  end
+
   def test_cross_site_scripting_with_slice
     assert_no_warning :type => :template,
       :warning_code => 4,


### PR DESCRIPTION
This only handles the simple case of

```ruby
def cool_method
  return unless ['a', 'b'].include? x

  something_dangerous_but_now_benign(x)
end
```

Fixes #1057