### PR TITLE
Refactor process_default methods for sexps

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -62,12 +62,8 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
   #Default Sexp processing. Iterates over each value in the Sexp
   #and processes them if they are also Sexps.
   def process_default exp
-    exp.each_with_index do |e, _i|
-      if sexp? e
-        process e
-      else
-        e
-      end
+    exp.each do |e|
+      process e if sexp? e
     end
 
     exp

--- a/lib/brakeman/processors/base_processor.rb
+++ b/lib/brakeman/processors/base_processor.rb
@@ -37,11 +37,7 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
     exp = exp.dup
 
     exp.each_with_index do |e, i|
-      if sexp? e and not e.empty?
-        exp[i] = process e
-      else
-        e
-      end
+      exp[i] = process e if sexp? e and not e.empty?
     end
 
     exp


### PR DESCRIPTION
In both of the methods I refactored, `e` is returned in an else statement, but it's not really going anywhere. The methods return `exp` in the end.

They look similar to lines 55-75 of `processers/alias_processers.rb`:

```ruby
def process_default exp
    @exp_context.push exp

    begin
      exp.map! do |e|
        if sexp? e and not e.empty?
          process e
        else
          e
        end
      end
    rescue => err
      @tracker.error err if @tracker
    end

    result = replace(exp)

    @exp_context.pop

    result
  end
```

Because it uses `map!` here I can see why `e` is returned, but it didn't make sense to me for the other methods, so I went ahead and deleted them.

Also the method in `base_check.rb` doesn't use the sexp's index so i just changed it to `each`.

Let me know what you think.