### PR TITLE
Set default external encoding to UTF-8

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,8 @@
 #Adjust path in case called directly and not through gem
 $:.unshift "#{File.expand_path(File.dirname(__FILE__))}/../lib"
 
+Encoding.default_external = 'UTF-8'
+
 require 'brakeman'
 require 'brakeman/commandline'
 


### PR DESCRIPTION
Seems to be the safest when environments are setting e.g. `LC_ALL=C`.