### PR TITLE
Add representation of safe literals

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -404,6 +404,8 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
       nil
     elsif call? value and value.method == :to_s
       unsafe_string_interp? value.target
+    elsif call? value and safe_literal_target? value
+      nil
     else
       case value.node_type
       when :or

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -345,12 +345,12 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       call = exp.block_call
       block_args = exp.block_args
 
-      if [:each, :map].include? call.method and all_literals? call.target and block_args.length == 2 and block_args.last.is_a? Symbol
+      if call? call and [:each, :map].include? call.method and all_literals? call.target and block_args.length == 2 and block_args.last.is_a? Symbol
         # Iterating over an array of all literal values
         local = Sexp.new(:lvar, block_args.last)
         env.current[local] = safe_literal(exp.line)
       else
-        exp.block_args.each do |e|
+        block_args.each do |e|
           #Force block arg(s) to be local
           if node_type? e, :lasgn
             env.current[Sexp.new(:lvar, e.lhs)] = Sexp.new(:lvar, e.lhs)

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -342,22 +342,31 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     @exp_context.pop
 
     env.scope do
-      exp.block_args.each do |e|
-        #Force block arg(s) to be local
-        if node_type? e, :lasgn
-          env.current[Sexp.new(:lvar, e.lhs)] = Sexp.new(:lvar, e.lhs)
-        elsif node_type? e, :kwarg
-          env.current[Sexp.new(:lvar, e[1])] = e[2]
-        elsif node_type? e, :masgn, :shadow
-          e[1..-1].each do |var|
-            local = Sexp.new(:lvar, var)
+      call = exp.block_call
+      block_args = exp.block_args
+
+      if [:each, :map].include? call.method and all_literals? call.target and block_args.length == 2 and block_args.last.is_a? Symbol
+        # Iterating over an array of all literal values
+        local = Sexp.new(:lvar, block_args.last)
+        env.current[local] = safe_literal(exp.line)
+      else
+        exp.block_args.each do |e|
+          #Force block arg(s) to be local
+          if node_type? e, :lasgn
+            env.current[Sexp.new(:lvar, e.lhs)] = Sexp.new(:lvar, e.lhs)
+          elsif node_type? e, :kwarg
+            env.current[Sexp.new(:lvar, e[1])] = e[2]
+          elsif node_type? e, :masgn, :shadow
+            e[1..-1].each do |var|
+              local = Sexp.new(:lvar, var)
+              env.current[local] = local
+            end
+          elsif e.is_a? Symbol
+            local = Sexp.new(:lvar, e)
             env.current[local] = local
+          else
+            raise "Unexpected value in block args: #{e.inspect}"
           end
-        elsif e.is_a? Symbol
-          local = Sexp.new(:lvar, e)
-          env.current[local] = local
-        else
-          raise "Unexpected value in block args: #{e.inspect}"
         end
       end
 

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -336,7 +336,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     @exp_context.push exp
     exp[1] = process exp.block_call
     if array_detect_all_literals? exp[1]
-      return exp.block_call.target[1]
+      return safe_literal(exp.line)
     end
 
     @exp_context.pop
@@ -739,12 +739,12 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
             # set x to "a" inside the true branch
             var = condition.first_arg
             previous_value = env.current[var]
-            env.current[var] = condition.target[1]
+            env.current[var] = safe_literal(var.line)
             exp[branch_index] = process_if_branch branch
             env.current[var] = previous_value
           elsif i == 1 and array_include_all_literals? condition and early_return? branch
             var = condition.first_arg
-            env.current[var] = condition.target[1]
+            env.current[var] = safe_literal(var.line)
             exp[branch_index] = process_if_branch branch
           else
             exp[branch_index] = process_if_branch branch

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -124,7 +124,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     end
 
     if hash? t
-      if v = hash_access(t, exp.first_arg)
+      if v = process_hash_access(t, exp.first_arg)
         v.deep_clone(exp.line)
       else
         case t.node_type

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -687,18 +687,14 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   def array_include_all_literals? exp
     call? exp and
     exp.method == :include? and
