### PR TITLE
Exit on warn by default

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -71,6 +71,7 @@ module Brakeman
     if @quiet
       options[:report_progress] = false
     end
+
     scan options
   end
 
@@ -156,23 +157,24 @@ module Brakeman
   #Default set of options
   def self.default_options
     { :assume_all_routes => true,
-      :skip_checks => Set.new,
       :check_arguments => true,
-      :safe_methods => Set.new,
-      :min_confidence => 2,
-      :combine_locations => true,
       :collapse_mass_assignment => false,
+      :combine_locations => true,
+      :engine_paths => ["engines/*"],
+      :exit_on_warn => true,
       :highlight_user_input => true,
-      :ignore_redirect_to_model => true,
+      :html_style => "#{File.expand_path(File.dirname(__FILE__))}/brakeman/format/style.css",
       :ignore_model_output => false,
+      :ignore_redirect_to_model => true,
       :index_libs => true,
       :message_limit => 100,
+      :min_confidence => 2,
+      :output_color => true,
       :parallel_checks => true,
       :relative_path => false,
       :report_progress => true,
-      :html_style => "#{File.expand_path(File.dirname(__FILE__))}/brakeman/format/style.css",
-      :output_color => true,
-      :engine_paths => ["engines/*"]
+      :safe_methods => Set.new,
+      :skip_checks => Set.new,
     }
   end
 
@@ -508,7 +510,7 @@ module Brakeman
     missing = Brakeman::Checks.missing_checks(included_checks || Set.new, excluded_checks || Set.new)
 
     unless missing.empty?
-      raise MissingChecksError, "Could not find specified check#{missing.length > 1 ? 's' : ''}: #{missing.to_a.join(', ')}"
+      raise MissingChecksError, "Could not find specified check#{missing.length > 1 ? 's' : ''}: #{missing.map {|c| "`#{c}`"}.join(', ')}"
     end
   end
 

--- a/lib/brakeman/commandline.rb
+++ b/lib/brakeman/commandline.rb
@@ -117,11 +117,11 @@ module Brakeman
       def regular_report options
         tracker = run_brakeman options 
 
-        if options[:exit_on_warn] and not tracker.filtered_warnings.empty?
+        if tracker.options[:exit_on_warn] and not tracker.filtered_warnings.empty?
           quit Brakeman::Warnings_Found_Exit_Code
         end
 
-        if options[:exit_on_error] and tracker.errors.any?
+        if tracker.options[:exit_on_error] and tracker.errors.any?
           quit Brakeman::Errors_Found_Exit_Code
         end
       end

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -55,7 +55,7 @@ module Brakeman::Options
           options[:quiet] = quiet
         end
 
-        opts.on( "-z", "--[no-]exit-on-warn", "Exit code is non-zero if warnings found") do |exit_on_warn|
+        opts.on( "-z", "--[no-]exit-on-warn", "Exit code is non-zero if warnings found (Default)") do |exit_on_warn|
           options[:exit_on_warn] = exit_on_warn
         end
 

--- a/test/tests/commandline.rb
+++ b/test/tests/commandline.rb
@@ -113,9 +113,21 @@ class CommandlineTests < Minitest::Test
     end
   end
 
-  def test_exit_on_warn
+  def test_exit_on_warn_default
     assert_exit Brakeman::Warnings_Found_Exit_Code do
-      scan_app "--exit-on-warn"
+      scan_app
+    end
+  end
+
+  def test_no_exit_on_warn
+    assert_exit do
+      scan_app "--no-exit-on-warn"
+    end
+  end
+
+  def test_exit_on_warn_no_warnings
+    assert_exit do
+      scan_app "-t", "None"
     end
   end
 end


### PR DESCRIPTION
Make `--exit-on-warn` (`-z`) the default.

Also fixes the issue of not respecting `exit_on_warn` or `exit_on_error` settings in configuration files.