### PR TITLE
Deprecate safe_level of ERB.new in Ruby 2.6

### DIFF
--- a/lib/brakeman/parsers/template_parser.rb
+++ b/lib/brakeman/parsers/template_parser.rb
@@ -58,7 +58,11 @@ module Brakeman
         Brakeman::ScannerErubis.new(text, :filename => path).src
       else
         require 'erb'
-        src = ERB.new(text, nil, path).src
+        src = if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+          ERB.new(text, trim_mode: path).src
+        else
+          ERB.new(text, nil, path).src
+        end
         src.sub!(/^#.*\n/, '') if Brakeman::Scanner::RUBY_1_9
         src
       end


### PR DESCRIPTION
This PR suppresses the following warnings when using Ruby 2.6.0-dev.

```console
% ruby -v
ruby 2.6.0dev (2018-05-22 trunk 63488) [x86_64-darwin17]
%RUBYOPT='-w' bundle exec rake
(snip)
/Users/koic/src/github.com/presidentbeef/brakeman/lib/brakeman/parsers/template_parser.rb:61:
warning: Passing safe_level with the 2nd argument of ERB.new is deprecated.
Do not use it, and specify other arguments as keyword arguments.
/Users/koic/src/github.com/presidentbeef/brakeman/lib/brakeman/parsers/template_parser.rb:61:
warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated.
Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087/NEWS#stdlib-updates-outstanding-ones-only

This PR uses `ERB.instance_method(:initialize).parameters.assoc(:key)` to switch `ERB.new` interface. Because Brakeman supports multiple Ruby versions, it need to use the appropriate interface. This approach is built into Ruby.
https://github.com/ruby/ruby/commit/3406c5d