### PR TITLE
Stop using CONFIDENCE[...] in checks

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -10,7 +10,9 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
   include Brakeman::Util
   attr_reader :tracker, :warnings
 
-  CONFIDENCE = { :high => 0, :med => 1, :low => 2 }
+  # This is for legacy support.
+  # Use :high, :medium, or :low instead when creating warnings.
+  CONFIDENCE = Brakeman::Warning::CONFIDENCE
 
   Match = Struct.new(:type, :match)
 

--- a/lib/brakeman/checks/check_basic_auth.rb
+++ b/lib/brakeman/checks/check_basic_auth.rb
@@ -30,7 +30,7 @@ class Brakeman::CheckBasicAuth < Brakeman::BaseCheck
               :warning_code => :basic_auth_password,
               :message => "Basic authentication password stored in source code",
               :code => call,
-              :confidence => 0,
+              :confidence => :high,
               :file => controller.file
           break
         end
@@ -50,7 +50,7 @@ class Brakeman::CheckBasicAuth < Brakeman::BaseCheck
               :warning_type => "Basic Auth",
               :warning_code => :basic_auth_password,
               :message => "Basic authentication password stored in source code",
-              :confidence => 0
+              :confidence => :high
       end
     end
   end

--- a/lib/brakeman/checks/check_basic_auth_timing_attack.rb
+++ b/lib/brakeman/checks/check_basic_auth_timing_attack.rb
@@ -26,7 +26,7 @@ class Brakeman::CheckBasicAuthTimingAttack < Brakeman::BaseCheck
         :warning_type => "Timing Attack",
         :warning_code => :CVE_2015_7576,
         :message => "Basic authentication in Rails #{rails_version} is vulnerable to timing attacks. Upgrade to #@upgrade",
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :link => "https://groups.google.com/d/msg/rubyonrails-security/ANv0HDHEC3k/mt7wNGxbFQAJ"
     end
   end

--- a/lib/brakeman/checks/check_content_tag.rb
+++ b/lib/brakeman/checks/check_content_tag.rb
@@ -105,7 +105,7 @@ class Brakeman::CheckContentTag < Brakeman::CheckCrossSiteScripting
         :warning_code => :xss_content_tag,
         :message => message,
         :user_input => input,
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :link_path => "content_tag"
 
     elsif not tracker.options[:ignore_model_output] and match = has_immediate_model?(arg)
@@ -113,9 +113,9 @@ class Brakeman::CheckContentTag < Brakeman::CheckCrossSiteScripting
         add_result result
 
         if likely_model_attribute? match
-          confidence = CONFIDENCE[:high]
+          confidence = :high
         else
-          confidence = CONFIDENCE[:med]
+          confidence = :medium
         end
 
         warn :result => result,
@@ -139,7 +139,7 @@ class Brakeman::CheckContentTag < Brakeman::CheckCrossSiteScripting
         :warning_code => :xss_content_tag,
         :message => message,
         :user_input => @matched,
-        :confidence => CONFIDENCE[:med],
+        :confidence => :medium,
         :link_path => "content_tag"
     end
   end
@@ -159,9 +159,9 @@ class Brakeman::CheckContentTag < Brakeman::CheckCrossSiteScripting
   def check_cve_2016_6316
     if cve_2016_6316?
       confidence = if @content_tags.any?
-                     CONFIDENCE[:high]
+                     :high
                    else
-                     CONFIDENCE[:med]
+                     :medium
                    end
 
       fix_version = case

--- a/lib/brakeman/checks/check_create_with.rb
+++ b/lib/brakeman/checks/check_create_with.rb
@@ -51,15 +51,15 @@ class Brakeman::CheckCreateWith < Brakeman::BaseCheck
     if call? exp and exp.method == :permit
       nil
     elsif request_value? exp
-      CONFIDENCE[:high]
+      :high
     elsif hash? exp
       nil
     elsif has_immediate_user_input?(exp)
-      CONFIDENCE[:high]
+      :high
     elsif include_user_input? exp
-      CONFIDENCE[:med]
+      :medium
     else
-      CONFIDENCE[:low]
+      :weak
     end
   end
 
@@ -68,7 +68,7 @@ class Brakeman::CheckCreateWith < Brakeman::BaseCheck
         :warning_code => :CVE_2014_3514,
         :message => @message,
         :gem_info => gemfile_or_environment,
-        :confidence => CONFIDENCE[:med],
+        :confidence => :medium,
         :link_path => "https://groups.google.com/d/msg/rubyonrails-security/M4chq5Sb540/CC1Fh0Y_NWwJ"
   end
 end

--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -77,7 +77,7 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
         :warning_code => :cross_site_scripting,
         :message => message,
         :code => input.match,
-        :confidence => CONFIDENCE[:high]
+        :confidence => :high
 
     elsif not tracker.options[:ignore_model_output] and match = has_immediate_model?(out)
       method = if call? match
@@ -90,9 +90,9 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
         add_result exp
 
         if likely_model_attribute? match
-          confidence = CONFIDENCE[:high]
+          confidence = :high
         else
-          confidence = CONFIDENCE[:med]
+          confidence = :medium
         end
 
         message = "Unescaped model attribute"
@@ -178,14 +178,14 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
           warning_code = :cross_site_scripting
 
           if @known_dangerous.include? exp.method
-            confidence = CONFIDENCE[:high]
+            confidence = :high
             if exp.method == :to_json
               message += " in JSON hash"
               link_path += "_to_json"
               warning_code = :xss_to_json
             end
           else
-            confidence = CONFIDENCE[:low]
+            confidence = :weak
           end
 
           warn :template => @current_template,

--- a/lib/brakeman/checks/check_default_routes.rb
+++ b/lib/brakeman/checks/check_default_routes.rb
@@ -21,7 +21,7 @@ class Brakeman::CheckDefaultRoutes < Brakeman::BaseCheck
         :warning_code => :all_default_routes,
         :message => "All public methods in controllers are available as actions in routes.rb",
         :line => tracker.routes[:allow_all_actions].line,
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :file => "#{tracker.app_path}/config/routes.rb"
     end
   end
@@ -43,7 +43,7 @@ class Brakeman::CheckDefaultRoutes < Brakeman::BaseCheck
           :warning_code => :controller_default_routes,
           :message => "Any public method in #{name} can be used as an action for #{verb} requests.",
           :line => actions[2],
-          :confidence => CONFIDENCE[:med],
+          :confidence => :medium,
           :file => "#{tracker.app_path}/config/routes.rb"
       end
     end
@@ -67,9 +67,9 @@ class Brakeman::CheckDefaultRoutes < Brakeman::BaseCheck
     end
 
     if allow_all_actions? or @actions_allowed_on_controller
-      confidence = CONFIDENCE[:high]
+      confidence = :high
     else
-      confidence = CONFIDENCE[:med]
+      confidence = :medium
     end
 
     warn :warning_type => "Remote Code Execution",