-    node_type? exp.target, :array and
-    exp.target.length > 1 and
-    exp.target.all? { |e| e.is_a? Symbol or node_type? e, :lit, :str }
+    all_literals? exp.target
   end
 
   def array_detect_all_literals? exp
     call? exp and
     [:detect, :find].include? exp.method and
-    node_type? exp.target, :array and
-    exp.target.length > 1 and
     exp.first_arg.nil? and
-    exp.target.all? { |e| e.is_a? Symbol or node_type? e, :lit, :str }
+    all_literals? exp.target
   end
 
   #Sets @inside_if = true

--- a/lib/brakeman/processors/lib/call_conversion_helper.rb
+++ b/lib/brakeman/processors/lib/call_conversion_helper.rb
@@ -78,7 +78,13 @@ module Brakeman
     # Process hash access by returning the value associated
     # with the given argument.
     def process_hash_access hash, index, original_exp = nil
-      hash_access(hash, index) or original_exp
+      if value = hash_access(hash, index)
+        value # deep_clone?
+      elsif all_literals? hash, :hash
+        safe_literal(hash.line)
+      else
+        original_exp
+      end
     end
   end
 end

--- a/lib/brakeman/processors/lib/call_conversion_helper.rb
+++ b/lib/brakeman/processors/lib/call_conversion_helper.rb
@@ -1,0 +1,74 @@
+module Brakeman
+  module CallConversionHelper
+    # Join two array literals into one.
+    def join_arrays lhs, rhs, original_exp = nil
+      if array? lhs and array? rhs
+        result = Sexp.new(:array).line(lhs.line)
+        result.concat lhs[1..-1]
+        result.concat rhs[1..-1]
+        result
+      else
+        original_exp
+      end
+    end
+
+    # Join two string literals into one.
+    def join_strings lhs, rhs, original_exp = nil
+      if string? lhs and string? rhs
+        result = Sexp.new(:str).line(lhs.line)
+        result.value = lhs.value + rhs.value
+
+        if result.value.length > 50
+          # Avoid gigantic strings
+          lhs
+        else
+          result
+        end
+      elsif call? lhs and lhs.method == :+ and string? lhs.first_arg
+        joined = join_strings lhs.first_arg, rhs
+        lhs.first_arg = joined
+        lhs
+      else
+        original_exp
+      end
+    end
+
+    def math_op op, lhs, rhs, original_exp = nil
+      if number? lhs and number? rhs
+        if op == :/ and rhs.value == 0 and not lhs.value.is_a? Float
+          # Avoid division by zero
+          return original_exp
+        else
+          value = lhs.value.send(op, rhs.value)
+          Sexp.new(:lit, value).line(lhs.line)
+        end
+      elsif call? lhs and lhs.method == :+ and number? lhs.first_arg
+        # (x + 1) + 2 -> (x + 3)
+        lhs.first_arg = Sexp.new(:lit, lhs.first_arg.value + rhs.value).line(lhs.first_arg.line)
+        lhs
+      else
+        original_exp
+      end
+    end
+
+    # Process single integer access to an array.
+    #
+    # Returns the value inside the array, if possible.
+    def process_array_access array, args, original_exp = nil
+      if args.length == 1 and integer? args.first
+        index = args.first.value
+
+        #Have to do this because first element is :array and we have to skip it
+        array[1..-1][index] or original_exp
+      else
+        original_exp
+      end
+    end
+
+    # Process hash access by returning the value associated
+    # with the given argument.
+    def process_hash_access hash, index, original_exp = nil
+      hash_access(hash, index) or original_exp
+    end
+  end
+end

--- a/lib/brakeman/processors/lib/call_conversion_helper.rb
+++ b/lib/brakeman/processors/lib/call_conversion_helper.rb
@@ -1,5 +1,11 @@
 module Brakeman
   module CallConversionHelper
+    def all_literals? exp, expected_type = :array
+      node_type? exp, expected_type and
+        exp.length > 1 and
+        exp.all? { |e| e.is_a? Symbol or node_type? e, :lit, :str }
+    end
+
     # Join two array literals into one.
     def join_arrays lhs, rhs, original_exp = nil
       if array? lhs and array? rhs

