### PR TITLE
Document --no-pager option

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -173,7 +173,7 @@ To compare results of a scan with a previous scan, use the JSON output option an
 
 This will output JSON with two lists: one of fixed warnings and one of new warnings.
 
-By default, brakeman opens output in editor. To have brakeman output to terminal, use
+By default, brakeman opens output in `less` pager. To have brakeman output directly to terminal, use
 
     brakeman --no-pager
 

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -173,6 +173,10 @@ To compare results of a scan with a previous scan, use the JSON output option an
 
 This will output JSON with two lists: one of fixed warnings and one of new warnings.
 
+By default, brakeman opens output in editor. To have brakeman output to terminal, use
+
+    brakeman --no-pager
+
 ## Ignoring Stuff
 
 Brakeman will ignore warnings if configured to do so. By default, it looks for a configuration file in `config/brakeman.ignore`.


### PR DESCRIPTION
Version 4.0.0 of brakeman is outputting to terminal by default but is opening report in [`less` pager](https://www.wikiwand.com/en/Less_(Unix)).

If you don't want this behaviour and want to have it output to STDOUT, you have to use `--no-pager` option.

This behaviour made our CI script hang since `brakeman` command opened report in `less` pager.