--- a/lib/brakeman/checks/check_deserialize.rb
+++ b/lib/brakeman/checks/check_deserialize.rb
@@ -36,9 +36,9 @@ class Brakeman::CheckDeserialize < Brakeman::BaseCheck
     method = result[:call].method
 
     if input = has_immediate_user_input?(arg)
-      confidence = CONFIDENCE[:high]
+      confidence = :high
     elsif input = include_user_input?(arg)
-      confidence = CONFIDENCE[:med]
+      confidence = :medium
     end
 
     if confidence

--- a/lib/brakeman/checks/check_detailed_exceptions.rb
+++ b/lib/brakeman/checks/check_detailed_exceptions.rb
@@ -18,7 +18,7 @@ class Brakeman::CheckDetailedExceptions < Brakeman::BaseCheck
       warn :warning_type => "Information Disclosure",
            :warning_code => :local_request_config,
            :message => "Detailed exceptions are enabled in production",
-           :confidence => CONFIDENCE[:high],
+           :confidence => :high,
            :file => "config/environments/production.rb"
     end
   end
@@ -32,9 +32,9 @@ class Brakeman::CheckDetailedExceptions < Brakeman::BaseCheck
 
         if method_name == :show_detailed_exceptions? and not safe? body
           if true? body
-            confidence = CONFIDENCE[:high]
+            confidence = :high
           else
-            confidence = CONFIDENCE[:med]
+            confidence = :medium
           end
 
           warn :warning_type => "Information Disclosure",

--- a/lib/brakeman/checks/check_digest_dos.rb
+++ b/lib/brakeman/checks/check_digest_dos.rb
@@ -19,9 +19,9 @@ class Brakeman::CheckDigestDoS < Brakeman::BaseCheck
     end
 
     if with_http_digest?
-      confidence = CONFIDENCE[:high]
+      confidence = :high
     else
-      confidence = CONFIDENCE[:low]
+      confidence = :weak
     end
 
     warn :warning_type => "Denial of Service",

--- a/lib/brakeman/checks/check_dynamic_finders.rb
+++ b/lib/brakeman/checks/check_dynamic_finders.rb
@@ -26,7 +26,7 @@ class Brakeman::CheckDynamicFinders < Brakeman::BaseCheck
             :warning_type => "SQL Injection",
             :warning_code => :sql_injection_dynamic_finder,
             :message => "MySQL integer conversion may cause 0 to match any string",
-            :confidence => CONFIDENCE[:med],
+            :confidence => :medium,
             :user_input => arg
 
           break

--- a/lib/brakeman/checks/check_escape_function.rb
+++ b/lib/brakeman/checks/check_escape_function.rb
@@ -13,7 +13,7 @@ class Brakeman::CheckEscapeFunction < Brakeman::BaseCheck
       warn :warning_type => 'Cross Site Scripting',
         :warning_code => :CVE_2011_2932,
         :message => 'Versions before 2.3.14 have a vulnerability in escape method when used with Ruby 1.8: CVE-2011-2932',
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :gem_info => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/topic/rubyonrails-security/Vr_7WSOrEZU/discussion"
     end

--- a/lib/brakeman/checks/check_evaluation.rb
+++ b/lib/brakeman/checks/check_evaluation.rb
@@ -29,7 +29,7 @@ class Brakeman::CheckEvaluation < Brakeman::BaseCheck
         :message => "User input in eval",
         :code => result[:call],
         :user_input => input,
-        :confidence => CONFIDENCE[:high]
+        :confidence => :high
     end
   end
 end

--- a/lib/brakeman/checks/check_execute.rb
+++ b/lib/brakeman/checks/check_execute.rb
@@ -56,9 +56,9 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
     if failure and original? result
 
       if failure.type == :interp #Not from user input
-        confidence = CONFIDENCE[:med]
+        confidence = :medium
       else
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       end
 
       warn :result => result,
@@ -79,7 +79,7 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
           :warning_code => :command_injection,
           :message => "Possible command injection in open()",
           :user_input => match,
-          :confidence => CONFIDENCE[:high]
+          :confidence => :high
       end
     end
   end
@@ -111,9 +111,9 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
     exp = result[:call]
 
     if input = include_user_input?(exp)
-      confidence = CONFIDENCE[:high]
+      confidence = :high
     elsif input = dangerous?(exp)
-      confidence = CONFIDENCE[:med]
+      confidence = :medium
     else
       return
     end

--- a/lib/brakeman/checks/check_file_access.rb
+++ b/lib/brakeman/checks/check_file_access.rb
@@ -32,18 +32,18 @@ class Brakeman::CheckFileAccess < Brakeman::BaseCheck
     file_name = call.first_arg
 
     if match = has_immediate_user_input?(file_name)
-      confidence = CONFIDENCE[:high]
+      confidence = :high
     elsif match = has_immediate_model?(file_name)
       match = Match.new(:model, match)
-      confidence = CONFIDENCE[:med]
+      confidence = :medium
     elsif tracker.options[:check_arguments] and
       match = include_user_input?(file_name)
 
       #Check for string building in file name
       if call?(file_name) and (file_name.method == :+ or file_name.method == :<<)
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       else
-        confidence = CONFIDENCE[:low]
+        confidence = :weak
       end
     end
 

--- a/lib/brakeman/checks/check_file_disclosure.rb
+++ b/lib/brakeman/checks/check_file_disclosure.rb
@@ -23,7 +23,7 @@ class Brakeman::CheckFileDisclosure < Brakeman::BaseCheck
       warn :warning_type => "File Access",
         :warning_code => :CVE_2014_7829,
         :message => "Rails #{rails_version} has a file existence disclosure. Upgrade to #{fix_version} or disable serving static assets",
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :gem_info => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/msg/rubyonrails-security/23fiuwb1NBA/MQVM1-5GkPMJ"
     end

--- a/lib/brakeman/checks/check_filter_skipping.rb
+++ b/lib/brakeman/checks/check_filter_skipping.rb
@@ -13,7 +13,7 @@ class Brakeman::CheckFilterSkipping < Brakeman::BaseCheck
       warn :warning_type => "Default Routes",
         :warning_code => :CVE_2011_2929,
         :message => "Versions before 3.0.10 have a vulnerability which allows filters to be bypassed: CVE-2011-2929",
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :gem_info => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/topic/rubyonrails-security/NCCsca7TEtY/discussion"
     end

--- a/lib/brakeman/checks/check_forgery_setting.rb
+++ b/lib/brakeman/checks/check_forgery_setting.rb
@@ -29,7 +29,7 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
             :warning_type => "Cross-Site Request Forgery",
             :warning_code => :csrf_not_protected_by_raising_exception,
             :message => "protect_from_forgery should be configured with 'with: :exception'",
-            :confidence => CONFIDENCE[:med],
+            :confidence => :medium,
             :file => controller.file
           }
 
@@ -50,7 +50,7 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
     opts = {
       :controller => :ApplicationController,
       :warning_type => "Cross-Site Request Forgery",
-      :confidence => CONFIDENCE[:high]
+      :confidence => :high
     }.merge opts
 
     warn opts

