### PR TITLE
Add --enable option to enable optional checks

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -348,7 +348,7 @@ module Brakeman
     scanner = Scanner.new options
     tracker = scanner.tracker
 
-    check_for_missing_checks options[:run_checks], options[:skip_checks]
+    check_for_missing_checks options[:run_checks], options[:skip_checks], options[:enable_checks]
 
     notify "Processing application in #{tracker.app_path}"
     scanner.process
@@ -521,8 +521,10 @@ module Brakeman
     end if options[:additional_checks_path]
   end
 
-  def self.check_for_missing_checks included_checks, excluded_checks
-    missing = Brakeman::Checks.missing_checks(included_checks || Set.new, excluded_checks || Set.new)
+  def self.check_for_missing_checks included_checks, excluded_checks, enabled_checks
+    checks = included_checks.to_a + excluded_checks.to_a + enabled_checks.to_a
+
+    missing = Brakeman::Checks.missing_checks(checks)
 
     unless missing.empty?
       raise MissingChecksError, "Could not find specified check#{missing.length > 1 ? 's' : ''}: #{missing.map {|c| "`#{c}`"}.join(', ')}"

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -169,6 +169,19 @@ module Brakeman::Options
           options[:engine_paths].merge paths
         end
 
+        opts.on "-E", "--enable Check1,Check2,etc", Array, "Enable the specified checks" do |checks|
+          checks.map! do |check|
+            if check.start_with? "Check"
+              check
+            else
+              "Check" << check
+            end
+          end
+
+          options[:enable_checks] ||= Set.new
+          options[:enable_checks].merge checks
+        end
+
         opts.on "-t", "--test Check1,Check2,etc", Array, "Only run the specified checks" do |checks|
           checks.each_with_index do |s, index|
             if s[0,5] != "Check"

--- a/test/tests/checks.rb
+++ b/test/tests/checks.rb
@@ -1,0 +1,91 @@
+require_relative '../test'
+
+class ChecksTests < Minitest::Test
+  def setup_tracker options = {}
+    options[:app_path] = "/tmp/NOT_REAL"
+    options = Brakeman.set_options(options)
+    app_tree = Brakeman::AppTree.from_options(options)
+    @tracker = Brakeman::Tracker.new(app_tree, nil, options)
+  end
+
+  def test_default_checks
+    t = setup_tracker
+
+    all_checks = Brakeman::Checks.checks.length
+    optional_checks = Brakeman::Checks.optional_checks.length
+    default_checks = Brakeman::Checks.checks_to_run(t).length
+
+    assert_operator all_checks, :>, default_checks
+    assert_operator all_checks, :>, optional_checks
+    assert_equal all_checks, default_checks + optional_checks
+  end
+
+  def test_run_all_checks
+    t = setup_tracker run_all_checks: true
+
+    assert_equal Brakeman::Checks.checks.length, Brakeman::Checks.checks_to_run(t).length
+  end
+
+  def test_run_single_check
+    t = setup_tracker run_checks: ["CheckCrossSiteScripting"]
+
+    assert_equal [Brakeman::CheckCrossSiteScripting], Brakeman::Checks.checks_to_run(t)
+  end
+
+  def test_enable_single_optional_check
+    t = setup_tracker enable_checks: ["CheckSymbolDoS"]
+
+    assert_includes Brakeman::Checks.checks_to_run(t), Brakeman::CheckSymbolDoS
+
+    expected = Brakeman::Checks.checks.length - Brakeman::Checks.optional_checks.length + 1
+
+    assert_equal expected, Brakeman::Checks.checks_to_run(t).length
+  end
+
+  def test_enable_optional_checks
+    t = setup_tracker enable_checks: ["CheckSymbolDoS", "CheckUnscopedFind"]
+
+    assert_includes Brakeman::Checks.checks_to_run(t), Brakeman::CheckSymbolDoS
+    assert_includes Brakeman::Checks.checks_to_run(t), Brakeman::CheckUnscopedFind
+
+    expected = Brakeman::Checks.checks.length - Brakeman::Checks.optional_checks.length + 2
+
+    assert_equal expected, Brakeman::Checks.checks_to_run(t).length
+  end
+
+  def test_missing_checks
+    checks = ["Checkarghlbarghl", "CheckUnscopedFind"]
+
+    assert_equal Set["Checkarghlbarghl"], Brakeman::Checks.missing_checks(checks)
+  end
+
+  def test_check_for_missing_checks
+    require 'brakeman/options'
+    options, _ = Brakeman::Options.parse(["-t", "blah"])
+    t = setup_tracker options
+
+    assert_raises Brakeman::MissingChecksError do
+      Brakeman.check_for_missing_checks options[:run_checks], options[:skip_checks], options[:enable_checks]
+    end
+  end
+
+  def test_check_for_missing_skipped_checks
+    require 'brakeman/options'
+    options, _ = Brakeman::Options.parse(["-x", "blah"])
+    t = setup_tracker options
+
+    assert_raises Brakeman::MissingChecksError do
+      Brakeman.check_for_missing_checks options[:run_checks], options[:skip_checks], options[:enable_checks]
+    end
+  end
+
+  def test_check_for_missing_enabled_checks
+    require 'brakeman/options'
+    options, _ = Brakeman::Options.parse(["-E", "blah"])
+    t = setup_tracker options
+
+    assert_raises Brakeman::MissingChecksError do
+      Brakeman.check_for_missing_checks options[:run_checks], options[:skip_checks], options[:enable_checks]
+    end
+  end
+end


### PR DESCRIPTION
Currently you can

- Run the defaults, which does not include optional checks
- Run all checks with `-A`
- Disable specific checks with `-x`
- Run *only* specific checks with `-t`

But you cannot enable a subset of optional checks which also running the default checks.

This new option (`-E`/`--enable`) adds that capability.