### PR TITLE
Avoid nils when concatenating arrays

### DIFF
--- a/lib/brakeman/processors/lib/call_conversion_helper.rb
+++ b/lib/brakeman/processors/lib/call_conversion_helper.rb
@@ -9,7 +9,8 @@ module Brakeman
     # Join two array literals into one.
     def join_arrays lhs, rhs, original_exp = nil
       if array? lhs and array? rhs
-        result = Sexp.new(:array).line(lhs.line)
+        result = Sexp.new(:array)
+        result.line(lhs.line || rhs.line)
         result.concat lhs[1..-1]
         result.concat rhs[1..-1]
         result

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -155,6 +155,22 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
+  def test_array_plus_equals
+    assert_alias '[1, 2, 3]', <<-RUBY
+    x = [1]
+    x += [2, 3]
+    x
+    RUBY
+  end
+
+  def test_array_plu
+    assert_alias '[1, 2, 3]', <<-RUBY
+    x = [1]
+    y = x + [2, 3]
+    y
+    RUBY
+  end
+
   def test_hash_index
     assert_alias "'You say goodbye, I say :hello'", <<-RUBY
       x = {:goodbye => "goodbye cruel world" }


### PR DESCRIPTION
`Sexp#line` confuses me sometimes.

Should fix #1249