### PR TITLE
Better handle reporting locations of Sass syntax errors

### DIFF
--- a/lib/brakeman/parsers/template_parser.rb
+++ b/lib/brakeman/parsers/template_parser.rb
@@ -39,6 +39,8 @@ module Brakeman
         tracker.error e, "could not parse #{path}"
       rescue Haml::Error => e
         tracker.error e, ["While compiling HAML in #{path}"] << e.backtrace
+      rescue Sass::SyntaxError => e
+        tracker.error e, "While processing #{path}"
       rescue StandardError, LoadError => e
         tracker.error e.exception(e.message + "\nWhile processing #{path}"), e.backtrace
       end


### PR DESCRIPTION
Test case is a HAML file with some invalid SASS like:

```
:sass
  .foo
    2px
```

Somewhat unintelligible result is:
```
+Errors+

+----------------------------------------------------+------------------+
| Error                                              | Location         |
+----------------------------------------------------+------------------+
| Invalid CSS after "": expected selector, was "2px" | (__TEMPLATE__):2 |
+----------------------------------------------------+------------------+
```

With this change we get:
```
+Errors+

+----------------------------------------------------+-----------------------------------------------------------+
| Error                                              | Location                                                  |
+----------------------------------------------------+-----------------------------------------------------------+
| Invalid CSS after "": expected selector, was "2px" | While processing /test-project/app/views/tests/index.haml |
+----------------------------------------------------+-----------------------------------------------------------+
```

Not perfect, but it at least gives you some idea of where the problem is (without having to turn on the full debug output)

I couldn't find any tests for the template parser. If there are some, I'd be happy to add to them