### PR TITLE
Code Climate engine: fix `include_paths` when using custom app path

### DIFF
--- a/lib/brakeman/codeclimate/engine_configuration.rb
+++ b/lib/brakeman/codeclimate/engine_configuration.rb
@@ -67,11 +67,26 @@ module Brakeman
       end
 
       def stripped_include_paths(prefix)
+        subprefixes = path_subprefixes(prefix)
         engine_config["include_paths"] && engine_config["include_paths"].map do |path|
-          if path && path.start_with?(prefix)
-            path.sub(%r{^#{prefix}/?}, "")
+          next unless path
+          if path.start_with?(prefix)
+            path.sub(%r{^#{prefix}/?}, "./")
+          elsif subprefixes.any? { |subprefix| path =~ %r{^#{subprefix}/?$} }
+            "./"
           end
         end.compact
+      end
+
+      def path_subprefixes(path)
+        Pathname.new(path).each_filename.inject([]) do |memo, piece|
+         memo <<
+           if memo.any?
+             File.join(memo.last, piece)
+           else
+             File.join(piece)
+           end
+        end
       end
     end
   end

--- a/lib/brakeman/codeclimate/engine_configuration.rb
+++ b/lib/brakeman/codeclimate/engine_configuration.rb
@@ -37,8 +37,8 @@ module Brakeman
           @configured_options[:report_progress] = false
         end
 
-        if engine_config["include_paths"]
-          @configured_options[:only_files] = engine_config["include_paths"].compact
+        if active_include_paths
+          @configured_options[:only_files] = active_include_paths
         end
 
         if brakeman_configuration["app_path"]
@@ -57,6 +57,22 @@ module Brakeman
         end
       end
 
+      def active_include_paths
+        @active_include_paths ||=
+          if brakeman_configuration["app_path"]
+            stripped_include_paths(brakeman_configuration["app_path"])
+          else
+            engine_config["include_paths"] && engine_config["include_paths"].compact
+          end
+      end
+
+      def stripped_include_paths(prefix)
+        engine_config["include_paths"] && engine_config["include_paths"].map do |path|
+          if path && path.start_with?(prefix)
+            path.sub(%r{^#{prefix}/?}, "")
+          end
+        end.compact
+      end
     end
   end
 end

--- a/lib/brakeman/codeclimate/engine_configuration.rb
+++ b/lib/brakeman/codeclimate/engine_configuration.rb
@@ -70,11 +70,7 @@ module Brakeman
         subprefixes = path_subprefixes(prefix)
         engine_config["include_paths"] && engine_config["include_paths"].map do |path|
           next unless path
-          if path.start_with?(prefix)
-            path.sub(%r{^#{prefix}/?}, "./")
-          elsif subprefixes.any? { |subprefix| path =~ %r{^#{subprefix}/?$} }
-            "./"
-          end
+          stripped_include_path(prefix, subprefixes, path)
         end.compact
       end
 
@@ -86,6 +82,14 @@ module Brakeman
            else
              File.join(piece)
            end
+        end
+      end
+
+      def stripped_include_path(prefix, subprefixes, path)
+        if path.start_with?(prefix)
+          path.sub(%r{^#{prefix}/?}, "./")
+        elsif subprefixes.any? { |subprefix| path =~ %r{^#{subprefix}/?$} }
+          "./"
         end
       end
     end

--- a/test/tests/codeclimate_engine_configuration.rb
+++ b/test/tests/codeclimate_engine_configuration.rb
@@ -50,14 +50,58 @@ class EngineConfigurationTests < Minitest::Test
       Brakeman::Codeclimate::EngineConfiguration.new(config).options[:app_path]
   end
 
-  def test_custom_app_include_paths
+  def test_custom_app_path_include_paths
     config = {
       "include_paths" => ["foo/bar", "foo/42.rb", "foo/blub/neat", "README", "baz"],
       "config" => {
         "app_path" => "foo"
       }
     }
-    assert_equal ["bar", "42.rb", "blub/neat"],
+    assert_equal ["./bar", "./42.rb", "./blub/neat"],
+      Brakeman::Codeclimate::EngineConfiguration.new(config).options[:only_files]
+  end
+
+  def test_custom_app_path_include_paths_exact_match
+    config = {
+      "include_paths" => ["foo/"],
+      "config" => {
+        "app_path" => "foo/"
+      }
+    }
+    assert_equal ["./"],
+      Brakeman::Codeclimate::EngineConfiguration.new(config).options[:only_files]
+  end
+
+  def test_custom_nested_app_path_include_paths
+    config = {
+      "include_paths" => ["foo/"],
+      "config" => {
+        "app_path" => "foo/bar/baz"
+      }
+    }
+    assert_equal ["./"],
+      Brakeman::Codeclimate::EngineConfiguration.new(config).options[:only_files]
+  end
+
+  def test_custom_nested_app_path_include_paths_no_trailing_slash
+    config = {
+      "include_paths" => ["foo"],
+      "config" => {
+        "app_path" => "foo/bar/baz"
+      }
+    }
+    assert_equal ["./"],
+      Brakeman::Codeclimate::EngineConfiguration.new(config).options[:only_files]
+  end
+
+  def test_custom_nested_app_path_include_paths_not_a_parent
+    config = {
+      "include_paths" => ["foo/nope"],
+      "config" => {
+        "app_path" => "foo/bar/baz"
+      }
+    }
+    assert_equal [],
       Brakeman::Codeclimate::EngineConfiguration.new(config).options[:only_files]
   end
 end

--- a/test/tests/codeclimate_engine_configuration.rb
+++ b/test/tests/codeclimate_engine_configuration.rb
@@ -35,8 +35,29 @@ class EngineConfigurationTests < Minitest::Test
       Brakeman::Codeclimate::EngineConfiguration.new.options[:output_format]
   end
 
-  def test_app_path
+  def test_default_app_path
     assert_equal Dir.pwd,
       Brakeman::Codeclimate::EngineConfiguration.new.options[:app_path]
+  end
+
+  def test_custom_app_path
+    config = {
+      "config" => {
+        "app_path" => "foo/bar"
+      }
+    }
+    assert_equal File.join(Dir.pwd, "foo/bar"),
+      Brakeman::Codeclimate::EngineConfiguration.new(config).options[:app_path]
+  end
+
+  def test_custom_app_include_paths
+    config = {
+      "include_paths" => ["foo/bar", "foo/42.rb", "foo/blub/neat", "README", "baz"],
+      "config" => {
+        "app_path" => "foo"
+      }
+    }
+    assert_equal ["bar", "42.rb", "blub/neat"],
+      Brakeman::Codeclimate::EngineConfiguration.new(config).options[:only_files]
   end
 end


### PR DESCRIPTION
Brakeman (very reasonably) expects the `only_files` options to be
relative to the `app_path` option. The support that was added to the
Code Climate engine for a custom `app_path` option did not take
`include_paths` into account, so the normal result of using a custom
`app_path` would have ended up being that *nothing* would get analyzed:
because with a custom `app_path` of, say, `foo`, an include path might
include something like `foo/bar` when it needs to be adjusted to just
`bar`.

The fix here is to strip the `app_path` prefix from all matching
`include_paths`, and drop non-matching `include_paths` entirely.