### PR TITLE
Handle nested destructuring/multiple assignment

### DIFF
--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1030,4 +1030,12 @@ class AliasProcessorTests < Minitest::Test
       params.symbolize_keys[:x]
     OUTPUT
   end
+
+  def test_array_destructuring_asgn
+    assert_alias "1", <<-INPUT
+    x = [:a, [0, 1], :b, :c]
+    a, (x, y), b, c = x
+    y
+    INPUT
+  end
 end


### PR DESCRIPTION
For example:

```ruby
   x = [:a, [0, 1], :b, :c]
   a, (x, y), b, c = x
   a
   b
   c
   x
   y
```

will be interpreted as

```ruby
   x = [:a, [0, 1], :b, :c]
   a, (x, y), b, c = [:a, [0, 1], :b, :c]
   :a
   :b
   :c
   0
   1
```