### PR TITLE
require missing `brakeman/version` module

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'brakeman/version'
 
 module Brakeman
 


### PR DESCRIPTION
Since `v3.7.1`, a regression was introduced in https://github.com/presidentbeef/brakeman/commit/c204a92bc1164021f152b83adea01fca339595a3 causing cli call with option `--ensure-latest` to fail.

```ruby
❯ bin/brakeman --ensure-latest --rails4
my_project/vendor/bundle/ruby/2.3.0/gems/brakeman-3.7.1/lib/brakeman.rb:315:in `ensure_latest': uninitialized constant Brakeman::Version (NameError)
	from my_project/vendor/bundle/ruby/2.3.0/gems/brakeman-3.7.1/lib/brakeman/commandline.rb:42:in `check_latest'
	from my_project/vendor/bundle/ruby/2.3.0/gems/brakeman-3.7.1/lib/brakeman/commandline.rb:34:in `run'
	from my_project/vendor/bundle/ruby/2.3.0/gems/brakeman-3.7.1/lib/brakeman/commandline.rb:20:in `start'
	from my_project/vendor/bundle/ruby/2.3.0/gems/brakeman-3.7.1/bin/brakeman:8:in `<top (required)>'
	from bin/brakeman:17:in `load'
	from bin/brakeman:17:in `<main>'
```
