### PR TITLE
Avoid command injection warning when using Shellwords.escape

### DIFF
--- a/test/apps/rails5.2/lib/shell.rb
+++ b/test/apps/rails5.2/lib/shell.rb
@@ -1,0 +1,11 @@
+class ShellStuff
+  def initialize(one, two)
+    @one = Shellwords.shellescape(one)
+    @two = Shellwords.escape(two)
+  end
+
+  def run(ip)
+    ip = Shellwords.shellescape(ip)
+    `dig +short -x #{ip} @#{@one} -p #{@two}`
+  end
+end

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -52,4 +52,17 @@ class Rails52Tests < Minitest::Test
       :code => s(:dxstr, "", s(:evstr, s(:ivar, :@blah))),
       :user_input => s(:ivar, :@blah)
   end
+
+  def test_command_injection_shellwords
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :fingerprint => "89b886281c6329f5c5f319932d98ea96527d50f1d188fde9fd85ff93130b7c50",
+      :warning_type => "Command Injection",
+      :line => 9,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 1,
+      :relative_path => "lib/shell.rb",
+      :code => s(:dxstr, "dig +short -x ", s(:evstr, s(:call, s(:const, :Shellwords), :shellescape, s(:lvar, :ip))), s(:str, " @"), s(:evstr, s(:call, s(:const, :Shellwords), :shellescape, s(:lvar, :one))), s(:str, " -p "), s(:evstr, s(:call, s(:const, :Shellwords), :escape, s(:lvar, :two)))),
+      :user_input => s(:call, s(:const, :Shellwords), :shellescape, s(:lvar, :ip))
+  end
 end


### PR DESCRIPTION
fixes #1159