### PR TITLE
Support "app_path" configuration for Code Climate engine

### DIFF
--- a/lib/brakeman/codeclimate/engine_configuration.rb
+++ b/lib/brakeman/codeclimate/engine_configuration.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module Brakeman
   module Codeclimate
     class EngineConfiguration
@@ -37,6 +39,12 @@ module Brakeman
 
         if engine_config["include_paths"]
           @configured_options[:only_files] = engine_config["include_paths"].compact
+        end
+
+        if brakeman_configuration["app_path"]
+          @configured_options[:path_prefix] = brakeman_configuration["app_path"]
+          path = Pathname.new(Dir.pwd) + brakeman_configuration["app_path"]
+          @configured_options[:app_path] = path.to_s
         end
         @configured_options
       end

--- a/lib/brakeman/report/report_codeclimate.rb
+++ b/lib/brakeman/report/report_codeclimate.rb
@@ -1,5 +1,6 @@
 require "json"
 require "yaml"
+require "pathname"
 
 class Brakeman::Report::CodeClimate < Brakeman::Report::Base
   DOCUMENTATION_PATH = File.expand_path("../../../../docs/warning_types", __FILE__)
@@ -24,7 +25,7 @@ class Brakeman::Report::CodeClimate < Brakeman::Report::Base
       severity: severity_level_for(warning.confidence),
       remediation_points: remediation_points_for(warning_code_name),
       location: {
-        path: warning.relative_path,
+        path: file_path(warning),
         lines: {
           begin: warning.line || 1,
           end: warning.line || 1,
@@ -66,5 +67,13 @@ class Brakeman::Report::CodeClimate < Brakeman::Report::Base
     filename = File.join(DOCUMENTATION_PATH, directory, "index.markdown")
 
     File.read(filename) if File.exist?(filename)
+  end
+
+  def file_path(warning)
+    fp = Pathname.new(warning.relative_path)
+    if tracker.options[:path_prefix]
+      fp = Pathname.new(tracker.options[:path_prefix]) + fp
+    end
+    fp.to_s
   end
 end

--- a/test/tests/codeclimate_engine_configuration.rb
+++ b/test/tests/codeclimate_engine_configuration.rb
@@ -2,12 +2,14 @@ require_relative '../test'
 require 'brakeman/codeclimate/engine_configuration'
 
 class EngineConfigurationTests < Minitest::Test
-  def test_keys_exist
+  def test_for_expected_keys
     config = {
       "include_paths" => ["/foo"]
     }
-    assert_equal [:app_path, :only_files, :output_files, :output_format, :pager, :quiet],
-      Brakeman::Codeclimate::EngineConfiguration.new(config).options.keys.sort
+
+    expected = [:app_path, :only_files, :output_files, :output_format, :pager, :quiet]
+    actual = Brakeman::Codeclimate::EngineConfiguration.new(config).options.keys.sort
+    assert_equal expected, actual
   end
 
   def test_debug_key

--- a/test/tests/codeclimate_output.rb
+++ b/test/tests/codeclimate_output.rb
@@ -28,4 +28,10 @@ class TestCodeClimateOutput < Minitest::Test
       assert issue["content"]["body"].length > 0
     end
   end
+
+  def test_file_path_with_prefix
+    report = Brakeman.run({app_path: "#{TEST_PATH}/apps/rails2", path_prefix: "apps/rails2"}).report.to_codeclimate
+    issues ||= report.split("\0").map { |json| JSON.parse(json) }
+    assert issues.first["location"]["path"].start_with?("apps/rails2")
+  end
 end


### PR DESCRIPTION
This allows users of the Code Climate engine to specify a sub-directory to scan (something Brakeman itself has supported for a long time).

This support required 2 changes:

1. Scanning the subdirectory which is specified as "app_path" under the brakeman "config" block in a .codeclimate.yml
2. After scanning, ensuring that paths in reported issues are prefixed with the specified "app_path". This ensures that reported paths are from the root of the project (as required by Code Climate) instead of from the root of the application.