### PR TITLE
Re-parse with latest RubyParser on errors

### DIFF
--- a/lib/brakeman/file_parser.rb
+++ b/lib/brakeman/file_parser.rb
@@ -31,13 +31,17 @@ module Brakeman
       end
     end
 
-    def parse_ruby input, path
+    def parse_ruby input, path, parser = RubyParser.new
       begin
         Brakeman.debug "Parsing #{path}"
-        RubyParser.new.parse input, path, @timeout
+        parser.parse input, path, @timeout
       rescue Racc::ParseError => e
-        @tracker.error e, "Could not parse #{path}"
-        nil
+        if parser.class == RubyParser
+          return parse_ruby(input, path, RubyParser.latest)
+        else
+          @tracker.error e, "Could not parse #{path}"
+          nil
+        end
       rescue Timeout::Error => e
         @tracker.error Exception.new("Parsing #{path} took too long (> #{@timeout} seconds). Try increasing the limit with --parser-timeout"), caller
         nil

--- a/test/tests/file_parser.rb
+++ b/test/tests/file_parser.rb
@@ -1,0 +1,26 @@
+require_relative '../test'
+
+class FileParserTests < Minitest::Test
+  def setup
+    @tracker = Brakeman::Tracker.new(nil)
+    @file_parser = Brakeman::FileParser.new(@tracker, nil)
+  end
+
+  def test_parse_error
+    @file_parser.parse_ruby <<-RUBY, "/tmp/BRAKEMAN_FAKE_PATH/test.rb"
+        x =
+    RUBY
+
+    assert_equal 1, @tracker.errors.length
+  end
+
+  def test_parse_error_shows_newer_failure
+    @file_parser.parse_ruby <<-RUBY, "/tmp/BRAKEMAN_FAKE_PATH/test.rb"
+    blah(x: 1)
+    thing do
+    RUBY
+
+    assert_equal 1, @tracker.errors.length
+    assert_match /parse error on value \"\$end\" \(\$end\)/, @tracker.errors.first[:error]
+  end
+end


### PR DESCRIPTION
Otherwise the error message can be misleading because it's trying to parse Ruby 1.8 syntax and failing, usually on a newer syntax (not the actual problem). To avoid this, re-parse with the latest version supported by RubyParser to get a better error message.