### PR TITLE
Add plaintext fingerprint to warning hash

### DIFF
--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -208,13 +208,16 @@ class Brakeman::Warning
    output
   end
 
-  def fingerprint
+  def fingerprint_as_s
     loc = self.location
     location_string = loc && loc.sort_by { |k, v| k.to_s }.inspect
     warning_code_string = sprintf("%03d", @warning_code)
     code_string = @code.inspect
+    "#{warning_code_string}#{code_string}#{location_string}#{@relative_path}#{self.confidence}"
+  end
 
-    Digest::SHA2.new(256).update("#{warning_code_string}#{code_string}#{location_string}#{@relative_path}#{self.confidence}").to_s
+  def fingerprint
+    Digest::SHA2.new(256).update(fingerprint_as_s).to_s
   end
 
   def location include_renderer = true
@@ -238,6 +241,7 @@ class Brakeman::Warning
     { :warning_type => self.warning_type,
       :warning_code => @warning_code,
       :fingerprint => self.fingerprint,
+      :fingerprint_as_s => self.fingerprint_as_s,
       :check_name => self.check.gsub(/^Brakeman::Check/, ''),
       :message => self.message,
       :file => self.file,
@@ -263,4 +267,3 @@ class Brakeman::Warning
     formatted
   end
 end
-

--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -208,7 +208,7 @@ class Brakeman::Warning
    output
   end
 
-  def fingerprint_as_s
+  def fingerprint_text
     loc = self.location
     location_string = loc && loc.sort_by { |k, v| k.to_s }.inspect
     warning_code_string = sprintf("%03d", @warning_code)
@@ -217,7 +217,7 @@ class Brakeman::Warning
   end
 
   def fingerprint
-    Digest::SHA2.new(256).update(fingerprint_as_s).to_s
+    Digest::SHA2.new(256).update(fingerprint_text).to_s
   end
 
   def location include_renderer = true
@@ -241,7 +241,7 @@ class Brakeman::Warning
     { :warning_type => self.warning_type,
       :warning_code => @warning_code,
       :fingerprint => self.fingerprint,
-      :fingerprint_as_s => self.fingerprint_as_s,
+      :fingerprint_text => self.fingerprint_text,
       :check_name => self.check.gsub(/^Brakeman::Check/, ''),
       :message => self.message,
       :file => self.file,

--- a/test/tests/json_output.rb
+++ b/test/tests/json_output.rb
@@ -26,7 +26,7 @@ class JSONOutputTests < Minitest::Test
 
   def test_for_expected_warning_keys
     expected = ["warning_type", "check_name", "message", "file", "link", "code", "location",
-      "render_path", "user_input", "confidence", "line", "warning_code", "fingerprint"]
+      "render_path", "user_input", "confidence", "line", "warning_code", "fingerprint", "fingerprint_text"]
 
     @@json["warnings"].each do |warning|
       assert (warning.keys - expected).empty?, "#{(warning.keys - expected).inspect} did not match expected keys"


### PR DESCRIPTION
Occasionally when comparing two brakeman reports to find new warnings introduced by a code change, it will report an old warning and it's not immediately apparent why the code change caused the warning to reappear. You would assume it's because the fingerprint changed, but just seeing that two hashes are different doesn't give you any context for why it changed. This PR breaks up the one fingerprint method into two — one to generate the string and the other to hash it. This allows you to pass the plaintext fingerprint into the warning hash.

It's entirely possible this PR is just adding redundant data to the hash, and we would be fine using the data already in the hash (since it makes up most of the fingerprint), but having access to the fingerprint string would tell you with certainty why a fingerprint changed. I feel like people might find the fingerprint text useful to have, though perhaps it's not needed for most use cases.