--- a/lib/brakeman/checks/check_header_dos.rb
+++ b/lib/brakeman/checks/check_header_dos.rb
@@ -18,7 +18,7 @@ class Brakeman::CheckHeaderDoS < Brakeman::BaseCheck
       warn :warning_type => "Denial of Service",
         :warning_code => :CVE_2013_6414,
         :message => message,
-        :confidence => CONFIDENCE[:med],
+        :confidence => :medium,
         :gem_info => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/msg/ruby-security-ann/A-ebV4WxzKg/KNPTbX8XAQUJ"
     end

--- a/lib/brakeman/checks/check_i18n_xss.rb
+++ b/lib/brakeman/checks/check_i18n_xss.rb
@@ -21,7 +21,7 @@ class Brakeman::CheckI18nXSS < Brakeman::BaseCheck
       warn :warning_type => "Cross Site Scripting",
         :warning_code => :CVE_2013_4491,
         :message => message,
-        :confidence => CONFIDENCE[:med],
+        :confidence => :medium,
         :gem_info => gemfile_or_environment(:i18n),
         :link_path => "https://groups.google.com/d/msg/ruby-security-ann/pLrh6DUw998/bLFEyIO4k_EJ"
     end

--- a/lib/brakeman/checks/check_jruby_xml.rb
+++ b/lib/brakeman/checks/check_jruby_xml.rb
@@ -31,7 +31,7 @@ class Brakeman::CheckJRubyXML < Brakeman::BaseCheck
     warn :warning_type => "File Access",
       :warning_code => :CVE_2013_1856,
       :message => "Rails #{rails_version} with JRuby has a vulnerability in XML parser: upgrade to #{fix_version} or patch",
-      :confidence => CONFIDENCE[:high],
+      :confidence => :high,
       :gem_info => gemfile_or_environment,
       :link => "https://groups.google.com/d/msg/rubyonrails-security/KZwsQbYsOiI/5kUV7dSCJGwJ"
   end

--- a/lib/brakeman/checks/check_json_encoding.rb
+++ b/lib/brakeman/checks/check_json_encoding.rb
@@ -16,9 +16,9 @@ class Brakeman::CheckJSONEncoding < Brakeman::BaseCheck
       end
 
       if tracker.find_call(:methods => [:to_json, :encode]).any?
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       else
-        confidence = CONFIDENCE[:med]
+        confidence = :medium
       end
 
       warn :warning_type => "Cross Site Scripting",

--- a/lib/brakeman/checks/check_json_parsing.rb
+++ b/lib/brakeman/checks/check_json_parsing.rb
@@ -30,7 +30,7 @@ class Brakeman::CheckJSONParsing < Brakeman::BaseCheck
       warn :warning_type => "Remote Code Execution",
         :warning_code => :CVE_2013_0333,
         :message => message,
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :gem_info => gem_info,
         :link_path => "https://groups.google.com/d/topic/rubyonrails-security/1h2DR63ViGo/discussion"
     end
@@ -71,11 +71,11 @@ class Brakeman::CheckJSONParsing < Brakeman::BaseCheck
               (version >= "1.5.5" and version < "1.6.0")
 
     warning_type = "Denial of Service"
-    confidence = CONFIDENCE[:med]
+    confidence = :medium
     message = "#{name} gem version #{version} has a symbol creation vulnerablity: upgrade to "
 
     if version >= "1.7.0"
-      confidence = CONFIDENCE[:high]
+      confidence = :high
       warning_type = "Remote Code Execution"
       message = "#{name} gem version #{version} has a remote code vulnerablity: upgrade to 1.7.7"
     elsif version >= "1.6.0"
@@ -83,12 +83,12 @@ class Brakeman::CheckJSONParsing < Brakeman::BaseCheck
     elsif version >= "1.5.0"
       message << "1.5.5"
     else
-      confidence = CONFIDENCE[:low]
+      confidence = :weak
       message << "1.5.5"
     end
 
-    if confidence == CONFIDENCE[:med] and uses_json_parse?
-      confidence = CONFIDENCE[:high]
+    if confidence == :medium and uses_json_parse?
+      confidence = :high
     end
 
     warn :warning_type => warning_type,

--- a/lib/brakeman/checks/check_link_to.rb
+++ b/lib/brakeman/checks/check_link_to.rb
@@ -70,7 +70,7 @@ class Brakeman::CheckLinkTo < Brakeman::CheckCrossSiteScripting
 
     message = "Unescaped #{friendly_type_of input} in link_to"
 
-    warn_xss(result, message, input, CONFIDENCE[:high])
+    warn_xss(result, message, input, :high)
   end
 
   # Check if we should warn about the specified method
@@ -81,8 +81,8 @@ class Brakeman::CheckLinkTo < Brakeman::CheckCrossSiteScripting
     method = match.method
     return false if IGNORE_MODEL_METHODS.include? method
 
-    confidence = CONFIDENCE[:med]
-    confidence = CONFIDENCE[:high] if likely_model_attribute? match
+    confidence = :medium
+    confidence = :high if likely_model_attribute? match
     warn_xss(result, "Unescaped model attribute in link_to", match, confidence)
   end
 
@@ -93,7 +93,7 @@ class Brakeman::CheckLinkTo < Brakeman::CheckCrossSiteScripting
 
     message = "Unescaped #{friendly_type_of matched} in link_to"
 
-    warn_xss(result, message, @matched, CONFIDENCE[:med])
+    warn_xss(result, message, @matched, :medium)
   end
 
   # Create a warn for this xss

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -52,7 +52,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
           :warning_code => :xss_link_to_href,
           :message => message,
           :user_input => input,
-          :confidence => CONFIDENCE[:high],
+          :confidence => :high,
           :link_path => "link_to_href"
       end
     elsif has_immediate_model? url_arg or model_find_call? url_arg
@@ -85,7 +85,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
           :warning_code => :xss_link_to_href,
           :message => message,
           :user_input => @matched,
-          :confidence => CONFIDENCE[:med],
+          :confidence => :medium,
           :link_path => "link_to_href"
       end
     end

--- a/lib/brakeman/checks/check_mail_to.rb
+++ b/lib/brakeman/checks/check_mail_to.rb
@@ -23,7 +23,7 @@ class Brakeman::CheckMailTo < Brakeman::BaseCheck
         :warning_type => "Mail Link",
         :warning_code => :CVE_2011_0446,
         :message => message,
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :gem_info => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/topic/rubyonrails-security/8CpI7egxX4E/discussion"
     end

--- a/lib/brakeman/checks/check_mass_assignment.rb
+++ b/lib/brakeman/checks/check_mass_assignment.rb
@@ -80,9 +80,9 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
           return
         elsif not node_type? first_arg, :hash
           if attr_protected
-            confidence = CONFIDENCE[:med]
+            confidence = :medium
           else
-            confidence = CONFIDENCE[:high]
+            confidence = :high
           end
         else
           return
@@ -90,7 +90,7 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
       elsif node_type? call.first_arg, :lit, :str
         return
       else
