### PR TITLE
Allow `symbolize_keys` to be called on params

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -290,7 +290,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     end
 
     if request_value? arg
-      unless call? arg and params? arg.target and [:permit, :slice, :to_h, :to_hash].include? arg.method
+      unless call? arg and params? arg.target and [:permit, :slice, :to_h, :to_hash, :symbolize_keys].include? arg.method
         # Model.where(params[:where])
         arg
       end

--- a/test/apps/rails5.2/app/controllers/users_controller.rb
+++ b/test/apps/rails5.2/app/controllers/users_controller.rb
@@ -3,4 +3,9 @@ class UsersController < ApplicationController
     index_params = params.permit(:name, friend_names: []).to_hash
     User.where(index_params).qualify.all
   end
+
+  def show
+    show_params = params.permit(:id, :name).to_hash.symbolize_keys
+    User.where(show_params).qualify.all
+  end
 end

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -27,6 +27,17 @@ class Rails52Tests < Minitest::Test
       :relative_path => "app/controllers/application_controller.rb"
   end
 
+  def test_query_with_symbolize_keys
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "b7614315999c9f0db62649515da3bc9ce32ec418d69ea13af0564841392c98af",
+      :warning_type => "SQL Injection",
+      :line => 9,
+      :message => /^Possible SQL injection/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb"
+  end
+
   def test_sql_injection_not
     assert_warning :type => :warning,
       :warning_code => 0,


### PR DESCRIPTION
Fixes #1206