### PR TITLE
Remove unnecessary code arguments in some checks

### DIFF
--- a/lib/brakeman/checks/check_evaluation.rb
+++ b/lib/brakeman/checks/check_evaluation.rb
@@ -27,7 +27,6 @@ class Brakeman::CheckEvaluation < Brakeman::BaseCheck
         :warning_type => "Dangerous Eval",
         :warning_code => :code_eval,
         :message => "User input in eval",
-        :code => result[:call],
         :user_input => input,
         :confidence => :high
     end

--- a/lib/brakeman/checks/check_send.rb
+++ b/lib/brakeman/checks/check_send.rb
@@ -28,7 +28,6 @@ class Brakeman::CheckSend < Brakeman::BaseCheck
         :warning_type => "Dangerous Send",
         :warning_code => :dangerous_send,
         :message => "User controlled method execution",
-        :code => result[:call],
         :user_input => input,
         :confidence => :high
     end

--- a/lib/brakeman/checks/check_session_manipulation.rb
+++ b/lib/brakeman/checks/check_session_manipulation.rb
@@ -27,7 +27,6 @@ class Brakeman::CheckSessionManipulation < Brakeman::BaseCheck
         :warning_type => "Session Manipulation",
         :warning_code => :session_key_manipulation,
         :message => msg(msg_input(input), " used as key in session hash"),
-        :code => result[:call],
         :user_input => input,
         :confidence => confidence
     end


### PR DESCRIPTION
Passing `code: result[:call]` is redundant if `result: result` is given.

This is just to avoid confusion in the future when I wonder why that was specified explicitly.