### PR TITLE
Convert !! calls to boolean value

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -269,6 +269,11 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       if array? target and target.length > 2 and (string? first_arg or first_arg.nil?)
         exp = process_array_join(target, first_arg)
       end
+    when :!
+      #  Convert `!!a` to boolean
+      if call? target and target.method == :!
+        exp = s(:or, s(:true).line(exp.line), s(:false).line(exp.line)).line(exp.line)
+      end
     end
 
     exp

--- a/test/apps/rails5.2/app/controllers/users_controller.rb
+++ b/test/apps/rails5.2/app/controllers/users_controller.rb
@@ -53,4 +53,9 @@ class UsersController < ApplicationController
     Oj.object_load(params[:json], mode: :strict) # Always unsafe, regardless of mode
     Oj.load(params[:json], mode: :strict) # Safe
   end
+
+  def not_not
+    si = ManualCSVImport.new(header_row: !!params[:header_row], archive: !!params[:archive])
+    @errors = [si.results[:invalid_info], si.results[:ignored_info]].flatten
+  end
 end

--- a/test/apps/rails5.2/app/views/users/not_not.html.erb
+++ b/test/apps/rails5.2/app/views/users/not_not.html.erb
@@ -1,0 +1,1 @@
+<%= @errors.join("<br/>").html_safe %>

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1134,6 +1134,13 @@ class AliasProcessorTests < Minitest::Test
     INPUT
   end
 
+  def test_bang_bang
+    assert_alias "true or false", <<-INPUT
+    x = !!a
+    x
+    INPUT
+  end
+
   def test_alias_processor_failure
     assert_raises do
       Brakeman::AliasProcessor.new.process s(:block, s(:attrasgn, s(:call, nil, :x), :"[]!", s(:lit, 1), s(:lit, 2)))

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -422,6 +422,17 @@ class Rails52Tests < Minitest::Test
       :user_input => s(:call, s(:call, nil, :params), :[], s(:lit, :x))
   end
 
+  def test_cross_site_scripting_not_not_false_positive
+    assert_no_warning :type => :template,
+      :warning_code => 2,
+      :warning_type => "Cross-Site Scripting",
+      :line => 1,
+      :message => /^Unescaped\ parameter\ value/,
+      :confidence => 2,
+      :relative_path => "app/views/users/not_not.html.erb",
+      :user_input => s(:call, s(:call, s(:call, s(:params), :[], s(:lit, :header_row)), :!), :!)
+  end
+
   def test_remote_code_execution_oj_load
     assert_warning :type => :warning,
       :warning_code => 25,


### PR DESCRIPTION
Calls like

```ruby
!!a
```

Will be converted to 

```ruby
(true or false)
```

to reflect that they are (almost always) a boolean value.

`!` *is a method call so it can do whatever you want but let's assume that's highly unusual. Also, this change only handles the method call case. Not going to worry about old code at this point.*

Fixes #1343