### PR TITLE
Add original exception to Tracker#errors list

### DIFF
--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -61,7 +61,11 @@ class Brakeman::Tracker
     Brakeman.debug exception
     Brakeman.debug backtrace
 
-    @errors << { :error => exception.to_s.gsub("\n", " "), :backtrace => backtrace }
+    @errors << {
+      :exception => exception,
+      :error => exception.to_s.gsub("\n", " "),
+      :backtrace => backtrace
+    }
   end
 
   #Run a set of checks on the current information. Results will be stored

--- a/test/tests/tracker.rb
+++ b/test/tests/tracker.rb
@@ -1,0 +1,23 @@
+require_relative '../test'
+
+class TrackerTests < Minitest::Test
+  def setup
+    @tracker = Brakeman::Tracker.new(nil)
+  end
+
+  def test_exception_in_error_list
+    @tracker.error Exception.new
+
+    assert_equal 1, @tracker.errors.length
+
+    @tracker.errors.each do |e|
+      assert e.has_key? :exception
+      assert e.has_key? :error
+      assert e.has_key? :backtrace
+
+      assert e[:exception].is_a? Exception
+      assert e[:error].is_a? String
+      assert e[:backtrace].is_a? Array
+    end
+  end
+end


### PR DESCRIPTION
When tracking errors, hang on to the original exception that was raised, not just its attributes.