### PR TITLE
Make ErbTemplateProcessor aware of `String#<<` method for Ruby 2.5

### DIFF
--- a/lib/brakeman/processors/erb_template_processor.rb
+++ b/lib/brakeman/processors/erb_template_processor.rb
@@ -14,7 +14,7 @@ class Brakeman::ErbTemplateProcessor < Brakeman::TemplateProcessor
     
     #_erbout is the default output variable for erb
     if node_type? target, :lvar and target.value == :_erbout
-      if method == :concat
+      if method == :concat or method == :<<
         @inside_concat = true
         exp.arglist = process(exp.arglist)
         @inside_concat = false


### PR DESCRIPTION
Currently, the test fails on Ruby 2.5.

```
$ ruby -v
ruby 2.5.0rc1 (2017-12-14 trunk 61243) [x86_64-linux]
$ bundle exec rake
Run options: --seed 24396

.................................................
[1m[32mNo warnings found[0m

...



..Unrecognized action on _erbout: <<
Coverage report generated for Unit Tests to /home/pocke/ghq/github.com/presidentbeef/brakeman/coverage. 6542 / 11879 LOC (55.07%) covered.
rake aborted!
Command failed with status (1): [ruby -I"lib" -I"/home/pocke/.rbenv/versions/2.5.0-rc1/lib/ruby/gems/2.5.0/gems/rake-10.1.1/lib" "/home/pocke/.rbenv/versions/2.5.0-rc1/lib/ruby/gems/2.5.0/gems/rake-10.1.1/lib/rake/rake_test_loader.rb" "test/tests/*.rb" ]

Tasks: TOP => default => test
(See full trace by running task with --trace)
```

Because ERB uses `String#<<` instead of `concat` in Ruby 2.5.
See https://github.com/ruby/ruby/pull/1612

This pull-request will fix the problem.