-        confidence = CONFIDENCE[:low]
+        confidence = :weak
         input = nil
       end
 
@@ -182,9 +182,9 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
     return unless original? result
 
     confidence = if subsequent_mass_assignment? result
-                   CONFIDENCE[:high]
+                   :high
                  else
-                   CONFIDENCE[:med]
+                   :medium
                  end
 
     warn :result => result,

--- a/lib/brakeman/checks/check_mime_type_dos.rb
+++ b/lib/brakeman/checks/check_mime_type_dos.rb
@@ -24,7 +24,7 @@ class Brakeman::CheckMimeTypeDoS < Brakeman::BaseCheck
     warn :warning_type => "Denial of Service",
       :warning_code => :CVE_2016_0751,
       :message => message,
-      :confidence => CONFIDENCE[:med],
+      :confidence => :medium,
       :gem_info => gemfile_or_environment,
       :link_path => "https://groups.google.com/d/msg/rubyonrails-security/9oLY_FCzvoc/w9oI9XxbFQAJ"
   end

--- a/lib/brakeman/checks/check_model_attr_accessible.rb
+++ b/lib/brakeman/checks/check_model_attr_accessible.rb
@@ -11,11 +11,11 @@ class Brakeman::CheckModelAttrAccessible < Brakeman::BaseCheck
   @description = "Reports models which have dangerous attributes defined under the attr_accessible whitelist."
 
   SUSP_ATTRS = [
-    [:admin, CONFIDENCE[:high]], # Very dangerous unless some Rails authorization used
-    [:role, CONFIDENCE[:med]],
-    [:banned, CONFIDENCE[:med]],
-    [:account_id, CONFIDENCE[:high]],
-    [/\S*_id(s?)\z/, CONFIDENCE[:low]] # All other foreign keys have weak/low confidence
+    [:admin, :high], # Very dangerous unless some Rails authorization used
+    [:role, :medium],
+    [:banned, :medium],
+    [:account_id, :high],
+    [/\S*_id(s?)\z/, :weak] # All other foreign keys have weak/low confidence
   ]
 
   def run_check

--- a/lib/brakeman/checks/check_model_attributes.rb
+++ b/lib/brakeman/checks/check_model_attributes.rb
@@ -31,7 +31,7 @@ class Brakeman::CheckModelAttributes < Brakeman::BaseCheck
           :warning_type => "Attribute Restriction",
           :warning_code => :no_attr_accessible,
           :message => "Mass assignment is not restricted using attr_accessible",
-          :confidence => CONFIDENCE[:high]
+          :confidence => :high
       end
 
       unless protected_names.empty?
@@ -60,7 +60,7 @@ class Brakeman::CheckModelAttributes < Brakeman::BaseCheck
             :warning_type => "Attribute Restriction",
             :warning_code => :no_attr_accessible,
             :message => "Mass assignment is not restricted using attr_accessible",
-            :confidence => CONFIDENCE[:high]
+            :confidence => :high
         elsif not tracker.options[:ignore_attr_protected]
           message, confidence, link = check_for_attr_protected_bypass
 
@@ -106,11 +106,11 @@ class Brakeman::CheckModelAttributes < Brakeman::BaseCheck
 
     if upgrade_version
       message = "attr_protected is bypassable in #{rails_version}, use attr_accessible or upgrade to #{upgrade_version}"
-      confidence = CONFIDENCE[:high]
+      confidence = :high
       link = "https://groups.google.com/d/topic/rubyonrails-security/AFBKNY7VSH8/discussion"
     else
       message = "attr_accessible is recommended over attr_protected"
-      confidence = CONFIDENCE[:med]
+      confidence = :medium
       link = nil
     end
 

--- a/lib/brakeman/checks/check_model_serialize.rb
+++ b/lib/brakeman/checks/check_model_serialize.rb
@@ -49,9 +49,9 @@ class Brakeman::CheckModelSerialize < Brakeman::BaseCheck
       end
 
       if attrs.empty?
-        confidence = CONFIDENCE[:med]
+        confidence = :medium
       else
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       end
 
       warn :model => model.name,

--- a/lib/brakeman/checks/check_nested_attributes.rb
+++ b/lib/brakeman/checks/check_nested_attributes.rb
@@ -22,7 +22,7 @@ class Brakeman::CheckNestedAttributes < Brakeman::BaseCheck
       warn :warning_type => "Nested Attributes",
         :warning_code => :CVE_2010_3933,
         :message => message,
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :gem_info => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/topic/rubyonrails-security/-fkT0yja_gw/discussion"
     end

--- a/lib/brakeman/checks/check_nested_attributes_bypass.rb
+++ b/lib/brakeman/checks/check_nested_attributes_bypass.rb
@@ -38,7 +38,7 @@ class Brakeman::CheckNestedAttributesBypass < Brakeman::BaseCheck
       :message => message,
       :file => model.file,
       :line => args.line,
-      :confidence => CONFIDENCE[:med],
+      :confidence => :medium,
       :link_path => "https://groups.google.com/d/msg/rubyonrails-security/cawsWcQ6c8g/tegZtYdbFQAJ"
   end
 

--- a/lib/brakeman/checks/check_number_to_currency.rb
+++ b/lib/brakeman/checks/check_number_to_currency.rb
@@ -34,7 +34,7 @@ class Brakeman::CheckNumberToCurrency < Brakeman::BaseCheck
     warn :warning_type => "Cross Site Scripting",
       :warning_code => :CVE_2014_0081,
       :message => message,
-      :confidence => CONFIDENCE[:med],
+      :confidence => :medium,
       :gem_info => gemfile_or_environment,
       :link_path => "https://groups.google.com/d/msg/ruby-security-ann/9WiRn2nhfq0/2K2KRB4LwCMJ"
   end
@@ -67,7 +67,7 @@ class Brakeman::CheckNumberToCurrency < Brakeman::BaseCheck
       :warning_type => "Cross Site Scripting",
       :warning_code => :CVE_2014_0081_call,
       :message => "Format options in #{result[:call].method} are not safe in Rails #{rails_version}",
-      :confidence => CONFIDENCE[:high],
+      :confidence => :high,
       :link_path => "https://groups.google.com/d/msg/ruby-security-ann/9WiRn2nhfq0/2K2KRB4LwCMJ",
       :user_input => match
   end

--- a/lib/brakeman/checks/check_quote_table_name.rb
+++ b/lib/brakeman/checks/check_quote_table_name.rb
@@ -12,9 +12,9 @@ class Brakeman::CheckQuoteTableName < Brakeman::BaseCheck
         version_between?('3.0.0', '3.0.9'))
 
       if uses_quote_table_name?
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       else
-        confidence = CONFIDENCE[:med]
+        confidence = :medium
       end
 
       if rails_version =~ /^3/

--- a/lib/brakeman/checks/check_redirect.rb
+++ b/lib/brakeman/checks/check_redirect.rb
@@ -41,9 +41,9 @@ class Brakeman::CheckRedirect < Brakeman::BaseCheck
         res = include_user_input?(call)
 
       if res.type == :immediate
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       else
-        confidence = CONFIDENCE[:low]
+        confidence = :weak
       end
 
       warn :result => result,

