### PR TITLE
Add SQL safe methods configurable option

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -211,6 +211,10 @@ To indicate certain methods return properly escaped output and should not be war
 
     brakeman --safe-methods benign_method_escapes_output,totally_safe_from_xss
 
+Brakeman warns about use of SQL injection for user methods. There are times when this is not applicable, such as methods where the result has been safely wrapped. Safe methods can be ignored with
+
+    brakeman --sql-safe-methods method_safe_from_sql_injection,another_safe_sql_method
+
 Brakeman warns about use of user input in URLs generated with `link_to`. Since Rails does not provide anyway of making these URLs really safe (e.g. limiting protocols to HTTP(S)), safe methods can be ignored with
 
     brakeman --url-safe-methods ensure_safe_protocol_or_something

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -136,6 +136,11 @@ module Brakeman::Options
           options[:safe_methods].merge methods.map {|e| e.to_sym }
         end
 
+        opts.on "--sql-safe-methods method1,method2,etc", Array, "Do not warn of SQL injection for safe method" do |methods|
+          options[:sql_safe_methods] ||= Set.new
+          options[:sql_safe_methods].merge methods.map {|e| e.to_sym }
+        end
+
         opts.on "--url-safe-methods method1,method2,etc", Array, "Do not warn of XSS if the link_to href parameter is wrapped in a safe method" do |methods|
           options[:url_safe_methods] ||= Set.new
           options[:url_safe_methods].merge methods.map {|e| e.to_sym }

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -142,6 +142,11 @@ class BrakemanOptionsTest < Minitest::Test
     assert_equal Set[:test_method1, :test_method2], options[:safe_methods]
   end
 
+  def test__sql_safe_option
+    options = setup_options_from_input("--sql-safe-methods", "test_method2,test_method1,test_method2")
+    assert_equal Set[:test_method1, :test_method2], options[:sql_safe_methods]
+  end
+
   def test__url_safe_option
     options = setup_options_from_input("--url-safe-methods", "test_method2,test_method1,test_method2")
     assert_equal Set[:test_method1, :test_method2], options[:url_safe_methods]


### PR DESCRIPTION
Adds `sql-safe-methods` option, similar to `safe-methods` and `url-safe-methods` to minimise false positives by allowing customisation of the list of 'safe' SQL injection methods.

The use case I have is for a common method used to pull in application configuration and wrap a column with a timezone offset. Trying to avoid wrapping the helper method with `sanitize_sql` or similar.

I see that you've had some reservations with these 'safe' method overrides in the past but they do appear to be here to stay? Thoughts?