### PR TITLE
Add optional divide by zero check

### DIFF
--- a/lib/brakeman/checks/check_divide_by_zero.rb
+++ b/lib/brakeman/checks/check_divide_by_zero.rb
@@ -1,0 +1,40 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckDivideByZero < Brakeman::BaseCheck
+  Brakeman::Checks.add_optional self
+
+  @description = "Warns on potential division by zero"
+
+  def run_check
+    tracker.find_call(:method => :"/").each do |result|
+      check_division result
+    end
+  end
+
+  def check_division result
+    call = result[:call]
+
+    denominator = call.first_arg
+
+    if number? denominator and denominator.value == 0
+      numerator = call.target
+
+      if number? numerator
+        if numerator.value.is_a? Float
+          return # 0.0 / 0 is NaN and 1.0 / 0 is Infinity
+        else
+          confidence = :medium
+        end
+      else
+        confidence = :weak
+      end
+
+      warn :result => result,
+        :warning_type => "Divide by Zero",
+        :warning_code => :divide_by_zero,
+        :message => "Potential division by zero",
+        :confidence => confidence,
+        :user_input => denominator
+    end
+  end
+end

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -235,14 +235,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       end
     when :/
       if number? target and number? first_arg
-        if first_arg.value == 0 and not target.value.is_a? Float
-          if @tracker
-            location = [@current_class, @current_method, "line #{first_arg.line}"].compact.join(' ')
-            require 'brakeman/processors/output_processor'
-            code = Brakeman::OutputProcessor.new.format(exp)
-            @tracker.error Exception.new("Potential divide by zero: #{code} (#{location})")
-          end
-        else
+        unless first_arg.value == 0 and not target.value.is_a? Float
           exp = Sexp.new(:lit, target.value / first_arg.value)
         end
       end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -105,6 +105,7 @@ module Brakeman::WarningCodes
     :secret_in_source => 101,
     :CVE_2016_6316 => 102,
     :CVE_2016_6317 => 103,
+    :divide_by_zero => 104,
   }
 
   def self.code name

--- a/test/apps/rails5/lib/a_lib.rb
+++ b/test/apps/rails5/lib/a_lib.rb
@@ -3,4 +3,14 @@ class JustAClass
     joins("INNER JOIN things ON id = #{params[:id]}").
     joins("INNER JOIN things ON stuff = 1")
   end
+
+  def divide_by_zero
+    whatever / 0 # warns
+
+    x = 100
+    y = x - 100
+    z = x / y # warns
+
+    1.0 / 0 # does not warn
+  end
 end

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -13,7 +13,7 @@ class Rails5Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 9,
-      :generic => 12
+      :generic => 14
     }
   end
 
@@ -66,6 +66,32 @@ class Rails5Tests < Minitest::Test
       :confidence => 1,
       :relative_path => "app/models/thing.rb",
       :user_input => s(:call, nil, :quoted_primary_key)
+  end
+
+  def test_divide_by_zero_1
+    assert_warning :type => :warning,
+      :warning_code => 104,
+      :fingerprint => "f0729f7446e41e51883e58c74aa0789c0c7a48ab832f16c17b7eaba01a21ce6e",
+      :warning_type => "Divide by Zero",
+      :line => 8,
+      :message => /^Potential\ division\ by\ zero/,
+      :confidence => 2,
+      :relative_path => "lib/a_lib.rb",
+      :code => s(:call, s(:call, nil, :whatever), :/, s(:lit, 0)),
+      :user_input => s(:lit, 0)
+  end
+
+  def test_divide_by_zero_2
+    assert_warning :type => :warning,
+      :warning_code => 104,
+      :fingerprint => "9ca769ad11ef57b7490caccc70af1bb8a623dfca2e84e5593d8dec901d3841f2",
+      :warning_type => "Divide by Zero",
+      :line => 12,
+      :message => /^Potential\ division\ by\ zero/,
+      :confidence => 1,
+      :relative_path => "lib/a_lib.rb",
+      :code => s(:call, s(:lit, 100), :/, s(:lit, 0)),
+      :user_input => s(:lit, 0)
   end
 
   def test_dangerous_send_with_safe_call


### PR DESCRIPTION
instead of reporting as an error, as implicitly requested in #1103.