### PR TITLE
Improve multi-value Sexp error

### DIFF
--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -50,12 +50,12 @@ class Sexp
   end
 
   def value
-    raise WrongSexpError, "Sexp#value called on multi-item Sexp", caller[1..-1] if size > 2
+    raise WrongSexpError, "Sexp#value called on multi-item Sexp: `#{self.inspect}`" if size > 2
     self[1]
   end
 
   def value= exp
-    raise WrongSexpError, "Sexp#value= called on multi-item Sexp", caller[1..-1] if size > 2
+    raise WrongSexpError, "Sexp#value= called on multi-item Sexp: `#{self.inspect}`" if size > 2
     @my_hash_value = nil
     self[1] = exp
   end


### PR DESCRIPTION
Originally I guess the idea was to point to where the Sexp was actually used since the default report only outputs the first line in the stack trace. But mangling stack traces gets confusing and I think I did it wrong.

Also kind of useful to see the actually Sexp causing the error!