### PR TITLE
Fewer link_to warnings

### DIFF
--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -36,7 +36,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     @matched = false
     url_arg = process call.second_arg
 
-    if call? url_arg and url_arg.method == :url_for
+    if check_argument? url_arg
       url_arg = url_arg.first_arg
     end
 
@@ -71,6 +71,17 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     end
   end
 
+  def check_argument? url_arg
+    return unless call? url_arg
+
+    target = url_arg.target
+    method = url_arg.method
+
+    method == :url_for or
+      method == :h or
+      cgi_escaped? target, method
+  end
+
   def ignore_model_call? url_arg, exp
     return true unless call? exp
 
@@ -80,7 +91,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     return true unless model_find_call? target
 
     return true unless method.to_s =~ /url|uri|link|page|site/
-    
+
     ignore_call? target, method or
       IGNORE_MODEL_METHODS.include? method or
       ignore_interpolation? url_arg, exp

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -78,6 +78,8 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
     method = exp.method
 
     return true unless model_find_call? target
+
+    return true unless method.to_s =~ /url|uri|link|page|site/
     
     ignore_call? target, method or
       IGNORE_MODEL_METHODS.include? method or

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -55,39 +55,6 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
           :confidence => CONFIDENCE[:high],
           :link_path => "link_to_href"
       end
-    elsif has_immediate_model? url_arg or model_find_call? url_arg
-
-      # Decided NOT warn on models.  polymorphic_path is called it a model is
-      # passed to link_to (which passes it to url_for)
-
-    elsif array? url_arg
-      # Just like models, polymorphic path/url is called if the argument is
-      # an array
-
-    elsif hash? url_arg
-
-      # url_for uses the key/values pretty carefully and I don't see a risk.
-      # IF you have default routes AND you accept user input for :controller
-      # and :only_path, then MAYBE you could trigger a javascript:/data:
-      # attack.
-
-    elsif @matched
-      if @matched.type == :model and not tracker.options[:ignore_model_output]
-        message = "Unsafe model attribute in link_to href"
-      elsif @matched.type == :params and not call_on_params? @matched.match
-        message = "Unsafe parameter value in link_to href"
-      end
-
-      if message and not duplicate? result and not ignore_interpolation? url_arg, @matched.match
-        add_result result
-        warn :result => result,
-          :warning_type => "Cross Site Scripting",
-          :warning_code => :xss_link_to_href,
-          :message => message,
-          :user_input => @matched,
-          :confidence => CONFIDENCE[:med],
-          :link_path => "link_to_href"
-      end
     end
   end
 

