### PR TITLE
Ignore freeze calls

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -197,7 +197,6 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       return Sexp.new(:false)
     end
 
-
     #See if it is possible to simplify some basic cases
     #of addition/concatenation.
     case method
@@ -286,6 +285,10 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     when :first
       if array? target and first_arg.nil? and sexp? target[1]
         exp = target[1]
+      end
+    when :freeze
+      if string? target
+        exp = process exp.target
       end
     end
 

--- a/test/apps/rails5.2/app/models/user.rb
+++ b/test/apps/rails5.2/app/models/user.rb
@@ -2,4 +2,12 @@ class User < ActiveRecord::Base
   def not_something thing
     where.not("blah == #{thing}")
   end
+  SUBQUERY_TABLE_ALIAS = "my_table_alias".freeze
+
+  # This is used inside a larger query by using `inner_query.to_sql`
+  def inner_query
+    self.class.
+      select("#{SUBQUERY_TABLE_ALIAS}.*").
+      from("#{table_name} AS #{SUBQUERY_TABLE_ALIAS}")
+  end
 end

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -40,6 +40,19 @@ class Rails52Tests < Minitest::Test
       :user_input => s(:lvar, :thing)
   end
 
+  def test_sql_injection_string_freeze
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "b1ed6e8858db8a9a176fba44374a9a43c6277ea5df3ed04236a5870eed44e43c",
+      :warning_type => "SQL Injection",
+      :line => 11,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 1,
+      :relative_path => "app/models/user.rb",
+      :code => s(:call, s(:call, s(:call, s(:self), :class), :select, s(:dstr, "", s(:evstr, s(:call, s(:str, "my_table_alias"), :freeze)), s(:str, ".*"))), :from, s(:dstr, "", s(:evstr, s(:call, nil, :table_name)), s(:str, " AS "), s(:evstr, s(:call, s(:str, "my_table_alias"), :freeze)))),
+      :user_input => s(:call, s(:str, "my_table_alias"), :freeze)
+  end
+
   def test_command_injection_1
     assert_no_warning :type => :warning,
       :warning_code => 14,


### PR DESCRIPTION
Treat 

```ruby
"blah".freeze
```
as
```ruby
"blah"
```