### PR TITLE
Add optional check for config.force_ssl

### DIFF
--- a/lib/brakeman/checks/check_force_ssl.rb
+++ b/lib/brakeman/checks/check_force_ssl.rb
@@ -1,0 +1,27 @@
+class Brakeman::CheckForceSSL < Brakeman::BaseCheck
+  Brakeman::Checks.add_optional self
+
+  @description = "Check that force_ssl setting is enabled in production"
+
+  def run_check
+    return if tracker.config.rails.empty? or tracker.config.rails_version.nil?
+    return if tracker.config.rails_version < "3.1.0"
+
+    force_ssl = tracker.config.rails[:force_ssl]
+
+    if false? force_ssl or force_ssl.nil?
+      line = if sexp? force_ssl
+               force_ssl.line
+             else
+               1
+             end
+
+      warn :warning_type => "Missing Encryption",
+        :warning_code => :force_ssl_disabled,
+        :message => msg("The application does not force use of HTTPS: ", msg_code("config.force_ssl"), " is not enabled"),
+        :confidence => :high,
+        :file => "config/environments/production.rb",
+        :line => line
+    end
+  end
+end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -110,6 +110,7 @@ module Brakeman::WarningCodes
     :CVE_2018_8048 => 106,
     :CVE_2018_3741 => 107,
     :CVE_2018_3760 => 108,
+    :force_ssl_disabled => 109,
   }
 
   def self.code name

--- a/test/apps/rails3.1/config/environments/production.rb
+++ b/test/apps/rails3.1/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails31::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # See everything in the log (default is :info)
   # config.log_level = :debug

--- a/test/apps/rails5.2/config/environments/production.rb
+++ b/test/apps/rails5.2/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/test/apps/rails6/config/environments/production.rb
+++ b/test/apps/rails6/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/test/test.rb
+++ b/test/test.rb
@@ -91,7 +91,7 @@ module BrakemanTester::CheckExpected
         warnings = report[(type.to_s << "_warnings").to_sym]
       end
 
-      assert_equal number, warnings.length, lambda { "Expected #{number} #{type} warnings, but found #{warnings.length}:\n#{warnings.map { |w| w.to_hash.pretty_inspect }.join("\n")}" }
+      assert_equal number, warnings.length, lambda { "Expected #{number} #{type} warnings, but found #{warnings.length}:\n#{warnings.map { |w| w.message }.join("\n")}" }
     end
   end
 

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Minitest::Test
       :controller => 0,
       :model => 3,
       :template => 8,
-      :generic => 84
+      :generic => 85
     }
   end
 
@@ -667,6 +667,19 @@ class Rails4Tests < Minitest::Test
       :confidence => 1,
       :relative_path => "app/controllers/users_controller.rb",
       :code => s(:call, s(:colon2, s(:const, :OpenSSL), :Digest), :new, s(:str, "SHA1")),
+      :user_input => nil
+  end
+
+  def test_missing_encryption_force_ssl
+    assert_warning :type => :warning,
+      :warning_code => 109,
+      :fingerprint => "6a26086cd2400fbbfb831b2f8d7291e320bcc2b36984d2abc359e41b3b63212b",
+      :warning_type => "Missing Encryption",
+      :line => 1,
+      :message => /^The application does not force use of HTTPS/,
+      :confidence => 0,
+      :relative_path => "config/environments/production.rb",
+      :code => nil,
       :user_input => nil
   end
 

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -13,7 +13,7 @@ class Rails5Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 10,
-      :generic => 20
+      :generic => 21
     }
   end
 
@@ -525,6 +525,19 @@ class Rails5Tests < Minitest::Test
       :message => /^Parameter\ value\ used\ in\ file\ name/,
       :confidence => 2,
       :relative_path => "app/controllers/file_controller.rb"
+  end
+
+  def test_missing_encryption_force_ssl
+    assert_warning :type => :warning,
+      :warning_code => 109,
+      :fingerprint => "6a26086cd2400fbbfb831b2f8d7291e320bcc2b36984d2abc359e41b3b63212b",
+      :warning_type => "Missing Encryption",
+      :line => 1,
+      :message => /^The application does not force use of HTTPS/,
+      :confidence => 0,
+      :relative_path => "config/environments/production.rb",
+      :code => nil,
+      :user_input => nil
   end
 
   def test_cross_site_scripting_CVE_2015_7578

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -13,7 +13,7 @@ class Rails52Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 5,
-      :generic => 15
+      :generic => 16
     }
   end
 
@@ -459,6 +459,19 @@ class Rails52Tests < Minitest::Test
       :relative_path => "app/controllers/users_controller.rb",
       :code => s(:call, s(:const, :Oj), :object_load, s(:call, s(:params), :[], s(:lit, :json)), s(:hash, s(:lit, :mode), s(:lit, :strict))),
       :user_input => s(:call, s(:params), :[], s(:lit, :json))
+  end
+
+  def test_missing_encryption_force_ssl
+    assert_warning :type => :warning,
+      :warning_code => 109,
+      :fingerprint => "6a26086cd2400fbbfb831b2f8d7291e320bcc2b36984d2abc359e41b3b63212b",
+      :warning_type => "Missing Encryption",
+      :line => 50,
+      :message => /^The\ application\ does\ not\ force\ use\ of\ HT/,
+      :confidence => 0,
+      :relative_path => "config/environments/production.rb",
+      :code => nil,
+      :user_input => nil
   end
 
   def test_cross_site_scripting_loofah_CVE_2018_8048


### PR DESCRIPTION
Warns when `config.force_ssl` is not enabled in production.

Closes #1181