### PR TITLE
Remove `*_id` warnings in PermitAttributes

### DIFF
--- a/lib/brakeman/checks/check_permit_attributes.rb
+++ b/lib/brakeman/checks/check_permit_attributes.rb
@@ -27,8 +27,6 @@ class Brakeman::CheckPermitAttributes < Brakeman::BaseCheck
       if symbol? arg
         if SUSPICIOUS_KEYS.key? arg.value
           warn_on_permit_key result, arg
-        elsif arg.value.match /_id$/
-          warn_on_permit_key result, arg, :medium
         end
       end
     end

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -13,7 +13,7 @@ class Rails5Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 9,
-      :generic => 18
+      :generic => 17
     }
   end
 
@@ -57,7 +57,7 @@ class Rails5Tests < Minitest::Test
   end
 
   def test_mass_assignment_permit_medium
-    assert_warning :type => :warning,
+    assert_no_warning :type => :warning,
       :warning_code => 105,
       :fingerprint => "c4c89a39b0a2dc707027f47747312d27308ea219a009e4f0116a759a71ad561b",
       :warning_type => "Mass Assignment",


### PR DESCRIPTION
closes #1144

Will add back later when it can be done with fewer false positives.