--- a/lib/brakeman/processors/lib/call_conversion_helper.rb
+++ b/lib/brakeman/processors/lib/call_conversion_helper.rb
@@ -30,7 +30,7 @@ module Brakeman
         else
           result
         end
-      elsif call? lhs and lhs.method == :+ and string? lhs.first_arg
+      elsif call? lhs and lhs.method == :+ and string? lhs.first_arg and string? rhs
         joined = join_strings lhs.first_arg, rhs
         lhs.first_arg = joined
         lhs
@@ -50,7 +50,7 @@ module Brakeman
           value = lhs.value.send(op, rhs.value)
           Sexp.new(:lit, value).line(lhs.line)
         end
-      elsif call? lhs and lhs.method == :+ and number? lhs.first_arg
+      elsif call? lhs and lhs.method == :+ and number? lhs.first_arg and number? rhs
         # (x + 1) + 2 -> (x + 3)
         lhs.first_arg = Sexp.new(:lit, lhs.first_arg.value + rhs.value).line(lhs.first_arg.line)
         lhs

--- a/lib/brakeman/processors/lib/call_conversion_helper.rb
+++ b/lib/brakeman/processors/lib/call_conversion_helper.rb
@@ -28,6 +28,8 @@ module Brakeman
         joined = join_strings lhs.first_arg, rhs
         lhs.first_arg = joined
         lhs
+      elsif safe_literal? lhs or safe_literal? rhs
+        safe_literal(lhs.line)
       else
         original_exp
       end
@@ -46,6 +48,8 @@ module Brakeman
         # (x + 1) + 2 -> (x + 3)
         lhs.first_arg = Sexp.new(:lit, lhs.first_arg.value + rhs.value).line(lhs.first_arg.line)
         lhs
+      elsif safe_literal? lhs or safe_literal? rhs
+        safe_literal(lhs.line)
       else
         original_exp
       end

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -310,7 +310,7 @@ module Brakeman::Util
   end
 
   def safe_literal line = nil
-    s(:lit, :BRAKEMAN_SAFE_LITERAL).line(line)
+    s(:lit, :BRAKEMAN_SAFE_LITERAL).line(line || 0)
   end
 
   def safe_literal? exp

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -317,6 +317,14 @@ module Brakeman::Util
     exp == SAFE_LITERAL
   end
 
+  def safe_literal_target? exp
+    if call? exp
+      safe_literal_target? exp.target
+    else
+      safe_literal? exp
+    end
+  end
+
   def rails_version
     @tracker.config.rails_version
   end

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -26,6 +26,8 @@ module Brakeman::Util
 
   ALL_COOKIES = Set[COOKIES, REQUEST_COOKIES]
 
+  SAFE_LITERAL = s(:lit, :BRAKEMAN_SAFE_LITERAL)
+
   #Convert a string from "something_like_this" to "SomethingLikeThis"
   #
   #Taken from ActiveSupport.
@@ -305,6 +307,14 @@ module Brakeman::Util
     end
 
     call
+  end
+
+  def safe_literal line = nil
+    s(:lit, :BRAKEMAN_SAFE_LITERAL).line(line)
+  end
+
+  def safe_literal? exp
+    exp == SAFE_LITERAL
   end
 
   def rails_version

--- a/test/apps/rails5.2/app/models/user.rb
+++ b/test/apps/rails5.2/app/models/user.rb
@@ -10,4 +10,10 @@ class User < ActiveRecord::Base
       select("#{SUBQUERY_TABLE_ALIAS}.*").
       from("#{table_name} AS #{SUBQUERY_TABLE_ALIAS}")
   end
+
+  def singularize_safe_literal
+    [:fees, :fair].each do |type|
+      Money.new(articles.sum("calculated_#{type.to_s.singularize}_cents * quantity"))
+    end
+  end
 end

--- a/test/apps/rails5.2/lib/shell.rb
+++ b/test/apps/rails5.2/lib/shell.rb
@@ -47,4 +47,27 @@ class ShellStuff
   def interpolated_ternary_dangerous
     `echo #{foo ? "bar" : bar} baz`
   end
