### PR TITLE
Fix typo when initializing @initialize_env

### DIFF
--- a/lib/brakeman/processors/library_processor.rb
+++ b/lib/brakeman/processors/library_processor.rb
@@ -13,7 +13,7 @@ class Brakeman::LibraryProcessor < Brakeman::BaseProcessor
     @alias_processor = Brakeman::AliasProcessor.new tracker
     @current_module = nil
     @current_class = nil
-    @intializer_env = nil
+    @initializer_env = nil
   end
 
   def process_library src, file_name = nil


### PR DESCRIPTION
Found via Synopsys Coverity