### PR TITLE
Relax Sass dependency to ~>3.0

### DIFF
--- a/gem_common.rb
+++ b/gem_common.rb
@@ -17,7 +17,7 @@ module Brakeman
       spec.add_dependency "highline", ">=1.6.20", "<2.0"
       spec.add_dependency "erubis", "~>2.6"
       spec.add_dependency "haml", ">=3.0", "<5.0"
-      spec.add_dependency "sass", "~>3.0", "<3.5.0"
+      spec.add_dependency "sass", "~>3.0"
       spec.add_dependency "slim", ">=1.3.6", "<=4.0.1"
     end
   end


### PR DESCRIPTION
Closes #1295

Note that this means Ruby 1.9 will no longer be supported in the `brakeman` gem release.