+
+  COMMANDS = { foo: "echo", bar: "cat" }
+  MORE_COMMANDS = { foo: "touch" }
+
+  def safe(arg)
+    command = if Date.today.tuesday? # Some condition.
+                COMMANDS[arg]
+              else
+                MORE_COMMANDS[arg]
+              end
+
+    `#{command} file1.txt`
+  end
+
+  EXPRESSIONS = ["users.email", "concat_ws(' ', users.first_name, users.last_name)"]
+
+  def perform_commands
+    EXPRESSIONS.each { |exp| `echo #{exp}` }
+  end
+
+  def scopes(base_scope)
+    EXPRESSIONS.map { |exp| base_scope.where("#{exp} ILIKE '%foo%'") }
+  end
 end

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -141,7 +141,7 @@ class AliasProcessorTests < Minitest::Test
   end
 
   def test_array_detect
-    assert_alias '1', <<-RUBY
+    assert_alias ':BRAKEMAN_SAFE_LITERAL', <<-RUBY
       x = [1,2,3].detect { |x| x.odd? }
       x
     RUBY
@@ -844,8 +844,8 @@ class AliasProcessorTests < Minitest::Test
     x
     INPUT
     if [1,2,3].include? x
-      y = 3
-      p 3
+      y = :BRAKEMAN_SAFE_LITERAL
+      p :BRAKEMAN_SAFE_LITERAL
     end
 
     x
@@ -861,7 +861,7 @@ class AliasProcessorTests < Minitest::Test
     INPUT
     x = params[:x].presence
     if ['a','b'].include? params[:x].presence
-      User.a
+      User.BRAKEMAN_SAFE_LITERAL
     end
 
     params[:x].presence
@@ -874,7 +874,7 @@ class AliasProcessorTests < Minitest::Test
     x
     INPUT
     return unless ['a', 'b'].include? x
-    'a'
+    :BRAKEMAN_SAFE_LITERAL
     OUTPUT
   end
 
@@ -894,7 +894,7 @@ class AliasProcessorTests < Minitest::Test
       do_stuff
       return
     end
-    'a'
+    :BRAKEMAN_SAFE_LITERAL
     OUTPUT
   end
 
@@ -904,7 +904,7 @@ class AliasProcessorTests < Minitest::Test
     x
     INPUT
     fail unless ['a', 'b'].include? x
-    'a'
+    :BRAKEMAN_SAFE_LITERAL
     OUTPUT
   end
 
@@ -914,7 +914,7 @@ class AliasProcessorTests < Minitest::Test
     x
     INPUT
     raise Z unless ['a', 'b'].include? x
-    'a'
+    :BRAKEMAN_SAFE_LITERAL
     OUTPUT
   end
 

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -64,6 +64,19 @@ class Rails52Tests < Minitest::Test
       :user_input => s(:call, s(:str, "my_table_alias"), :freeze)
   end
 
+  def test_sql_injection_with_array_map
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "d3e36e5e530dc926b4fd38c605cf39341bf9e48169310f34ac439caf129e1f6f",
+      :warning_type => "SQL Injection",
+      :line => 71,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 2,
+      :relative_path => "lib/shell.rb",
+      :code => s(:call, s(:lvar, :base_scope), :where, s(:dstr, "", s(:evstr, s(:lvar, :exp)), s(:str, " ILIKE '%foo%'"))),
+      :user_input => s(:lvar, :exp)
+  end
+
   def test_command_injection_1
     assert_no_warning :type => :warning,
       :warning_code => 14,
@@ -201,6 +214,32 @@ class Rails52Tests < Minitest::Test
       :relative_path => "lib/shell.rb",
       :code => s(:dxstr, "echo ", s(:evstr, s(:if, s(:call, nil, :foo), s(:str, "bar"), s(:call, nil, :bar))), s(:str, " baz")),
       :user_input => s(:call, nil, :bar)