--- a/lib/brakeman/checks/check_regex_dos.rb
+++ b/lib/brakeman/checks/check_regex_dos.rb
@@ -35,12 +35,12 @@ class Brakeman::CheckRegexDoS < Brakeman::BaseCheck
       next unless sexp? component
 
       if match = has_immediate_user_input?(component)
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       elsif match = has_immediate_model?(component)
         match = Match.new(:model, match)
-        confidence = CONFIDENCE[:med]
+        confidence = :medium
       elsif match = include_user_input?(component)
-        confidence = CONFIDENCE[:low]
+        confidence = :weak
       end
 
       if match

--- a/lib/brakeman/checks/check_render.rb
+++ b/lib/brakeman/checks/check_render.rb
@@ -36,12 +36,12 @@ class Brakeman::CheckRender < Brakeman::BaseCheck
 
       if input = has_immediate_user_input?(view)
         if string_interp? view
-          confidence = CONFIDENCE[:med]
+          confidence = :medium
         else
-          confidence = CONFIDENCE[:high]
+          confidence = :high
         end
       elsif input = include_user_input?(view)
-        confidence = CONFIDENCE[:low]
+        confidence = :weak
       else
         return
       end
@@ -77,7 +77,7 @@ class Brakeman::CheckRender < Brakeman::BaseCheck
           :warning_code => :dynamic_render_path_rce,
           :message => "Passing query parameters to render() is vulnerable in Rails #{rails_version} (CVE-2016-0752)",
           :user_input => view,
-          :confidence => CONFIDENCE[:high]
+          :confidence => :high
       end
     end
   end

--- a/lib/brakeman/checks/check_render_dos.rb
+++ b/lib/brakeman/checks/check_render_dos.rb
@@ -30,7 +30,7 @@ class Brakeman::CheckRenderDoS < Brakeman::BaseCheck
     warn :warning_type => "Denial of Service",
       :warning_code => :CVE_2014_0082,
       :message => message,
-      :confidence => CONFIDENCE[:high],
+      :confidence => :high,
       :link_path => "https://groups.google.com/d/msg/rubyonrails-security/LMxO_3_eCuc/ozGBEhKaJbIJ",
       :gem_info => gemfile_or_environment
   end

--- a/lib/brakeman/checks/check_render_inline.rb
+++ b/lib/brakeman/checks/check_render_inline.rb
@@ -28,14 +28,14 @@ class Brakeman::CheckRenderInline < Brakeman::CheckCrossSiteScripting
             :warning_code => :cross_site_scripting_inline,
             :message => "Unescaped #{friendly_type_of input} rendered inline",
             :user_input => input,
-            :confidence => CONFIDENCE[:high]
+            :confidence => :high
         elsif input = has_immediate_model?(render_value)
           warn :result => result,
             :warning_type => "Cross Site Scripting",
             :warning_code => :cross_site_scripting_inline,
             :message => "Unescaped model attribute rendered inline",
             :user_input => input,
-            :confidence => CONFIDENCE[:med]
+            :confidence => :medium
         end
       end
     end

--- a/lib/brakeman/checks/check_response_splitting.rb
+++ b/lib/brakeman/checks/check_response_splitting.rb
@@ -13,7 +13,7 @@ class Brakeman::CheckResponseSplitting < Brakeman::BaseCheck
       warn :warning_type => "Response Splitting",
         :warning_code => :CVE_2011_3186,
         :message => "Versions before 2.3.14 have a vulnerability content type handling allowing injection of headers: CVE-2011-3186",
-        :confidence => CONFIDENCE[:med],
+        :confidence => :medium,
         :gem_info => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/topic/rubyonrails-security/b_yTveAph2g/discussion"
     end

--- a/lib/brakeman/checks/check_route_dos.rb
+++ b/lib/brakeman/checks/check_route_dos.rb
@@ -21,7 +21,7 @@ class Brakeman::CheckRouteDoS < Brakeman::BaseCheck
       warn :warning_type => "Denial of Service",
         :warning_code => :CVE_2015_7581,
         :message => message,
-        :confidence => CONFIDENCE[:med],
+        :confidence => :medium,
         :gem_info => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/msg/rubyonrails-security/dthJ5wL69JE/YzPnFelbFQAJ"
     end

--- a/lib/brakeman/checks/check_safe_buffer_manipulation.rb
+++ b/lib/brakeman/checks/check_safe_buffer_manipulation.rb
@@ -25,7 +25,7 @@ class Brakeman::CheckSafeBufferManipulation < Brakeman::BaseCheck
     warn :warning_type => "Cross Site Scripting",
       :warning_code => :safe_buffer_vuln, 
       :message => message,
-      :confidence => CONFIDENCE[:med],
+      :confidence => :medium,
       :gem_info => gemfile_or_environment
   end
 end

--- a/lib/brakeman/checks/check_sanitize_methods.rb
+++ b/lib/brakeman/checks/check_sanitize_methods.rb
@@ -46,16 +46,16 @@ class Brakeman::CheckSanitizeMethods < Brakeman::BaseCheck
       message = "Rails #{rails_version} has a vulnerability in #{method}: upgrade to #{@fix_version} or patch"
 
       if include_user_input? result[:call]
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       else
-        confidence = CONFIDENCE[:medium]
+        confidence = :medium
       end
 
       warn :result => result,
         :warning_type => "Cross Site Scripting",
         :warning_code => code,
         :message => message,
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :link_path => link
     end
   end
@@ -64,9 +64,9 @@ class Brakeman::CheckSanitizeMethods < Brakeman::BaseCheck
     message = "rails-html-sanitizer #{tracker.config.gem_version(:'rails-html-sanitizer')} is vulnerable (#{cve}). Upgrade to 1.0.3"
 
     if tracker.find_call(:target => false, :method => :sanitize).any?
-      confidence = CONFIDENCE[:high]
+      confidence = :high
     else
-      confidence = CONFIDENCE[:med]
+      confidence = :medium
     end
 
     warn :warning_type => "Cross Site Scripting",

--- a/lib/brakeman/checks/check_secrets.rb
+++ b/lib/brakeman/checks/check_secrets.rb
@@ -25,7 +25,7 @@ class Brakeman::CheckSecrets < Brakeman::BaseCheck
           warn :warning_code => :secret_in_source,
             :warning_type => "Authentication",
             :message => "Hardcoded value for #{name} in source code",
-            :confidence => CONFIDENCE[:med],
+            :confidence => :medium,
             :file => constant.file,
             :line => constant.line
         end

--- a/lib/brakeman/checks/check_select_tag.rb
+++ b/lib/brakeman/checks/check_select_tag.rb
@@ -50,7 +50,7 @@ class Brakeman::CheckSelectTag < Brakeman::BaseCheck
           :warning_code => :CVE_2012_3463,
           :result => result,
           :message => @message,
