### PR TITLE
Upgrade RubyParser to 3.12

### DIFF
--- a/gem_common.rb
+++ b/gem_common.rb
@@ -5,7 +5,7 @@ module Brakeman
     end
 
     def self.base_dependencies spec
-      spec.add_dependency "ruby_parser", "~>3.11.0"
+      spec.add_dependency "ruby_parser", "~>3.12"
       spec.add_dependency "sexp_processor", "~> 4.7"
       spec.add_dependency "ruby2ruby", "~>2.4.0"
       spec.add_dependency "safe_yaml", ">= 1.0"


### PR DESCRIPTION
Also, minor versions are not as scary now (especially with the dependency vendoring), so be more liberal there.