### PR TITLE
Delete unneeded test

### DIFF
--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -26,16 +26,6 @@ class BrakemanTests < Minitest::Test
     assert_equal File.join(absolute_path, "Gemfile"), at.expand_path("Gemfile")
   end
 
-  def test_relative_path_in_warnings
-    relative_path = Pathname.new(File.dirname(__FILE__)).relative_path_from(Pathname.getwd)
-    absolute_path = relative_path.realpath.to_s
-    input = ["-p", relative_path.to_s]
-    options, _ = Brakeman::Options.parse input
-    at = Brakeman::AppTree.from_options options
-
-
-  end
-
   def test_app_tree_flexible_file_paths
     require 'brakeman/options'
     relative_path = File.expand_path(File.join(TEST_PATH, "/apps/rails4_non_standard_structure/"))


### PR DESCRIPTION
I didn't write in an assertion here because the test name said "in_warnings"

I'm assuming the test wants to check how the relative path shows up when an error is thrown? If not, please let me know.

Thanks :octocat:
