### PR TITLE
Add deserialization warning for Oj.load/object_load

### DIFF
--- a/test/apps/rails5.2/app/controllers/users_controller.rb
+++ b/test/apps/rails5.2/app/controllers/users_controller.rb
@@ -46,4 +46,11 @@ class UsersController < ApplicationController
   def two
     @user = User.find(params[:id])
   end
+
+  def some_api
+    Oj.load(params[:json]) # Unsafe by default
+    Oj.load(params[:json], mode: :object) # Unsafe, regardless of default
+    Oj.object_load(params[:json], mode: :strict) # Always unsafe, regardless of mode
+    Oj.load(params[:json], mode: :strict) # Safe
+  end
 end

--- a/test/apps/rails5.2/config/initializers/oj.rb
+++ b/test/apps/rails5.2/config/initializers/oj.rb
@@ -1,0 +1,4 @@
+# These are commented out by default and then turned on in test/tests/oj.rb for testing.
+#
+# Oj.mimic_JSON
+# Oj.default_options = { mode: :strict }

--- a/test/tests/oj.rb
+++ b/test/tests/oj.rb
@@ -1,0 +1,40 @@
+require_relative '../test'
+require 'brakeman/rescanner'
+
+class OjSettingsTests < Minitest::Test
+  include BrakemanTester::RescanTestHelper
+
+  def setup
+    @oj_config = "config/initializers/oj.rb"
+  end
+
+  def test_oj_mimic_json
+    before_rescan_of @oj_config, "rails5.2" do
+      replace @oj_config, "# Oj.mimic_JSON", "Oj.mimic_JSON"
+    end
+
+    assert_changes
+    assert_fixed 1 # Fix default Oj.load() behavior
+    assert_new 0
+  end
+
+  def test_oj_default_setting
+    before_rescan_of @oj_config, "rails5.2" do
+      replace @oj_config, "# Oj.default_options", "Oj.default_options"
+    end
+
+    assert_changes
+    assert_fixed 1 # Fix default Oj.load() behavior
+    assert_new 0
+  end
+
+  def test_oj_default_setting_still_unsafe
+    before_rescan_of @oj_config, "rails5.2" do
+      append @oj_config, "Oj.default_options = { whatever: false }"
+    end
+
+    assert_changes
+    assert_fixed 0 # Default is still bad, no changes 
+    assert_new 0
+  end
+end

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -13,7 +13,7 @@ class Rails52Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 12
+      :generic => 15
     }
   end
 
@@ -407,6 +407,45 @@ class Rails52Tests < Minitest::Test
       :relative_path => "app/views/users/_foo2.html.haml",
       :code => s(:call, s(:call, nil, :params), :[], s(:lit, :x)),
       :user_input => nil
+  end
+
+  def test_remote_code_execution_oj_load
+    assert_warning :type => :warning,
+      :warning_code => 25,
+      :fingerprint => "97ecaa5677c8eadaed09217a704e59092921fab24cc751e05dfb7b167beda2cf",
+      :warning_type => "Remote Code Execution",
+      :line => 51,
+      :message => /^`Oj\.load`\ called\ with\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :code => s(:call, s(:const, :Oj), :load, s(:call, s(:params), :[], s(:lit, :json))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :json))
+  end
+
+  def test_remote_code_execution_oj_load_mode
+    assert_warning :type => :warning,
+      :warning_code => 25,
+      :fingerprint => "006ac5fe3834bf2e73ee51b67eb111066f618be46e391d493c541ea2a906a82f",
+      :warning_type => "Remote Code Execution",
+      :line => 52,
+      :message => /^`Oj\.load`\ called\ with\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :code => s(:call, s(:const, :Oj), :load, s(:call, s(:params), :[], s(:lit, :json)), s(:hash, s(:lit, :mode), s(:lit, :object))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :json))
+  end
+
+  def test_remote_code_execution_oj_object_load
+    assert_warning :type => :warning,
+      :warning_code => 25,
+      :fingerprint => "3bc375c9cb79d8bcd9e7f1c09a574fa3deeab17f924cf20455cbd4c15e9c66eb",
+      :warning_type => "Remote Code Execution",
+      :line => 53,
+      :message => /^`Oj\.object_load`\ called\ with\ parameter\ v/,
+      :confidence => 0,
+      :relative_path => "app/controllers/users_controller.rb",
+      :code => s(:call, s(:const, :Oj), :object_load, s(:call, s(:params), :[], s(:lit, :json)), s(:hash, s(:lit, :mode), s(:lit, :strict))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :json))
   end
 
   def test_cross_site_scripting_loofah_CVE_2018_8048


### PR DESCRIPTION
As pointed [out here](https://www.honoki.net/2019/03/rce-in-slanger-0-6-0/), `Oj.load` by default will deserialize arbitrary Ruby objects from JSON.

This updates the deserialization check to look for:

* `Oj.load` with default options
* `Oj.object_load` with any options