### PR TITLE
Provide way to run tests via Docker

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,18 @@
+FROM ruby:2.4-alpine
+MAINTAINER Justin Collins
+
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app
+COPY brakeman.gemspec /usr/src/app
+COPY gem_common.rb /usr/src/app
+COPY lib/brakeman/version.rb /usr/src/app/lib/brakeman/
+
+RUN DOCKER_DEVELOPMENT=1 bundle install --jobs 4
+
+RUN adduser -u 9000 -D app && \
+    chown -R app:app /usr/src/app
+USER app
+
+ENV DOCKER_DEVELOPMENT=1
+CMD ["/usr/src/app/bin/codeclimate-brakeman"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec :name => "brakeman"
 
-unless ENV['BM_PACKAGE']
+unless ENV['BM_PACKAGE'] || ENV['DOCKER_DEVELOPMENT']
   gem "rake", "< 10.2.0"
   gem "codeclimate-test-reporter", group: :test, require: nil
   gem "json", "< 2.0", group: :test, require: nil # For Ruby 1.9.3 https://github.com/colszowka/simplecov/issues/511

--- a/test/README.md
+++ b/test/README.md
@@ -15,3 +15,19 @@ Run `ruby test/tests/some_file.rb` to run a single file of tests.
 ## Single Test
 
 Ruby `ruby test/test.rb --name test_something` to run a single test.
+
+## With Docker
+
+1. Make the docker development image
+
+```
+docker build -t brakeman-development -f Dockerfile.development .
+```
+
+2. Run tests mounting the current directory
+
+(mounting the current directory allows code changes without requiring an image rebuild)
+
+```
+docker run --mount type=bind,source="$(pwd)",target=/usr/src/app --rm brakeman-development ruby test/tests/codeclimate_output.rb
+```


### PR DESCRIPTION
Not having to setup a whole ruby environment locally makes it easier to write and run tests especially if new to the project (or away from it for a long time and your environment has changed).