+  end
+
+  def test_command_injection_with_hash_unknown_key_access
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :fingerprint => "d24b0ba3ecb378e00bc0c8034eb2651f145ec6247f7471f8a41b31d44d4cdd33",
+      :warning_type => "Command Injection",
+      :line => 61,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 1,
+      :relative_path => "lib/shell.rb",
+      :code => s(:dxstr, "", s(:evstr, s(:or, s(:call, s(:const, :COMMANDS), :[], s(:lvar, :arg)), s(:call, s(:const, :MORE_COMMANDS), :[], s(:lvar, :arg)))), s(:str, " file1.txt")),
+      :user_input => s(:call, s(:const, :COMMANDS), :[], s(:lvar, :arg))
+  end
+
+  def test_command_injection_with_array_each
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :fingerprint => "760cf49f3f216b99e9720a8282ace8096c3b844ebd1da16cf20478d00449cd90",
+      :warning_type => "Command Injection",
+      :line => 67,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 1,
+      :relative_path => "lib/shell.rb",
+      :code => s(:dxstr, "echo ", s(:evstr, s(:lvar, :exp))),
+      :user_input => s(:lvar, :exp)
   end
 
   def test_cross_site_scripting_loofah_CVE_2018_8048

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -77,6 +77,19 @@ class Rails52Tests < Minitest::Test
       :user_input => s(:lvar, :exp)
   end
 
+  def test_sql_injection_safe_literal_to_s_singularize
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "4de07c156fa4b7694024871f100409e41fbcac4f65813a34ba749e1751b95204",
+      :warning_type => "SQL Injection",
+      :line => 16,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 2,
+      :relative_path => "app/models/user.rb",
+      :code => s(:call, s(:call, nil, :articles), :sum, s(:dstr, "calculated_", s(:evstr, s(:call, s(:call, s(:lit, :BRAKEMAN_SAFE_LITERAL), :to_s), :singularize)), s(:str, "_cents * quantity"))),
+      :user_input => s(:call, s(:call, s(:lit, :BRAKEMAN_SAFE_LITERAL), :to_s), :singularize)
+  end
+
   def test_command_injection_1
     assert_no_warning :type => :warning,
       :warning_code => 14,


### PR DESCRIPTION
This changes how Brakeman handles a number of situations and opens the door to similar improvements in the future.

In particular:

In this code, Brakeman will know `i` is a safe literal value:

```ruby
[1, 2, 3, 4].each do |i|
   use(i)
end
```

and here, too:

```ruby
["blah", "this", "that"].map do |i|
   transform(i)
end
```

Also here Brakeman will know `x[anything]` is a "safe" literal value, even though the value of `anything` is not known:

```ruby
x = { this: "that" }
x[anything]
```

For these examples, Brakeman will know `x` is a literal value, but won't cause confusion by picking an exact one:

```ruby
raise unless [:a, :b, :c, :d].include? x

x = [1, 2, 3, 4, 5].detect { |i| i.odd? }
```

Brakeman will also handle this kind of thing:

```ruby
if ["ls", "cat", "who"].include? y
  x = y + "blah"
  `#{x} stuff}
end
```

Adding together string literals or number literals with a known safe literal will produce a safe literal. This is somewhat limited right now but will probably expand in the future.

---

Previously, if Brakeman saw code like this

```ruby
if [1, 0].include? x
  puts x
end
```

It would change it to

```ruby
if [1, 0].include? x
  puts 1
end
```

By setting `x` to `1` inside the branch, Brakeman could indicate that `x` was a 'safe' value.

But what if it were something like

```ruby
if [1, 0].include? x
  eval [params[:x], "nothing"][x]
end
```

Brakeman wouldn't warn about this because it would see

```ruby
if [1, 0].include? x
  eval "nothing"
end
```

Oops!

What is needed is a value to indicate a safe value without it causing this kind of downstream problem.

For now, that value is `:BRAKEMAN_SAFE_VALUE`.

Now our example would look like

```ruby
if [1, 0].include? x
  eval [params[:x], "nothing"][:BRAKEMAN_SAFE_VALUE]
end
```

and Brakeman will warn about `eval`ing a query parameter.