-          :confidence => CONFIDENCE[:high],
+          :confidence => :high,
           :user_input => input,
           :link_path => "https://groups.google.com/d/topic/rubyonrails-security/fV3QUToSMSw/discussion"
       end

--- a/lib/brakeman/checks/check_select_vulnerability.rb
+++ b/lib/brakeman/checks/check_select_vulnerability.rb
@@ -44,9 +44,9 @@ class Brakeman::CheckSelectVulnerability < Brakeman::BaseCheck
       add_result result
 
       if string_interp? third_arg
-        confidence = CONFIDENCE[:med]
+        confidence = :medium
       else
-        confidence = CONFIDENCE[:low]
+        confidence = :weak
       end
 
       warn :template => result[:location][:template],

--- a/lib/brakeman/checks/check_send.rb
+++ b/lib/brakeman/checks/check_send.rb
@@ -30,7 +30,7 @@ class Brakeman::CheckSend < Brakeman::BaseCheck
         :message => "User controlled method execution",
         :code => result[:call],
         :user_input => input,
-        :confidence => CONFIDENCE[:high]
+        :confidence => :high
     end
   end
 

--- a/lib/brakeman/checks/check_session_manipulation.rb
+++ b/lib/brakeman/checks/check_session_manipulation.rb
@@ -18,9 +18,9 @@ class Brakeman::CheckSessionManipulation < Brakeman::BaseCheck
 
     if input = has_immediate_user_input?(index)
       if params? index
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       else
-        confidence = CONFIDENCE[:med]
+        confidence = :medium
       end
 
       warn :result => result,

--- a/lib/brakeman/checks/check_session_settings.rb
+++ b/lib/brakeman/checks/check_session_settings.rb
@@ -137,7 +137,7 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
     warn :warning_type => "Session Setting",
       :warning_code => :http_cookies,
       :message => "Session cookies should be set to HTTP only",
-      :confidence => CONFIDENCE[:high],
+      :confidence => :high,
       :line => line,
       :file => file
 
@@ -147,7 +147,7 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
     warn :warning_type => "Session Setting",
       :warning_code => :session_secret,
       :message => "Session secret should not be included in version control",
-      :confidence => CONFIDENCE[:high],
+      :confidence => :high,
       :line => line,
       :file => file
   end
@@ -156,7 +156,7 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
     warn :warning_type => "Session Setting",
       :warning_code => :secure_cookies,
       :message => "Session cookie should be set to secure only",
-      :confidence => CONFIDENCE[:high],
+      :confidence => :high,
       :line => line,
       :file => file
   end

--- a/lib/brakeman/checks/check_simple_format.rb
+++ b/lib/brakeman/checks/check_simple_format.rb
@@ -21,7 +21,7 @@ class Brakeman::CheckSimpleFormat < Brakeman::CheckCrossSiteScripting
     warn :warning_type => "Cross Site Scripting",
       :warning_code => :CVE_2013_6416,
       :message => message,
-      :confidence => CONFIDENCE[:med],
+      :confidence => :medium,
       :gem_info => gemfile_or_environment,
       :link_path => "https://groups.google.com/d/msg/ruby-security-ann/5ZI1-H5OoIM/ZNq4FoR2GnIJ"
   end
@@ -51,7 +51,7 @@ class Brakeman::CheckSimpleFormat < Brakeman::CheckCrossSiteScripting
       :warning_type => "Cross Site Scripting",
       :warning_code => :CVE_2013_6416_call,
       :message => "Values passed to simple_format are not safe in Rails #{rails_version}",
-      :confidence => CONFIDENCE[:high],
+      :confidence => :high,
       :link_path => "https://groups.google.com/d/msg/ruby-security-ann/5ZI1-H5OoIM/ZNq4FoR2GnIJ",
       :user_input => match
   end

--- a/lib/brakeman/checks/check_single_quotes.rb
+++ b/lib/brakeman/checks/check_single_quotes.rb
@@ -32,7 +32,7 @@ class Brakeman::CheckSingleQuotes < Brakeman::BaseCheck
     warn :warning_type => "Cross Site Scripting",
       :warning_code => :CVE_2012_3464,
       :message => message,
-      :confidence => CONFIDENCE[:med],
+      :confidence => :medium,
       :gem_info => gemfile_or_environment,
       :link_path => "https://groups.google.com/d/topic/rubyonrails-security/kKGNeMrnmiY/discussion"
   end

--- a/lib/brakeman/checks/check_skip_before_filter.rb
+++ b/lib/brakeman/checks/check_skip_before_filter.rb
@@ -28,7 +28,7 @@ class Brakeman::CheckSkipBeforeFilter < Brakeman::BaseCheck
         :warning_code => :csrf_blacklist,
         :message => "Use whitelist (:only => [..]) when skipping CSRF check",
         :code => filter,
-        :confidence => CONFIDENCE[:med],
+        :confidence => :medium,
         :file => controller.file
 
     when :login_required, :authenticate_user!, :require_user
@@ -37,7 +37,7 @@ class Brakeman::CheckSkipBeforeFilter < Brakeman::BaseCheck
         :warning_type => "Authentication",
         :message => "Use whitelist (:only => [..]) when skipping authentication",
         :code => filter,
-        :confidence => CONFIDENCE[:med],
+        :confidence => :medium,
         :link => "authentication_whitelist",
         :file => controller.file
     end

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -207,19 +207,19 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
 
       input = include_user_input? dangerous_value
       if input
-        confidence = CONFIDENCE[:high]
+        confidence = :high
         user_input = input
       else
-        confidence = CONFIDENCE[:med]
+        confidence = :medium
         user_input = dangerous_value
       end
 
       if result[:call].target and result[:chain] and not @expected_targets.include? result[:chain].first
         confidence = case confidence
-                     when CONFIDENCE[:high]
-                       CONFIDENCE[:med]
-                     when CONFIDENCE[:med]
-                       CONFIDENCE[:low]
+                     when :high
+                       :medium
+                     when :medium
+                       :weak
                      else
                        confidence
                      end
@@ -235,9 +235,9 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
 
     if check_for_limit_or_offset_vulnerability call.last_arg
       if include_user_input? call.last_arg
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       else
-        confidence = CONFIDENCE[:low]
+        confidence = :weak
       end
 
       warn :result => result,

--- a/lib/brakeman/checks/check_sql_cves.rb
+++ b/lib/brakeman/checks/check_sql_cves.rb
@@ -79,7 +79,7 @@ class Brakeman::CheckSQLCVEs < Brakeman::BaseCheck
     warn :warning_type => 'SQL Injection',
       :warning_code => code,
       :message => "Rails #{rails_version} contains a SQL injection vulnerability (#{cve}). Upgrade to #{upgrade_version}",
-      :confidence => CONFIDENCE[:high],
+      :confidence => :high,
       :gem_info => gemfile_or_environment,
       :link_path => link
   end
