### PR TITLE
Code Climate: omit leading dot from `only_files`

### DIFF
--- a/lib/brakeman/codeclimate/engine_configuration.rb
+++ b/lib/brakeman/codeclimate/engine_configuration.rb
@@ -87,9 +87,9 @@ module Brakeman
 
       def stripped_include_path(prefix, subprefixes, path)
         if path.start_with?(prefix)
-          path.sub(%r{^#{prefix}/?}, "./")
+          path.sub(%r{^#{prefix}/?}, "/")
         elsif subprefixes.any? { |subprefix| path =~ %r{^#{subprefix}/?$} }
-          "./"
+          "/"
         end
       end
     end

--- a/test/tests/codeclimate_engine_configuration.rb
+++ b/test/tests/codeclimate_engine_configuration.rb
@@ -57,7 +57,7 @@ class EngineConfigurationTests < Minitest::Test
         "app_path" => "foo"
       }
     }
-    assert_equal ["./bar", "./42.rb", "./blub/neat"],
+    assert_equal ["/bar", "/42.rb", "/blub/neat"],
       Brakeman::Codeclimate::EngineConfiguration.new(config).options[:only_files]
   end
 
@@ -68,7 +68,7 @@ class EngineConfigurationTests < Minitest::Test
         "app_path" => "foo/"
       }
     }
-    assert_equal ["./"],
+    assert_equal ["/"],
       Brakeman::Codeclimate::EngineConfiguration.new(config).options[:only_files]
   end
 
@@ -79,7 +79,7 @@ class EngineConfigurationTests < Minitest::Test
         "app_path" => "foo/bar/baz"
       }
     }
-    assert_equal ["./"],
+    assert_equal ["/"],
       Brakeman::Codeclimate::EngineConfiguration.new(config).options[:only_files]
   end
 
@@ -90,7 +90,7 @@ class EngineConfigurationTests < Minitest::Test
         "app_path" => "foo/bar/baz"
       }
     }
-    assert_equal ["./"],
+    assert_equal ["/"],
       Brakeman::Codeclimate::EngineConfiguration.new(config).options[:only_files]
   end
 


### PR DESCRIPTION
When an `app_path` is specified in the Code Climate configuration, the relative paths that `Brakeman::Codeclimate::EngineConfiguration#active_include_paths` generates (added in presidentbeef/brakeman#1126) all start with a dot-slash (ex. `./app/`). This unfortunately causes a bug downstream in `Brakeman::AppTree#select_only_files` where _no_ paths actually match the `@only_files` regular expression.

A potential reason we missed this bug in the first place is the repository we were testing with used an `app_path` of `app`, which outwardly appears to mostly work.

/cc @wfleming 