### PR TITLE
Remove conditions for Ruby versions prior to 1.9

### DIFF
--- a/lib/brakeman/parsers/template_parser.rb
+++ b/lib/brakeman/parsers/template_parser.rb
@@ -63,7 +63,7 @@ module Brakeman
         else
           ERB.new(text, nil, '-').src
         end
-        src.sub!(/^#.*\n/, '') if Brakeman::Scanner::RUBY_1_9
+        src.sub!(/^#.*\n/, '')
         src
       end
     end

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -16,7 +16,6 @@ end
 #Scans the Rails application.
 class Brakeman::Scanner
   attr_reader :options
-  RUBY_1_9 = RUBY_VERSION >= "1.9.0"
 
   #Pass in path to the root of the Rails application
   def initialize options, processor = nil

--- a/test/tests/markdown_output.rb
+++ b/test/tests/markdown_output.rb
@@ -10,10 +10,6 @@ class TestMarkdownOutput < Minitest::Test
   end
 
   def test_reported_warnings
-    if Brakeman::Scanner::RUBY_1_9
-      assert_equal 171, @@report.lines.to_a.count
-    else
-      assert_equal 172, @@report.lines.to_a.count
-    end
+    assert_equal 171, @@report.lines.to_a.count
   end
 end

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -10,19 +10,11 @@ class Rails2Tests < Minitest::Test
   include BrakemanTester::CheckExpected
 
   def expected
-    if Brakeman::Scanner::RUBY_1_9
-      @expected ||= {
-        :controller => 1,
-        :model => 3,
-        :template => 47,
-        :generic => 57 }
-    else
-      @expected ||= {
-        :controller => 1,
-        :model => 3,
-        :template => 48,
-        :generic => 58 }
-    end
+    @expected ||= {
+      :controller => 1,
+      :model => 3,
+      :template => 47,
+      :generic => 57 }
   end
 
   def report
@@ -206,20 +198,6 @@ class Rails2Tests < Minitest::Test
       :confidence => 0,
       :file => /session_store\.rb/,
       :relative_path => "config/initializers/session_store.rb"
-  end
-
-  def test_rails_cve_2011_2932
-    unless Brakeman::Scanner::RUBY_1_9
-      assert_warning :type => :warning,
-        :warning_code => 83,
-        :fingerprint => "19e0b7ab34bebe1c887bc388a195a8619136abe5875d62010628958f0792479c",
-        :warning_type => "Cross-Site Scripting",
-        :line => nil,
-        :message => /^Versions\ before\ 2\.3\.14\ have\ a\ vulnerabil/,
-        :confidence => 0,
-        :relative_path => "config/environment.rb",
-        :user_input => nil
-    end
   end
 
   def test_rails_cve_2012_2660
@@ -1495,19 +1473,11 @@ class Rails2WithOptionsTests < Minitest::Test
   include BrakemanTester::CheckExpected
 
   def expected
-    if Brakeman::Scanner::RUBY_1_9
-      @expected ||= {
-        :controller => 1,
-        :model => 4,
-        :template => 47,
-        :generic => 57 }
-    else
-      @expected ||= {
-        :controller => 1,
-        :model => 4,
-        :template => 47,
-        :generic => 58 }
-    end
+    @expected ||= {
+      :controller => 1,
+      :model => 4,
+      :template => 47,
+      :generic => 57 }
   end
 
   def report

--- a/test/tests/tabs_output.rb
+++ b/test/tests/tabs_output.rb
@@ -10,10 +10,6 @@ class TestTabsOutput < Minitest::Test
   end
 
   def test_reported_warnings
-    if Brakeman::Scanner::RUBY_1_9
-      assert_equal 109, @@report.lines.to_a.count
-    else
-      assert_equal 110, @@report.lines.to_a.count
-    end
+    assert_equal 109, @@report.lines.to_a.count
   end
 end


### PR DESCRIPTION
Just cleaning up old code that is now unused because Brakeman doesn't support running with Ruby prior to 2.3.0.