@@ -99,7 +99,7 @@ class Brakeman::CheckSQLCVEs < Brakeman::BaseCheck
     warn :warning_type => 'SQL Injection',
       :warning_code => :CVE_2014_0080,
       :message => "Rails #{rails_version} contains a SQL injection vulnerability (CVE-2014-0080) with PostgreSQL. Upgrade to 4.0.3",
-      :confidence => CONFIDENCE[:high],
+      :confidence => :high,
       :gem_info => gemfile_or_environment(:pg),
       :link_path => "https://groups.google.com/d/msg/rubyonrails-security/Wu96YkTUR6s/pPLBMZrlwvYJ"
   end

--- a/lib/brakeman/checks/check_ssl_verify.rb
+++ b/lib/brakeman/checks/check_ssl_verify.rb
@@ -43,6 +43,6 @@ class Brakeman::CheckSSLVerify < Brakeman::BaseCheck
       :warning_type => "SSL Verification Bypass",
       :warning_code => :ssl_verification_bypass,
       :message => "SSL certificate verification was bypassed",
-      :confidence => CONFIDENCE[:high]
+      :confidence => :high
   end
 end

--- a/lib/brakeman/checks/check_strip_tags.rb
+++ b/lib/brakeman/checks/check_strip_tags.rb
@@ -34,7 +34,7 @@ class Brakeman::CheckStripTags < Brakeman::BaseCheck
         :warning_code => :CVE_2011_2931,
         :message => message,
         :gem_info => gemfile_or_environment,
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :link_path => "https://groups.google.com/d/topic/rubyonrails-security/K5EwdJt06hI/discussion"
     end
   end
@@ -56,7 +56,7 @@ class Brakeman::CheckStripTags < Brakeman::BaseCheck
     warn :warning_type => "Cross Site Scripting",
       :warning_code => :CVE_2012_3465,
       :message => message,
-      :confidence => CONFIDENCE[:high],
+      :confidence => :high,
       :gem_info => gemfile_or_environment,
       :link_path => "https://groups.google.com/d/topic/rubyonrails-security/FgVEtBajcTY/discussion"
   end
@@ -64,9 +64,9 @@ class Brakeman::CheckStripTags < Brakeman::BaseCheck
   def cve_2015_7579
     if tracker.config.gem_version(:'rails-html-sanitizer') == '1.0.2'
       if uses_strip_tags?
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       else
-        confidence = CONFIDENCE[:med]
+        confidence = :medium
       end
 
       message = "rails-html-sanitizer 1.0.2 is vulnerable (CVE-2015-7579). Upgrade to 1.0.3"

--- a/lib/brakeman/checks/check_symbol_dos.rb
+++ b/lib/brakeman/checks/check_symbol_dos.rb
@@ -28,9 +28,9 @@ class Brakeman::CheckSymbolDoS < Brakeman::BaseCheck
     end
 
     if input = args.map{ |arg| has_immediate_user_input?(arg) }.compact.first
-      confidence = CONFIDENCE[:high]
+      confidence = :high
     elsif input = args.map{ |arg| include_user_input?(arg) }.compact.first
-      confidence = CONFIDENCE[:med]
+      confidence = :medium
     end
 
     if confidence

--- a/lib/brakeman/checks/check_symbol_dos_cve.rb
+++ b/lib/brakeman/checks/check_symbol_dos_cve.rb
@@ -21,7 +21,7 @@ class Brakeman::CheckSymbolDoSCVE < Brakeman::BaseCheck
       warn :warning_type => "Denial of Service",
         :warning_code => :CVE_2013_1854,
         :message => "Rails #{rails_version} has a denial of service vulnerability in ActiveRecord: upgrade to #{fix_version} or patch",
-        :confidence => CONFIDENCE[:med],
+        :confidence => :medium,
         :gem_info => gemfile_or_environment,
         :link => "https://groups.google.com/d/msg/rubyonrails-security/jgJ4cjjS8FE/BGbHRxnDRTIJ"
     end

--- a/lib/brakeman/checks/check_translate_bug.rb
+++ b/lib/brakeman/checks/check_translate_bug.rb
@@ -13,9 +13,9 @@ class Brakeman::CheckTranslateBug < Brakeman::BaseCheck
         version_between?('3.1.0', '3.1.1')
 
       confidence = if uses_translate?
-        CONFIDENCE[:high]
+        :high
       else
-        CONFIDENCE[:med]
+        :medium
       end
 
       description = "have a vulnerability in the translate helper with keys ending in _html"

--- a/lib/brakeman/checks/check_unsafe_reflection.rb
+++ b/lib/brakeman/checks/check_unsafe_reflection.rb
@@ -31,9 +31,9 @@ class Brakeman::CheckUnsafeReflection < Brakeman::BaseCheck
     end
 
     if input = has_immediate_user_input?(arg)
-      confidence = CONFIDENCE[:high]
+      confidence = :high
     elsif input = include_user_input?(arg)
-      confidence = CONFIDENCE[:med]
+      confidence = :medium
     end
 
     if confidence

--- a/lib/brakeman/checks/check_unscoped_find.rb
+++ b/lib/brakeman/checks/check_unscoped_find.rb
@@ -35,7 +35,7 @@ class Brakeman::CheckUnscopedFind < Brakeman::BaseCheck
       :warning_code => :unscoped_find,
       :message      => "Unscoped call to #{result[:target]}##{result[:method]}",
       :code         => result[:call],
-      :confidence   => CONFIDENCE[:low],
+      :confidence   => :weak,
       :user_input   => input
   end
 end

--- a/lib/brakeman/checks/check_validation_regex.rb
+++ b/lib/brakeman/checks/check_validation_regex.rb
@@ -91,7 +91,7 @@ class Brakeman::CheckValidationRegex < Brakeman::BaseCheck
       :warning_code => :validation_regex,
       :message => "Insufficient validation for '#{get_name validator}' using #{regex.inspect}. Use \\A and \\z as anchors",
       :line => value.line,
-      :confidence => CONFIDENCE[:high]
+      :confidence => :high
     end
   end
 

--- a/lib/brakeman/checks/check_weak_hash.rb
+++ b/lib/brakeman/checks/check_weak_hash.rb
@@ -29,14 +29,14 @@ class Brakeman::CheckWeakHash < Brakeman::BaseCheck
 
     if DIGEST_CALLS.include? call.method
       if input = user_input_as_arg?(call)
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       elsif input = hashing_password?(call)
-        confidence = CONFIDENCE[:high]
+        confidence = :high
       else
-        confidence = CONFIDENCE[:med]
+        confidence = :medium
       end
     else
-      confidence = CONFIDENCE[:med]
+      confidence = :medium
     end
 
 
@@ -75,7 +75,7 @@ class Brakeman::CheckWeakHash < Brakeman::BaseCheck
       :warning_type => "Weak Hash",
       :warning_code => :weak_hash_hmac,
       :message => "Weak hashing algorithm (#{alg}) used in HMAC",
-      :confidence => CONFIDENCE[:med]
+      :confidence => :medium
   end
 
   def process_openssl_result result
