### PR TITLE
Clean up Ruby warnings

### DIFF
--- a/gem_common.rb
+++ b/gem_common.rb
@@ -16,7 +16,7 @@ module Brakeman
 
     def self.extended_dependencies spec
       spec.add_dependency "terminal-table", "~>1.4"
-      spec.add_dependency "highline", ">=1.6.20", "<2.0"
+      spec.add_dependency "highline", "~>2.0"
       spec.add_dependency "erubis", "~>2.6"
       spec.add_dependency "haml", ">=3.0", "<5.0"
       spec.add_dependency "slim", ">=1.3.6", "<=4.0.1"

--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -62,6 +62,7 @@ module Brakeman
       @absolute_engine_paths = @engine_paths.select { |path| path.start_with?(File::SEPARATOR) }
       @relative_engine_paths = @engine_paths - @absolute_engine_paths
       @gemspec = nil
+      @root_search_pattern = nil
     end
 
     def expand_path(path)
@@ -190,8 +191,8 @@ module Brakeman
     def root_search_pattern
       return @root_search_pattern if @root_search_pattern
 
-      abs = @absolute_engine_paths.to_a.map { |path| path.gsub /#{File::SEPARATOR}+$/, '' }
-      rel = @relative_engine_paths.to_a.map { |path| path.gsub /#{File::SEPARATOR}+$/, '' }
+      abs = @absolute_engine_paths.to_a.map { |path| path.gsub(/#{File::SEPARATOR}+$/, '') }
+      rel = @relative_engine_paths.to_a.map { |path| path.gsub(/#{File::SEPARATOR}+$/, '') }
 
       roots = ([@root] + abs).join(",")
       rel_engines = (rel + [""]).join("/,")

--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -33,6 +33,11 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
 
   FORM_BUILDER = Sexp.new(:call, Sexp.new(:const, :FormBuilder), :new)
 
+  def initialize *args
+    super
+    @matched = @mark = false
+  end
+
   #Run check
   def run_check
     setup

--- a/lib/brakeman/checks/check_default_routes.rb
+++ b/lib/brakeman/checks/check_default_routes.rb
@@ -6,6 +6,11 @@ class Brakeman::CheckDefaultRoutes < Brakeman::BaseCheck
 
   @description = "Checks for default routes"
 
+  def initialize *args
+    super
+    @actions_allowed_on_controller = nil
+  end
+
   #Checks for :allow_all_actions globally and for individual routes
   #if it is not enabled globally.
   def run_check

--- a/lib/brakeman/checks/check_dynamic_finders.rb
+++ b/lib/brakeman/checks/check_dynamic_finders.rb
@@ -43,6 +43,6 @@ class Brakeman::CheckDynamicFinders < Brakeman::BaseCheck
   end
 
   def potentially_dangerous? method_name
-    method_name.match /^find_by_.*(token|guid|password|api_key|activation|code|private|reset)/
+    method_name.match(/^find_by_.*(token|guid|password|api_key|activation|code|private|reset)/)
   end
 end

--- a/lib/brakeman/checks/check_json_parsing.rb
+++ b/lib/brakeman/checks/check_json_parsing.rb
@@ -5,6 +5,11 @@ class Brakeman::CheckJSONParsing < Brakeman::BaseCheck
 
   @description = "Checks for JSON parsing vulnerabilities CVE-2013-0333 and CVE-2013-0269"
 
+  def initialize *args
+    super
+    @uses_json_parse = nil
+  end
+
   def run_check
     check_cve_2013_0333
     check_cve_2013_0269

--- a/lib/brakeman/checks/check_secrets.rb
+++ b/lib/brakeman/checks/check_secrets.rb
@@ -35,6 +35,6 @@ class Brakeman::CheckSecrets < Brakeman::BaseCheck
 
   def looks_like_secret? name
     # REST_AUTH_SITE_KEY is the pepper in Devise
-    name.match /password|secret|(rest_auth_site|api)_key$/i
+    name.match(/password|secret|(rest_auth_site|api)_key$/i)
   end
 end

--- a/lib/brakeman/checks/check_simple_format.rb
+++ b/lib/brakeman/checks/check_simple_format.rb
@@ -5,6 +5,11 @@ class Brakeman::CheckSimpleFormat < Brakeman::CheckCrossSiteScripting
 
   @description = "Checks for simple_format XSS vulnerability (CVE-2013-6416) in certain versions"
 
+  def initialize *args
+    super
+    @found_any = false
+  end
+
   def run_check
     if version_between? "4.0.0", "4.0.1"
       @inspect_arguments = true

--- a/lib/brakeman/checks/check_skip_before_filter.rb
+++ b/lib/brakeman/checks/check_skip_before_filter.rb
@@ -38,7 +38,7 @@ class Brakeman::CheckSkipBeforeFilter < Brakeman::BaseCheck
         :message => msg("Use whitelist (", msg_code(":only => [..]"), ") when skipping authentication"),
         :code => filter,
         :confidence => :medium,
-        :link => "authentication_whitelist",
+        :link_path => "authentication_whitelist",
         :file => controller.file
     end
   end

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -26,7 +26,6 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     @inside_if = false
     @ignore_ifs = nil
     @exp_context = []
-    @current_module = nil
     @tracker = tracker #set in subclass as necessary
     @helper_method_cache = {}
     @helper_method_info = Hash.new({})

--- a/lib/brakeman/processors/base_processor.rb
+++ b/lib/brakeman/processors/base_processor.rb
@@ -234,8 +234,8 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
     elsif first_arg.is_a? Symbol or first_arg.is_a? String
       type = :action
       value = Sexp.new(:lit, first_arg.to_sym)
-		elsif first_arg.nil?
-			type = :default
+    elsif first_arg.nil?
+      type = :default
     elsif not hash? first_arg
       type = :action
       value = first_arg

--- a/lib/brakeman/processors/haml_template_processor.rb
+++ b/lib/brakeman/processors/haml_template_processor.rb
@@ -7,6 +7,11 @@ class Brakeman::HamlTemplateProcessor < Brakeman::TemplateProcessor
   JAVASCRIPT_FILTER = s(:colon2, s(:colon2, s(:const, :Haml), :Filters), :Javascript)
   COFFEE_FILTER = s(:colon2, s(:colon2, s(:const, :Haml), :Filters), :Coffee)
 
+  def initialize *args
+    super
+    @javascript = false
+  end
+
   #Processes call, looking for template output
   def process_call exp
     target = exp.target

--- a/lib/brakeman/processors/lib/render_path.rb
+++ b/lib/brakeman/processors/lib/render_path.rb
@@ -83,7 +83,7 @@ module Brakeman
     end
 
     def map &block
-      @path.map &block
+      @path.map(&block)
     end
 
     def to_a

--- a/lib/brakeman/processors/model_processor.rb
+++ b/lib/brakeman/processors/model_processor.rb
@@ -24,7 +24,6 @@ class Brakeman::ModelProcessor < Brakeman::BaseProcessor
   #s(:class, NAME, PARENT, BODY)
   def process_class exp
     name = class_name(exp.class_name)
-    parent = class_name(exp.parent_name)
 
     #If inside an inner class we treat it as a library.
     if @current_class

--- a/lib/brakeman/processors/output_processor.rb
+++ b/lib/brakeman/processors/output_processor.rb
@@ -8,6 +8,11 @@ require 'brakeman/util'
 class Brakeman::OutputProcessor < Ruby2Ruby
   include Brakeman::Util
 
+  def initialize *args
+    super
+    @user_input = nil
+  end
+
   #Copies +exp+ and then formats it.
   def format exp, user_input = nil, &block
     @user_input = user_input

--- a/lib/brakeman/report/pager.rb
+++ b/lib/brakeman/report/pager.rb
@@ -4,6 +4,7 @@ module Brakeman
       @tracker = tracker
       @pager = pager
       @output = output
+      @less_available = @less_options = nil
     end
 
     def page_report report, format

--- a/lib/brakeman/report/report_table.rb
+++ b/lib/brakeman/report/report_table.rb
@@ -199,10 +199,6 @@ class Brakeman::Report::Table < Brakeman::Report::Base
     end
   end
 
-  def convert_warning warning, original
-    warning
-  end
-
   def convert_ignored_warning warning, original
     convert_warning warning, original
   end

--- a/lib/brakeman/report/report_text.rb
+++ b/lib/brakeman/report/report_text.rb
@@ -201,8 +201,8 @@ class Brakeman::Report::Text < Brakeman::Report::Base
 
   # ONLY used for generate_controllers to avoid duplication
   def render_array name, cols, values, locals
-    controllers = values.map do |name, parent, includes, routes|
-      c = [ label("Controller", name) ]
+    controllers = values.map do |controller_name, parent, includes, routes|
+      c = [ label("Controller", controller_name) ]
       c << label("Parent", parent) unless parent.empty?
       c << label("Includes", includes) unless includes.empty?
       c << label("Routes", routes)

--- a/lib/brakeman/rescanner.rb
+++ b/lib/brakeman/rescanner.rb
@@ -263,9 +263,6 @@ class Brakeman::Rescanner < Brakeman::Scanner
     #Remove template
     tracker.reset_template template_name
 
-    rendered_from_controller = /^#{template_name}\.(.+Controller)#(.+)/
-    rendered_from_view = /^#{template_name}\.Template:(.+)/
-
     #Remove any rendered versions, or partials rendered from it
     tracker.templates.delete_if do |_name, template|
       template.file == path or template.name.to_sym == template_name.to_sym
@@ -371,7 +368,7 @@ class Brakeman::Rescanner < Brakeman::Scanner
       next unless template.render_path
 
       if template.render_path.include_any_method? method_names
-        name.to_s.match /^([^.]+)/
+        name.to_s.match(/^([^.]+)/)
 
         original = tracker.templates[$1.to_sym]
 

--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -34,6 +34,7 @@ class Brakeman::Warning
     :file => :@file,
     :gem_info => :@gem_info,
     :line => :@line,
+    :link => :@link, # added to fix debug warning, not expected to set via new()
     :link_path => :@link_path,
     :message => :@message,
     :method => :@method,
@@ -112,6 +113,8 @@ class Brakeman::Warning
 
     if options[:warning_code]
       @warning_code = Brakeman::WarningCodes.code options[:warning_code]
+    else
+      @warning_code = nil
     end
 
     Brakeman.debug("Warning created without warning code: #{options[:warning_code]}") unless @warning_code
@@ -253,16 +256,16 @@ class Brakeman::Warning
   def location include_renderer = true
     case @warning_set
     when :template
-      location = { :type => :template, :template => self.view_name(include_renderer) }
+      { :type => :template, :template => self.view_name(include_renderer) }
     when :model
-      location = { :type => :model, :model => self.model }
+      { :type => :model, :model => self.model }
     when :controller
-      location = { :type => :controller, :controller => self.controller }
+      { :type => :controller, :controller => self.controller }
     when :warning
       if self.class
-        location = { :type => :method, :class => self.class, :method => self.method }
+        { :type => :method, :class => self.class, :method => self.method }
       else
-        location = nil
+        nil
       end
     end
   end

--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -34,7 +34,7 @@ class Brakeman::Warning
     :file => :@file,
     :gem_info => :@gem_info,
     :line => :@line,
-    :link => :@link, # added to fix debug warning, not expected to set via new()
+    :link => :@link,
     :link_path => :@link_path,
     :message => :@message,
     :method => :@method,

--- a/lib/ruby_parser/bm_sexp_processor.rb
+++ b/lib/ruby_parser/bm_sexp_processor.rb
@@ -45,6 +45,7 @@ class Brakeman::SexpProcessor
     @expected            = Sexp
     @processors = self.class.processors
     @context    = []
+    @current_class = @current_module = @current_method = @visibility = nil
 
     if @processors.empty?
       public_methods.each do |name|

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -203,7 +203,7 @@ class ConfigTests < Minitest::Test
     }
 
     assert_output "" do
-      final_options = Brakeman.set_options(options)
+      Brakeman.set_options(options)
     end
   end
 

--- a/test/tests/checks.rb
+++ b/test/tests/checks.rb
@@ -77,7 +77,6 @@ class ChecksTests < Minitest::Test
   def test_check_for_missing_checks
     require 'brakeman/options'
     options, _ = Brakeman::Options.parse(["-t", "blah"])
-    t = setup_tracker options
 
     assert_raises Brakeman::MissingChecksError do
       Brakeman.check_for_missing_checks options[:run_checks], options[:skip_checks], options[:enable_checks]
@@ -87,7 +86,6 @@ class ChecksTests < Minitest::Test
   def test_check_for_missing_skipped_checks
     require 'brakeman/options'
     options, _ = Brakeman::Options.parse(["-x", "blah"])
-    t = setup_tracker options
 
     assert_raises Brakeman::MissingChecksError do
       Brakeman.check_for_missing_checks options[:run_checks], options[:skip_checks], options[:enable_checks]
@@ -97,7 +95,6 @@ class ChecksTests < Minitest::Test
   def test_check_for_missing_enabled_checks
     require 'brakeman/options'
     options, _ = Brakeman::Options.parse(["-E", "blah"])
-    t = setup_tracker options
 
     assert_raises Brakeman::MissingChecksError do
       Brakeman.check_for_missing_checks options[:run_checks], options[:skip_checks], options[:enable_checks]

--- a/test/tests/commandline.rb
+++ b/test/tests/commandline.rb
@@ -49,13 +49,13 @@ class CommandlineTests < Minitest::Test
   # Helpers
 
   def cl_with_options *opts
-    TestCommandline.start *TestCommandline.parse_options(opts)
+    TestCommandline.start(*TestCommandline.parse_options(opts))
   end
 
   def scan_app *opts
     opts << "#{TEST_PATH}/apps/rails4"
     assert_output do
-      cl_with_options *opts 
+      cl_with_options(*opts)
     end
   end
 
@@ -81,13 +81,13 @@ class CommandlineTests < Minitest::Test
   end
 
   def test_list_checks
-    assert_stderr /\AAvailable Checks:/ do
+    assert_stderr(/\AAvailable Checks:/) do
       cl_with_options "--checks"
     end
   end
 
   def test_bad_options
-    assert_stderr /\Ainvalid option: --not-a-real-option\nPlease see `brakeman --help`/, -1 do
+    assert_stderr(/\Ainvalid option: --not-a-real-option\nPlease see `brakeman --help`/, -1) do
       cl_with_options "--not-a-real-option"
     end
   end
@@ -107,7 +107,7 @@ class CommandlineTests < Minitest::Test
   end
 
   def test_show_help
-    assert_stdout /\AUsage: brakeman \[options\] rails\/root\/path/ do
+    assert_stdout(/\AUsage: brakeman \[options\] rails\/root\/path/) do
       assert_exit do
         cl_with_options "--help"
       end

--- a/test/tests/cves.rb
+++ b/test/tests/cves.rb
@@ -286,8 +286,8 @@ class CVETests < Minitest::Test
     assert_version "3.0.0"
 
     warning = new.find do |w|
-      w.warning_code == 31 # CVE_2010_3933
-      w.message.to_s == "Vulnerability in nested attributes (CVE-2010-3933). Upgrade to Rails 3.0.1"
+      w.warning_code == 31 and # CVE_2010_3933
+        w.message.to_s == "Vulnerability in nested attributes (CVE-2010-3933). Upgrade to Rails 3.0.1"
     end
 
     refute_nil warning

--- a/test/tests/file_parser.rb
+++ b/test/tests/file_parser.rb
@@ -21,6 +21,6 @@ class FileParserTests < Minitest::Test
     RUBY
 
     assert_equal 1, @tracker.errors.length
-    assert_match /parse error on value \"\$end\" \(\$end\)/, @tracker.errors.first[:error]
+    assert_match(/parse error on value \"\$end\" \(\$end\)/, @tracker.errors.first[:error])
   end
 end

--- a/test/tests/pager.rb
+++ b/test/tests/pager.rb
@@ -32,6 +32,7 @@ class ReportPagerTests < Minitest::Test
   end
 
   def test_highline
+    require 'highline/io_console_compatible' # For StringIO compatibility
     out = StringIO.new
     $stdin = StringIO.new("\r\r\r\r\r\r\r")
     pager = Brakeman::Pager.new(nil, :highline, out)

--- a/test/tests/pager.rb
+++ b/test/tests/pager.rb
@@ -54,13 +54,17 @@ class ReportPagerTests < Minitest::Test
     end
   end
 
-  def test_set_color
-    pager = Brakeman::Pager.new(Brakeman::Tracker.new(nil))
+  def test_set_color_force
+    t = Brakeman::Tracker.new(nil)
+    t.options[:output_color] = :force 
+    pager = Brakeman::Pager.new(t)
     pager.set_color
+
+    assert t.options[:output_color]
   end
 
-  def test_output_report
-    out = $stdout = StringIO.new
+  def test_pager_output_report
+    $stdout = StringIO.new
     app_path = File.expand_path "#{TEST_PATH}/apps/rails5"
     tracker = Brakeman.run app_path: app_path, run_checks: [], quiet: true, summary_only: :no_summary
     pager = Brakeman::Pager.new(tracker)

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -1438,7 +1438,7 @@ class Rails3Tests < Minitest::Test
       :user_input => nil
   end
 
-  def test_cross_site_scripting_CVE_2016_6316
+  def test_cross_site_scripting_CVE_2016_6316_Gemfile
     assert_warning :type => :warning,
       :warning_code => 102,
       :fingerprint => "331e69e4654f158601d9a0e124304f825da4e0156d2c94759eb02611e280feaa",

--- a/test/tests/report_generation.rb
+++ b/test/tests/report_generation.rb
@@ -114,7 +114,7 @@ class TestReportGeneration < Minitest::Test
     report = @@report.to_plain
 
     assert report.is_a? String
-    assert report.match /Overview.*Warning Types.*Controller Overview.*Template Output.*Warnings/m
+    assert report.match(/Overview.*Warning Types.*Controller Overview.*Template Output.*Warnings/m)
   ensure
     @@tracker.options[:debug] = false
   end

--- a/test/tests/rescanner.rb
+++ b/test/tests/rescanner.rb
@@ -163,19 +163,19 @@ class RescannerTests < Minitest::Test
   end
 
   def test_delete_model_and_dependency
-      model = "app/models/user.rb"
-      dependency = "app/models/user/command_dependency.rb"
+    model = "app/models/user.rb"
+    dependency = "app/models/user/command_dependency.rb"
 
-      before_rescan_of model do
-        remove model
-        remove dependency
-      end
-
-      assert_reindex :controllers, :models, :templates
-      assert_changes
-      assert_new 6 #User is no longer a model, causing MORE warnings
-      assert_fixed 8
+    before_rescan_of model do
+      remove model
+      remove dependency
     end
+
+    assert_reindex :controllers, :models, :templates
+    assert_changes
+    assert_new 6 #User is no longer a model, causing MORE warnings
+    assert_fixed 8
+  end
 
   def test_add_method_to_model
     model = "app/models/user.rb"

--- a/test/tests/sexp.rb
+++ b/test/tests/sexp.rb
@@ -100,7 +100,6 @@ class SexpTests < Minitest::Test
 
   def test_stabby_lambda_no_args
     exp = parse "->{ hi }"
-    args = exp.block_args
 
     assert_equal s(:call, nil, :lambda), exp.block_call
     assert_equal s(:args), exp.block_args
@@ -358,6 +357,7 @@ class SexpTests < Minitest::Test
     s.line(10)
 
     refute_nil s.instance_variable_get(:@my_hash_value)
+    assert_equal s_hash, s.hash
   end
 
   def test_sexp_line_set


### PR DESCRIPTION
I believe this cleans up all unnecessary Ruby warnings.

To do so, Highline has been bumped to ~>2.0. Brakeman Pro has used the pre-release versions of Highline 2.0 for a long time (for JRuby compatibility), so this should be fairly safe.

In the cleanup process, some test bugs were fixed, too!