### PR TITLE
CI against Ruby 2.2.8, 2.3.5, and 2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ after_script:
 matrix:
   include:
     - rvm: "1.9.3"
-    - rvm: "2.2.7"
-    - rvm: "2.3.4"
-    - rvm: "2.4.1"
+    - rvm: "2.2.8"
+    - rvm: "2.3.5"
+    - rvm: "2.4.2"
       env: CC_TEST_REPORTER_ID=521d341f3320acda1902d0db0a3a92fb16b11ebfe3d5ab730218d4fc0fb3db13
 
 branches:


### PR DESCRIPTION
These Ruby versions are released.

https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-4-2-released/
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-2-8-released/