### PR TITLE
Avoid warning about file access for temp files

### DIFF
--- a/lib/brakeman/checks/check_file_access.rb
+++ b/lib/brakeman/checks/check_file_access.rb
@@ -47,7 +47,8 @@ class Brakeman::CheckFileAccess < Brakeman::BaseCheck
       end
     end
 
-    if match
+    if match and not temp_file? match.match
+
       message = "#{friendly_type_of(match).capitalize} used in file name"
 
       warn :result => result,
@@ -57,6 +58,14 @@ class Brakeman::CheckFileAccess < Brakeman::BaseCheck
         :confidence => confidence,
         :code => call,
         :user_input => match
+    end
+  end
+
+  def temp_file? exp
+    if call? exp
+      return true if exp.call_chain.include? :tempfile
+
+      params? exp.target and exp.method == :path
     end
   end
 end

--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -4,6 +4,7 @@
 class Sexp
   attr_accessor :original_line, :or_depth
   ASSIGNMENT_BOOL = [:gasgn, :iasgn, :lasgn, :cvdecl, :cvasgn, :cdecl, :or, :and, :colon2, :op_asgn_or]
+  CALLS = [:call, :attrasgn, :safe_call, :safe_attrasgn]
 
   def method_missing name, *args
     #Brakeman does not use this functionality,
@@ -305,6 +306,21 @@ class Sexp
     else
       nil
     end
+  end
+
+  def call_chain
+    expect :call, :attrasgn, :safe_call, :safe_attrasgn
+
+    chain = []
+    call = self
+
+    while call.class == Sexp and CALLS.include? call.first 
+      chain << call.method
+      call = call.target
+    end
+
+    chain.reverse!
+    chain
   end
 
   #Returns condition of an if expression:

--- a/test/apps/rails5/lib/a_lib.rb
+++ b/test/apps/rails5/lib/a_lib.rb
@@ -3,4 +3,9 @@ class JustAClass
     joins("INNER JOIN things ON id = #{params[:id]}").
     joins("INNER JOIN things ON stuff = 1")
   end
+
+  def tempfile
+    FileUtils.move(params.permit(:my_upload => ([:upload])).dig("my_upload", "upload").tempfile.path, "/tmp/new_temp_file")
+    FileUtils.move(params.permit(:my_upload => ([:upload])).dig("my_upload", "upload").path, "/tmp/new_temp_file")
+  end
 end

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -377,6 +377,30 @@ class Rails5Tests < Minitest::Test
       :user_input => s(:if, s(:true), s(:dstr, "bar = ", s(:evstr, s(:call, s(:call, s(:colon2, s(:const, :ActiveRecord), :Base), :connection), :quote, s(:true)))), nil)
   end
 
+  def test_tempfile_access
+    assert_no_warning :type => :warning,
+      :warning_code => 16,
+      :fingerprint => "4c1ffee385f7f0318d609a3675b13d9eeaf6da3ce6a7953df523c7d6ba4d24b5",
+      :warning_type => "File Access",
+      :line => 8,
+      :message => /^Parameter\ value\ used\ in\ file\ name/,
+      :confidence => 0,
+      :relative_path => "lib/a_lib.rb",
+      :code => s(:call, s(:const, :FileUtils), :move, s(:call, s(:call, s(:call, s(:call, s(:params), :permit, s(:hash, s(:lit, :my_upload), s(:array, s(:lit, :upload)))), :dig, s(:str, "my_upload"), s(:str, "upload")), :tempfile), :path), s(:str, "/tmp/new_temp_file")),
+      :user_input => s(:call, s(:call, s(:call, s(:call, s(:params), :permit, s(:hash, s(:lit, :my_upload), s(:array, s(:lit, :upload)))), :dig, s(:str, "my_upload"), s(:str, "upload")), :tempfile), :path)
+
+    assert_no_warning :type => :warning,
+      :warning_code => 16,
+      :fingerprint => "9783fd98e5657e76e8337bc7b319b101e8cf5ab3b290d69d5f00eee3a86e4ebd",
+      :warning_type => "File Access",
+      :line => 9,
+      :message => /^Parameter\ value\ used\ in\ file\ name/,
+      :confidence => 0,
+      :relative_path => "lib/a_lib.rb",
+      :code => s(:call, s(:const, :FileUtils), :move, s(:call, s(:call, s(:call, s(:params), :permit, s(:hash, s(:lit, :my_upload), s(:array, s(:lit, :upload)))), :dig, s(:str, "my_upload"), s(:str, "upload")), :path), s(:str, "/tmp/new_temp_file")),
+      :user_input => s(:call, s(:call, s(:call, s(:params), :permit, s(:hash, s(:lit, :my_upload), s(:array, s(:lit, :upload)))), :dig, s(:str, "my_upload"), s(:str, "upload")), :path)
+  end
+
   def test_cross_site_scripting_CVE_2015_7578
     assert_warning :type => :warning,
       :warning_code => 96,

--- a/test/tests/sexp.rb
+++ b/test/tests/sexp.rb
@@ -404,4 +404,23 @@ class SexpTests < Minitest::Test
       s(:blah, 1, 2).value
     end
   end
+
+  def test_call_chain
+    s = RubyParser.new.parse "w.new.x.y(:stuff).z.to_s(1)"
+    cc = [:w, :new, :x, :y, :z, :to_s]
+
+    assert_equal cc, s.call_chain
+  end
+
+  def test_short_call_chain
+    s = Sexp.new(:call, nil, :x)
+
+    assert_equal [:x], s.call_chain
+  end
+
+  def test_local_call_chain
+    s = Sexp.new(:call, s(:lvar, :z), :x)
+
+    assert_equal [:x], s.call_chain
+  end
 end


### PR DESCRIPTION
In particular, calls to `params[...].tempfile.path` or `params[...].path`.