### PR TITLE
Add --parser-timeout option

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -51,6 +51,7 @@ module Brakeman
   #  * :output_files - files for output
   #  * :output_formats - formats for output (:to_s, :to_tabs, :to_csv, :to_html)
   #  * :parallel_checks - run checks in parallel (default: true)
+  #  * :parser_timeout - set timeout for parsing an individual file (default: 10 seconds)
   #  * :print_report - if no output file specified, print to stdout (default: false)
   #  * :quiet - suppress most messages (default: true)
   #  * :rails3 - force Rails 3 mode (automatic)
@@ -174,6 +175,7 @@ module Brakeman
       :output_color => true,
       :pager => true,
       :parallel_checks => true,
+      :parser_timeout => 10,
       :relative_path => false,
       :report_progress => true,
       :safe_methods => Set.new,

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -127,6 +127,10 @@ module Brakeman::Options
           options[:branch_limit] = limit
         end
 
+        opts.on "--parser-timeout SECONDS", Integer, "Set parse timeout (Default: 10)" do |timeout|
+          options[:parser_timeout] = timeout
+        end
+
         opts.on "-r", "--report-direct", "Only report direct use of untrusted data" do |option|
           options[:check_arguments] = !option
         end

--- a/lib/brakeman/parsers/template_parser.rb
+++ b/lib/brakeman/parsers/template_parser.rb
@@ -93,7 +93,7 @@ module Brakeman
     end
 
     def self.parse_inline_erb tracker, text
-      fp = Brakeman::FileParser.new(nil, nil)
+      fp = Brakeman::FileParser.new(tracker, nil)
       tp = self.new(tracker, fp)
       src = tp.parse_erb '_inline_', text
       type = tp.erubis? ? :erubis : :erb

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -115,6 +115,11 @@ class BrakemanOptionsTest < Minitest::Test
     assert !options[:report_progress]
   end
 
+  def test_parser_timeout_option
+    options = setup_options_from_input("--parser-timeout", "1000")
+    assert_equal 1000, options[:parser_timeout]
+  end
+
   def test_quiet_option
     options = setup_options_from_input("-q")
     assert options[:quiet]

--- a/test/tests/parser_timeout.rb
+++ b/test/tests/parser_timeout.rb
@@ -1,0 +1,18 @@
+require_relative '../test'
+require 'brakeman/rescanner'
+
+class ParserTimeoutTests < Minitest::Test
+  include BrakemanTester::RescanTestHelper
+
+  def test_timeout
+    before_rescan_of "lib/large_file.rb", "rails5.2", { parser_timeout: 1 } do
+      random_ruby = Array.new(10000) { "def x_#{rand(1000)}\nputs '#{"**" * 1000}'\nend" }.join("\n")
+      write_file "lib/large_file.rb", random_ruby
+    end
+
+    assert_equal 1, @rescanner.tracker.errors.length
+
+    timeout_error = @rescanner.tracker.errors.first
+    assert_match(/Parsing .* took too long \(> 1 seconds\)/, timeout_error[:error])
+  end
+end


### PR DESCRIPTION
This sets the timeout used for parsing a single file.

The default is the same as RubyParser's current default: 10 seconds.

This PR also changes the error message when a timeout does occur to something useful.