### PR TITLE
Always run optional checks when they are enabled

### DIFF
--- a/lib/brakeman/checks.rb
+++ b/lib/brakeman/checks.rb
@@ -170,7 +170,7 @@ class Brakeman::Checks
                @checks + @optional_checks
              else
                @checks.dup
-             end
+             end.to_set
 
     if enabled_checks = tracker.options[:enable_checks]
       @optional_checks.each do |c|
@@ -186,12 +186,13 @@ class Brakeman::Checks
   def self.filter_checks checks, tracker
     skipped = tracker.options[:skip_checks]
     explicit = tracker.options[:run_checks]
+    enabled = tracker.options[:enable_checks] || []
 
     checks.reject do |c|
       check_name = self.get_check_name(c)
 
       skipped.include? check_name or
-        (explicit and not explicit.include? check_name)
+        (explicit and not explicit.include? check_name and not enabled.include? check_name)
     end
   end
 

--- a/test/tests/checks.rb
+++ b/test/tests/checks.rb
@@ -53,6 +53,21 @@ class ChecksTests < Minitest::Test
     assert_equal expected, Brakeman::Checks.checks_to_run(t).length
   end
 
+  def test_enable_optional_checks_duplicate
+    t = setup_tracker enable_checks: ["CheckUnscopedFind"], run_checks: ["CheckUnscopedFind"]
+
+    assert_includes Brakeman::Checks.checks_to_run(t), Brakeman::CheckUnscopedFind
+    assert_equal 1, Brakeman::Checks.checks_to_run(t).length
+  end
+
+  def test_enable_optional_checks_with_explicit
+    t = setup_tracker enable_checks: ["CheckUnscopedFind"], run_checks: ["CheckCrossSiteScripting"]
+
+    assert_includes Brakeman::Checks.checks_to_run(t), Brakeman::CheckUnscopedFind
+    assert_includes Brakeman::Checks.checks_to_run(t), Brakeman::CheckCrossSiteScripting
+    assert_equal 2, Brakeman::Checks.checks_to_run(t).length
+  end
+
   def test_missing_checks
     checks = ["Checkarghlbarghl", "CheckUnscopedFind"]
 


### PR DESCRIPTION
Pretty much an edge case, but if `-t` and `-E` are used together, you shouldn't get duplicates and all the specified checks should run.