--- a/test/apps/rails2/app/views/home/test_params.html.erb
+++ b/test/apps/rails2/app/views/home/test_params.html.erb
@@ -13,7 +13,7 @@ Not-so-dangerous href: <%= link_to "some text", ensure_valid_proto!(params[:not_
 
 Dangerous href: <%= link_to "more text", params[:dangerous] %>
 
-Still dangerous hrefs: <%= link_to "donkey", not_safe(params[:bad_robot]) %>
+Not going to warn: <%= link_to "donkey", not_safe(params[:bad_robot]) %>
 
 Not completely safe: <%= link_to "Helvetica hoodie bushwick", h(params[:js_xss]) %>
 

--- a/test/apps/rails3/app/views/home/test_params.html.erb
+++ b/test/apps/rails3/app/views/home/test_params.html.erb
@@ -13,7 +13,7 @@ Not-so-dangerous href: <%= link_to "some text", ensure_valid_proto!(params[:not_
 
 Dangerous href: <%= link_to "more text", params[:dangerous] %>
 
-Still dangerous hrefs: <%= link_to "donkey", not_safe(params[:bad_robot]) %>
+Not going to warn: <%= link_to "donkey", not_safe(params[:bad_robot]) %>
 
 Not completely safe: <%= link_to "Helvetica hoodie bushwick", h(params[:js_xss]) %>
 

--- a/test/apps/rails4/app/views/another/various_xss.html.erb
+++ b/test/apps/rails4/app/views/another/various_xss.html.erb
@@ -1,10 +1,10 @@
 <%= link_to 'stuff', cool_thing_url(params[:x]) %> Don't warn
-<%= link_to 'stuff', Thing.find(params[:id]).home_url %> Warn
-<%= link_to 'stuff', Thing.find(params[:id]).home_path %> Don't warn
-<%= link_to 'other stuff', home_path(Thing.find(params[:id])) %> Don't warn
+<%= link_to 'stuff', User.find(params[:id]).home_url %> Warn
+<%= link_to 'stuff', User.find(params[:id]).home_path %> Don't warn
+<%= link_to 'other stuff', home_path(User.find(params[:id])) %> Don't warn
 <%= raw(x(params[:x])) %> Warn with warning code 2 not 5
-<% form_for Thing.first do |t| %>
-  <%== t.select(things, Thing.new(params[:t]).stuff) %>
+<% form_for User.first do |t| %>
+  <%== t.select(things, User.new(params[:t]).stuff) %>
 <% end %>
 
 <%= link_to 'Bars', current_user.bars.find(params[:id]) %> Don't warn

--- a/test/tests/markdown_output.rb
+++ b/test/tests/markdown_output.rb
@@ -9,9 +9,9 @@ class TestMarkdownOutput < Minitest::Test
 
   def test_reported_warnings
     if Brakeman::Scanner::RUBY_1_9
-      assert_equal 172, @@report.lines.to_a.count
+      assert_equal 170, @@report.lines.to_a.count
     else
-      assert_equal 173, @@report.lines.to_a.count
+      assert_equal 171, @@report.lines.to_a.count
     end
   end
 end

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -1486,13 +1486,13 @@ class Rails2WithOptionsTests < Minitest::Test
       @expected ||= {
         :controller => 1,
         :model => 4,
-        :template => 47,
+        :template => 46,
         :generic => 57 }
     else
       @expected ||= {
         :controller => 1,
         :model => 4,
-        :template => 47,
+        :template => 46,
         :generic => 58 }
     end
   end

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -14,13 +14,13 @@ class Rails2Tests < Minitest::Test
       @expected ||= {
         :controller => 1,
         :model => 3,
-        :template => 47,
+        :template => 46,
         :generic => 57 }
     else
       @expected ||= {
         :controller => 1,
         :model => 3,
-        :template => 47,
+        :template => 46,
         :generic => 58 }
     end
   end
@@ -537,7 +537,7 @@ class Rails2Tests < Minitest::Test
       :file => /test_params\.html\.erb/,
       :relative_path => "app/views/home/test_params.html.erb"
 
-    assert_warning :type => :template,
+    assert_no_warning :type => :template,
       :warning_type => "Cross Site Scripting",
       :line => 16,
       :message => /^Unsafe parameter value in link_to href/,
@@ -549,7 +549,7 @@ class Rails2Tests < Minitest::Test
       :warning_type => "Cross Site Scripting",
       :line => 18,
       :message => /^Unsafe parameter value in link_to href/,
-      :confidence => 1,
+      :confidence => 0,
       :file => /test_params\.html\.erb/,
       :relative_path => "app/views/home/test_params.html.erb"
   end

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -13,7 +13,7 @@ class Rails3Tests < Minitest::Test
     @expected ||= {
       :controller => 1,
       :model => 9,
-      :template => 42,
+      :template => 41,
       :generic => 76
     }
 
@@ -565,18 +565,17 @@ class Rails3Tests < Minitest::Test
       :confidence => 0,
       :file => /test_params\.html\.erb/
 
-    assert_warning :type => :template,
+    assert_no_warning :type => :template,
       :warning_type => "Cross Site Scripting",
       :line => 16,
       :message => /^Unsafe parameter value in link_to href/,
-      :confidence => 1,
       :file => /test_params\.html\.erb/
 
     assert_warning :type => :template,
       :warning_type => "Cross Site Scripting",
       :line => 18,
       :message => /^Unsafe parameter value in link_to href/,
-      :confidence => 1,
+      :confidence => 0,
       :file => /test_params\.html\.erb/
   end
 

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -843,13 +843,14 @@ class Rails4Tests < Minitest::Test
   def test_cross_site_scripting_warn_on_url_methods_in_href
     assert_warning :type => :template,
       :warning_code => 4,
-      :fingerprint => "92d5f7afb5676d2aca85d6dc796d3606ec225c178a3727ba6a790138276a7c1c",
+      :fingerprint => "31b5a196d06699ced844270d876e7af818f5487dd82d713a47790798c1d6effd",
       :warning_type => "Cross Site Scripting",
       :line => 2,
-      :message => /^Unsafe\ parameter\ value\ in\ link_to\ href/,
-      :confidence => 1,
+      :message => /^Potentially\ unsafe\ model\ attribute\ in\ li/,
+      :confidence => 2,
       :relative_path => "app/views/another/various_xss.html.erb",
-      :user_input => s(:call, nil, :params)
+      :code => s(:call, nil, :link_to, s(:str, "stuff"), s(:call, s(:call, s(:const, :User), :find, s(:call, s(:call, nil, :params), :[], s(:lit, :id))), :home_url)),
+      :user_input => s(:call, s(:call, s(:const, :User), :find, s(:call, s(:call, nil, :params), :[], s(:lit, :id))), :home_url)
   end
 
   def test_cross_site_scripting_no_warning_on_path_methods_in_href

--- a/test/tests/tabs_output.rb
+++ b/test/tests/tabs_output.rb
@@ -9,9 +9,9 @@ class TestTabsOutput < Minitest::Test
 
   def test_reported_warnings
     if Brakeman::Scanner::RUBY_1_9
-      assert_equal 110, @@report.lines.to_a.count
+      assert_equal 108, @@report.lines.to_a.count
     else
-      assert_equal 111, @@report.lines.to_a.count
+      assert_equal 109, @@report.lines.to_a.count
     end
   end
 end


### PR DESCRIPTION
Only warn on direct user input and model attributes that look like URLs.