### PR TITLE
Track parent calls in CallIndex

### DIFF
--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -19,6 +19,7 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
     @current_method = opts[:method]
     @current_template = opts[:template]
     @current_file = opts[:file]
+    @current_call = nil
     process exp
   end
 
@@ -111,7 +112,8 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
                 :method => method_name,
                 :call => exp,
                 :nested => false,
-                :location => make_location }
+                :location => make_location,
+                :parent => @current_call }
   end
 
   #Gets the target of a call as a Symbol
@@ -199,13 +201,24 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
     end
 
     method = exp.method
-    process_call_args exp
 
-    { :target => target,
+    call_hash = {
+      :target => target,
       :method => method,
       :call => exp,
       :nested => @in_target,
       :chain => get_chain(exp),
-      :location => make_location }
+      :location => make_location,
+      :parent => @current_call
+    }
+
+    old_parent = @current_call
+    @current_call = call_hash
+
+    process_call_args exp
+
+    @current_call = old_parent
+
+    call_hash
   end
 end

--- a/test/tests/call_index.rb
+++ b/test/tests/call_index.rb
@@ -18,6 +18,7 @@ class CallIndexTests < Minitest::Test
       def x
         x.y.z(1)
         params[:x].y.z(2)
+        third(second.thing(first.thing))
       end
     RUBY
 
@@ -25,6 +26,7 @@ class CallIndexTests < Minitest::Test
     class A
       do_a_thing
 
+      # Not indexed
       def x
         x.y.z(1)
         params[:x].y.z(2)
@@ -96,6 +98,21 @@ class CallIndexTests < Minitest::Test
 
   def test_find_class_scope_call_by_method
     assert_found 1, :method => :do_a_thing
+  end
+
+  def test_parent_call
+    first = @call_index.find_calls(method: :first, nested: true).first
+    first_thing = @call_index.find_calls(target: :first, method: :thing).first
+    second = @call_index.find_calls(method: :second, nested: true).first
+    second_thing = @call_index.find_calls(target: :second, method: :thing).first
+    third = @call_index.find_calls(target: nil, method: :third).first
+
+    assert_equal second_thing, first_thing[:parent]
+    assert_equal third, second_thing[:parent]
+
+    assert_equal second_thing, first[:parent]
+    assert_equal third, second[:parent]
+    assert_nil third[:parent]
   end
 
   def test_find_error


### PR DESCRIPTION
In other words, be able to go from call argument to the method call itself.