### PR TITLE
Better processing of `op_asgn1`

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -567,19 +567,26 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   #Assignments like this
   # x[:y] ||= 1
   def process_op_asgn1 exp
-    return process_default(exp) if exp[3] != :"||"
+    target_var = exp[1]
+    target_var &&= target_var.deep_clone
 
     target = exp[1] = process(exp[1])
     index = exp[2][1] = process(exp[2][1])
     value = exp[4] = process(exp[4])
     match = Sexp.new(:call, target, :[], index)
 
-    unless env[match]
-      if request_value? target
-        env[match] = match.combine(value)
-      else
-        env[match] = value
+    if exp[3] == :"||"
+      unless env[match]
+        if request_value? target
+          env[match] = match.combine(value)
+        else
+          env[match] = value
+        end
       end
+    else
+      new_value = process s(:call, s(:call, target_var, :[], index), exp[3], value)
+
+      env[match] = new_value
     end
 
     exp

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -173,6 +173,19 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
+  def test_hash_update
+    assert_alias "2", <<-RUBY
+      @foo = {
+        :denominator => 0
+      }
+
+      @foo[:denominator] += 2
+
+      x = @foo[:denominator]
+      x
+    RUBY
+  end
+
   def test_obvious_if
     assert_alias "'Yes!'", <<-RUBY
       condition = true


### PR DESCRIPTION
e.g.

```ruby
x[:y] += z
```

Basically fixes #1103