### PR TITLE
Do not warn about *_url on models in redirects

### DIFF
--- a/lib/brakeman/checks/check_redirect.rb
+++ b/lib/brakeman/checks/check_redirect.rb
@@ -79,7 +79,7 @@ class Brakeman::CheckRedirect < Brakeman::BaseCheck
     end
 
     if res = has_immediate_model?(arg)
-      unless call? arg and arg.method.to_s =~ /_path/
+      unless call? arg and arg.method.to_s =~ /_path|_url/
         return Match.new(immediate, res)
       end
     elsif call? arg

--- a/test/apps/rails5/app/controllers/widget_controller.rb
+++ b/test/apps/rails5/app/controllers/widget_controller.rb
@@ -103,6 +103,18 @@ class WidgetController < ApplicationController
     end
   end
 
+  def redirect_to_url
+    session = User.find_by_token params[:session]
+
+    if session
+      # proceed with extracting user context from session and more and redirect to the last url the user was shown to
+      login(session.user)
+      redirect_to session.user.current_url
+    else
+      redirect_to expired_or_invalid_session_path
+    end
+  end
+
   def render_safely
     slug = params[:slug].to_s
     render slug if template_exists?(slug, 'pages')

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -274,6 +274,19 @@ class Rails5Tests < Minitest::Test
       :user_input => s(:call, s(:call, s(:call, s(:const, :User), :find_by_token, s(:call, s(:params), :[], s(:lit, :session))), :user), :current_path)
   end
 
+  def test_redirect_with_url_on_model
+    assert_no_warning :type => :warning,
+                      :warning_code => 18,
+                      :fingerprint => "30666ad621e97ffcdacff38d70b1bafd35e7ed26dff01097df386c43158198f0",
+                      :warning_type => "Redirect",
+                      :line => 112,
+                      :message => /^Possible\ unprotected\ redirect/,
+                      :confidence => 0,
+                      :relative_path => "app/controllers/widget_controller.rb",
+                      :code => s(:call, nil, :redirect_to, s(:call, s(:call, s(:call, s(:const, :User), :find_by_token, s(:call, s(:params), :[], s(:lit, :session))), :user), :current_url)),
+                      :user_input => s(:call, s(:call, s(:call, s(:const, :User), :find_by_token, s(:call, s(:params), :[], s(:lit, :session))), :user), :current_url)
+  end
+
   def test_cross_site_scripting_with_slice
     assert_no_warning :type => :template,
       :warning_code => 4,
@@ -395,7 +408,7 @@ class Rails5Tests < Minitest::Test
       :warning_code => 15,
       :fingerprint => "5c250fd85fe088bf628d517af37038fa516acc4b6103ee6d8a15e857079ad434",
       :warning_type => "Dynamic Render Path",
-      :line => 108,
+      :line => 120,
       :message => /^Render\ path\ contains\ parameter\ value/,
       :confidence => 0,
       :relative_path => "app/controllers/widget_controller.rb",


### PR DESCRIPTION
## Issue
I have an app that uses draper decorators, one of which provides a `step_url` method, which produces warnings. Changing it to `step_path` removes the warnings, but is slightly misleading because it uses the `url_for` helper.

## Fix
This is basically just an add-on to #1164, so that model methods ending in `_url` also do not generate warnings.