@@ -91,7 +91,7 @@ class Brakeman::CheckWeakHash < Brakeman::BaseCheck
           :warning_type => "Weak Hash",
           :warning_code => :weak_hash_digest,
           :message => "Weak hashing algorithm (#{alg}) used",
-          :confidence => CONFIDENCE[:med]
+          :confidence => :medium
       end
     end
   end

--- a/lib/brakeman/checks/check_without_protection.rb
+++ b/lib/brakeman/checks/check_without_protection.rb
@@ -42,11 +42,11 @@ class Brakeman::CheckWithoutProtection < Brakeman::BaseCheck
           add_result res
 
           if input = include_user_input?(call.arglist)
-            confidence = CONFIDENCE[:high]
+            confidence = :high
           elsif all_literals? call
             return
           else
-            confidence = CONFIDENCE[:med]
+            confidence = :medium
           end
 
           warn :result => res, 

--- a/lib/brakeman/checks/check_xml_dos.rb
+++ b/lib/brakeman/checks/check_xml_dos.rb
@@ -28,7 +28,7 @@ class Brakeman::CheckXMLDoS < Brakeman::BaseCheck
     warn :warning_type => "Denial of Service",
       :warning_code => :CVE_2015_3227,
       :message => message,
-      :confidence => CONFIDENCE[:med],
+      :confidence => :medium,
       :gem_info => gemfile_or_environment,
       :link_path => "https://groups.google.com/d/msg/rubyonrails-security/bahr2JLnxvk/x4EocXnHPp8J"
   end

--- a/lib/brakeman/checks/check_yaml_parsing.rb
+++ b/lib/brakeman/checks/check_yaml_parsing.rb
@@ -27,7 +27,7 @@ class Brakeman::CheckYAMLParsing < Brakeman::BaseCheck
       warn :warning_type => "Remote Code Execution",
         :warning_code => :CVE_2013_0156,
         :message => message,
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :gem_info => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/topic/rubyonrails-security/61bkgvnSGTQ/discussion"
     end
@@ -39,7 +39,7 @@ class Brakeman::CheckYAMLParsing < Brakeman::BaseCheck
       warn :warning_type => "Remote Code Execution",
         :warning_code => :CVE_2013_0156,
         :message => message,
-        :confidence => CONFIDENCE[:high],
+        :confidence => :high,
         :gem_info => gemfile_or_environment,
         :link_path => "https://groups.google.com/d/topic/rubyonrails-security/61bkgvnSGTQ/discussion"
     end

--- a/lib/brakeman/report/report_base.rb
+++ b/lib/brakeman/report/report_base.rb
@@ -10,7 +10,7 @@ class Brakeman::Report::Base
 
   attr_reader :tracker, :checks
 
-  TEXT_CONFIDENCE = [ "High", "Medium", "Weak" ]
+  TEXT_CONFIDENCE = Brakeman::Warning::TEXT_CONFIDENCE
 
   def initialize app_tree, tracker
     @app_tree = app_tree

--- a/lib/brakeman/report/report_base.rb
+++ b/lib/brakeman/report/report_base.rb
@@ -3,6 +3,7 @@ require 'brakeman/util'
 require 'brakeman/version'
 require 'brakeman/report/renderer'
 require 'brakeman/processors/output_processor'
+require 'brakeman/warning'
 
 # Base class for report formats
 class Brakeman::Report::Base

--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -10,27 +10,39 @@ class Brakeman::Warning
 
   attr_accessor :code, :context, :file, :message, :relative_path
 
-  TEXT_CONFIDENCE = [ "High", "Medium", "Weak" ]
+  TEXT_CONFIDENCE = {
+    0 => "High",
+    1 => "Medium",
+    2 => "Weak",
+  }
 
-  OPTIONS = {:called_from => :@called_from,
-              :check => :@check,
-              :class => :@class,
-              :code => :@code,
-              :confidence => :@confidence,
-              :controller => :@controller,
-              :file => :@file,
-              :gem_info => :@gem_info,
-              :line => :@line,
-              :link_path => :@link_path,
-              :message => :@message,
-              :method => :@method,
-              :model => :@model,
-              :relative_path => :@relative_path,
-              :template => :@template,
-              :user_input => :@user_input,
-              :warning_set => :@warning_set,
-              :warning_type => :@warning_type
-            }
+  CONFIDENCE = {
+    :high => 0,
+    :med => 1,
+    :medium => 1,
+    :low => 2,
+    :weak => 2,
+  }
+
+  OPTIONS = {
+    :called_from => :@called_from,
+    :check => :@check,
+    :class => :@class,
+    :code => :@code,
+    :controller => :@controller,
+    :file => :@file,
+    :gem_info => :@gem_info,
+    :line => :@line,
+    :link_path => :@link_path,
+    :message => :@message,
+    :method => :@method,
+    :model => :@model,
+    :relative_path => :@relative_path,
+    :template => :@template,
+    :user_input => :@user_input,
+    :warning_set => :@warning_set,
+    :warning_type => :@warning_type,
+  }
 
   #+options[:result]+ can be a result from Tracker#find_call. Otherwise, it can be +nil+.
   def initialize options = {}
@@ -39,6 +51,8 @@ class Brakeman::Warning
     OPTIONS.each do |key, var|
       self.instance_variable_set(var, options[key])
     end
+
+    self.confidence = options[:confidence]
 
     result = options[:result]
     if result
@@ -111,6 +125,20 @@ class Brakeman::Warning
 
   def eql? other_warning
     self.hash == other_warning.hash
+  end
+
+  def confidence= conf
+    @confidence = case conf
+                  when Integer
+                    conf
+                  when Symbol
+                    CONFIDENCE[conf]
+                  else
+                    raise "Could not set confidence to `#{conf}`"
+                  end
+
+    raise "Could not set confidence to `#{conf}`" unless @confidence
+    raise "Invalid confidence: `#{@confidence}`" unless TEXT_CONFIDENCE[@confidence]
   end
 
   #Returns name of a view, including where it was rendered from

--- a/test/tests/warning.rb
+++ b/test/tests/warning.rb
@@ -1,0 +1,29 @@
+require 'brakeman/warning'
+
+class WarningTests < Minitest::Test
+  def test_confidence_symbols
+    [:high, :med, :medium, :low, :weak].each do |c|
+      w = Brakeman::Warning.new(confidence: c) 
+      assert_equal Brakeman::Warning::CONFIDENCE[c], w.confidence
+    end
+  end
+
+  def test_confidence_integers
+    [0, 1, 2].each do |c|
+      w = Brakeman::Warning.new(confidence: c) 
+      assert_equal c, w.confidence
+    end
+  end
+
+  def test_bad_confidence_symbol
+    assert_raises do
+      Brakeman::Warning.new(confidence: :blah)
+    end
+  end
+
+  def test_bad_confidence_integer
+    assert_raises do
+      Brakeman::Warning.new(confidence: 10)
+    end
+  end
+end


### PR DESCRIPTION
Just use `:high`, `:medium`, or `:low`/`:weak` instead.

Moves `CONFIDENCE` to `Brakeman::Warnings::CONFIDENCE` as well.