### PR TITLE
Switch to plain output format by default

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -213,10 +213,12 @@ module Brakeman
       [:to_markdown]
     when :cc, :to_cc, :codeclimate, :to_codeclimate
       [:to_codeclimate]
-    when :plain ,:to_plain
-      [:to_plain]
+    when :plain ,:to_plain, :text, :to_text, :to_s
+      [:to_text]
+    when :table, :to_table
+      [:to_table]
     else
-      [:to_s]
+      [:to_text]
     end
   end
   private_class_method :get_formats_from_output_format
@@ -239,9 +241,11 @@ module Brakeman
       when /(\.cc|\.codeclimate)$/i
         :to_codeclimate
       when /\.plain$/i
-        :to_plain
+        :to_text
+      when /\.table$/i
+        :to_table
       else
-        :to_s
+        :to_text
       end
     end
   end

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -201,7 +201,7 @@ module Brakeman::Options
 
         opts.on "-f",
           "--format TYPE",
-          [:pdf, :text, :html, :csv, :tabs, :json, :markdown, :codeclimate, :cc, :plain],
+          [:pdf, :text, :html, :csv, :tabs, :json, :markdown, :codeclimate, :cc, :plain, :table],
           "Specify output formats. Default is text" do |type|
 
           type = "s" if type == :text

--- a/lib/brakeman/report.rb
+++ b/lib/brakeman/report.rb
@@ -6,7 +6,7 @@ require 'brakeman/report/report_base'
 class Brakeman::Report
   attr_reader :tracker
 
-  VALID_FORMATS = [:to_html, :to_pdf, :to_csv, :to_json, :to_tabs, :to_hash, :to_s, :to_markdown, :to_codeclimate, :to_plain]
+  VALID_FORMATS = [:to_html, :to_pdf, :to_csv, :to_json, :to_tabs, :to_hash, :to_s, :to_markdown, :to_codeclimate, :to_plain, :to_text]
 
   def initialize app_tree, tracker
     @app_tree = app_tree
@@ -34,10 +34,10 @@ class Brakeman::Report
       Brakeman::Report::Hash
     when :to_markdown
       return self.to_markdown
-    when :to_plain
+    when :to_plain, :to_text, :to_s
       return self.to_plain
-    when :to_s
-      return self.to_s
+    when :to_table
+      return self.to_table
     when :to_pdf
       raise "PDF output is not yet supported."
     else
@@ -64,7 +64,7 @@ class Brakeman::Report
     generate Brakeman::Report::JSON
   end
 
-  def to_s
+  def to_table
     require_report 'table'
     generate Brakeman::Report::Table
   end
@@ -74,10 +74,13 @@ class Brakeman::Report
     generate Brakeman::Report::Markdown
   end
 
-  def to_plain
+  def to_text
     require_report 'text'
     generate Brakeman::Report::Text
   end
+
+  alias to_plain to_text
+  alias to_s to_text
 
   def generate reporter
     reporter.new(@app_tree, @tracker).generate_report

--- a/lib/brakeman/report/report_text.rb
+++ b/lib/brakeman/report/report_text.rb
@@ -186,12 +186,10 @@ class Brakeman::Report::Text < Brakeman::Report::Base
   # ONLY used for generate_controllers to avoid duplication
   def render_array name, cols, values, locals
     controllers = values.map do |name, parent, includes, routes|
-      [
-        label("Controller", name),
-        label("Parent", parent),
-        label("Includes", includes),
-        label("Routes", routes)
-      ]
+      c = [ label("Controller", name) ]
+      c << label("Parent", parent) unless parent.empty?
+      c << label("Includes", includes) unless includes.empty?
+      c << label("Routes", routes)
     end
 
     double_space "Controller Overview", controllers

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -260,15 +260,15 @@ class ConfigTests < Minitest::Test
     output_format_tester({:output_format => :to_tabs}, [:to_tabs])
     output_format_tester({:output_format => :markdown}, [:to_markdown])
     output_format_tester({:output_format => :to_markdown}, [:to_markdown])
-    output_format_tester({:output_format => :others}, [:to_s])
+    output_format_tester({:output_format => :others}, [:to_text])
 
     output_format_tester({:output_files => ['xx.html', 'xx.pdf']}, [:to_html, :to_pdf])
     output_format_tester({:output_files => ['xx.pdf', 'xx.json']}, [:to_pdf, :to_json])
     output_format_tester({:output_files => ['xx.json', 'xx.tabs']}, [:to_json, :to_tabs])
     output_format_tester({:output_files => ['xx.tabs', 'xx.csv']}, [:to_tabs, :to_csv])
-    output_format_tester({:output_files => ['xx.csv', 'xx.xxx']}, [:to_csv, :to_s])
-    output_format_tester({:output_files => ['xx.md', 'xx.xxx']}, [:to_markdown, :to_s])
-    output_format_tester({:output_files => ['xx.xx', 'xx.xx']}, [:to_s, :to_s])
+    output_format_tester({:output_files => ['xx.csv', 'xx.xxx']}, [:to_csv, :to_text])
+    output_format_tester({:output_files => ['xx.md', 'xx.xxx']}, [:to_markdown, :to_text])
+    output_format_tester({:output_files => ['xx.xx', 'xx.xx']}, [:to_text, :to_text])
     output_format_tester({:output_files => ['xx.html', 'xx.pdf', 'xx.csv', 'xx.tabs', 'xx.json', 'xx.md']}, [:to_html, :to_pdf, :to_csv, :to_tabs, :to_json, :to_markdown])
   end
 

--- a/test/tests/report_generation.rb
+++ b/test/tests/report_generation.rb
@@ -52,7 +52,7 @@ class TestReportGeneration < Minitest::Test
   def test_obsolete_reporting
     report = @@report.to_s
 
-    assert report.include? "+Obsolete Ignore Entries+"
+    assert report.include? "Obsolete Ignore Entries"
     assert report.include? "abcdef01234567890ba28050e7faf1d54f218dfa9435c3f65f47cb378c18cf98"
   end
 
@@ -101,7 +101,7 @@ class TestReportGeneration < Minitest::Test
   def test_controller_output
     text_report = @@report.to_s
 
-    assert text_report.include? "+CONTROLLERS+"
+    assert text_report.include? "Controller Overview"
 
     html_report = @@report.to_html
 


### PR DESCRIPTION
To get the original table format, use `-f table` or `-o report.table`.

`-f plain` and `-o report.plain` will continue to work as before.