### PR TITLE
Use relative paths for __FILE__

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -73,6 +73,15 @@ module Brakeman
       File.read(File.join(@root, path))
     end
 
+    def relative_path(path)
+      pname = Pathname.new path
+      if path and not path.empty? and pname.absolute?
+        pname.relative_path_from(Pathname.new(self.root)).to_s
+      else
+        path
+      end
+    end
+
     # This variation requires full paths instead of paths based
     # off the project root. I'd prefer to get all the code outside
     # of AppTree using project-root based paths (e.g. app/models/user.rb)

--- a/lib/brakeman/file_parser.rb
+++ b/lib/brakeman/file_parser.rb
@@ -5,16 +5,17 @@ module Brakeman
   class FileParser
     attr_reader :file_list
 
-    def initialize tracker, app_tree
+    def initialize tracker
       @tracker = tracker
       @timeout = @tracker.options[:parser_timeout]
-      @app_tree = app_tree
+      @app_tree = @tracker.app_tree
       @file_list = {}
     end
 
     def parse_files list, type
       read_files list, type do |path, contents|
-        if ast = parse_ruby(contents, path)
+        relative_path = @app_tree.relative_path(path) # For consistency in __FILE__ handling
+        if ast = parse_ruby(contents, relative_path)
           ASTFile.new(path, ast)
         end
       end

--- a/lib/brakeman/parsers/template_parser.rb
+++ b/lib/brakeman/parsers/template_parser.rb
@@ -95,7 +95,7 @@ module Brakeman
     end
 
     def self.parse_inline_erb tracker, text
-      fp = Brakeman::FileParser.new(tracker, nil)
+      fp = Brakeman::FileParser.new(tracker)
       tp = self.new(tracker, fp)
       src = tp.parse_erb '_inline_', text
       type = tp.erubis? ? :erubis : :erb

--- a/lib/brakeman/rescanner.rb
+++ b/lib/brakeman/rescanner.rb
@@ -132,7 +132,7 @@ class Brakeman::Rescanner < Brakeman::Scanner
     template_name = template_path_to_name(path)
 
     tracker.reset_template template_name
-    fp = Brakeman::FileParser.new(tracker, @app_tree)
+    fp = Brakeman::FileParser.new(tracker)
     template_parser = Brakeman::TemplateParser.new(tracker, fp)
     template_parser.parse_template path, @app_tree.read_path(path)
     process_template fp.file_list[:templates].first
@@ -386,7 +386,7 @@ class Brakeman::Rescanner < Brakeman::Scanner
 
   def parse_ruby_files list
     paths = list.select { |path| @app_tree.path_exists? path }
-    file_parser = Brakeman::FileParser.new(tracker, @app_tree)
+    file_parser = Brakeman::FileParser.new(tracker)
     file_parser.parse_files paths, :rescan
     file_parser.file_list[:rescan]
   end

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -65,7 +65,7 @@ class Brakeman::Scanner
   end
 
   def parse_files
-    fp = Brakeman::FileParser.new tracker, @app_tree
+    fp = Brakeman::FileParser.new tracker
 
     files = {
       :initializers => @app_tree.initializer_paths,
@@ -316,8 +316,8 @@ class Brakeman::Scanner
   end
 
   def parse_ruby_file path
-    fp = Brakeman::FileParser.new(self.tracker, @app_tree)
-    fp.parse_ruby(@app_tree.read(path), path)
+    fp = Brakeman::FileParser.new(self.tracker)
+    fp.parse_ruby(@app_tree.read(path), @app_tree.relative_path(path))
   end
 end
 

--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -12,7 +12,7 @@ class Brakeman::Tracker
   attr_accessor :controllers, :constants, :templates, :models, :errors,
     :checks, :initializers, :config, :routes, :processor, :libs,
     :template_cache, :options, :filter_cache, :start_time, :end_time,
-    :duration, :ignored_filter
+    :duration, :ignored_filter, :app_tree
 
   #Place holder when there should be a model, but it is not
   #clear what model it will be.

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -455,12 +455,7 @@ module Brakeman::Util
   end
 
   def relative_path file
-    pname = Pathname.new file
-    if file and not file.empty? and pname.absolute?
-      pname.relative_path_from(Pathname.new(@tracker.app_path)).to_s
-    else
-      file
-    end
+    @tracker.app_tree.relative_path(file)
   end
 
   #Convert path/filename to view name

--- a/test/apps/rails5.2/lib/shell.rb
+++ b/test/apps/rails5.2/lib/shell.rb
@@ -84,4 +84,9 @@ class ShellStuff
 
     `ls #{z}` # Also should not warn
   end
+
+  def file_constant_use
+    # __FILE__ should not change based on absolute path
+    `cp #{__FILE__} #{somewhere_else}`
+  end
 end

--- a/test/tests/file_parser.rb
+++ b/test/tests/file_parser.rb
@@ -3,7 +3,7 @@ require_relative '../test'
 class FileParserTests < Minitest::Test
   def setup
     @tracker = Brakeman::Tracker.new(nil)
-    @file_parser = Brakeman::FileParser.new(@tracker, nil)
+    @file_parser = Brakeman::FileParser.new(@tracker)
   end
 
   def test_parse_error

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -13,7 +13,7 @@ class Rails52Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 5,
-      :generic => 16
+      :generic => 17
     }
   end
 
@@ -355,6 +355,19 @@ class Rails52Tests < Minitest::Test
       :relative_path => "lib/shell.rb",
       :code => s(:dxstr, "ls ", s(:evstr, s(:call, s(:const, :Shellwords), :escape, s(:call, s(:call, s(:const, :User), :new), :z)))),
       :user_input => s(:call, s(:call, s(:const, :User), :new), :z)
+  end
+
+  def test_command_injection_with__file__
+    assert_warning :type => :warning,
+      :warning_code => 14,
+      :fingerprint => "8aeaa50052306c0c79e3b1ece079ba369e30356658b455b049da9543fd729d75",
+      :warning_type => "Command Injection",
+      :line => 90,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 1,
+      :relative_path => "lib/shell.rb",
+      :code => s(:dxstr, "cp lib/shell.rb ", s(:evstr, s(:call, nil, :somewhere_else))),
+      :user_input => s(:call, nil, :somewhere_else)
   end
 
   def test_cross_site_scripting_haml_sass


### PR DESCRIPTION
RubyParser converts `__FILE__` to the actual file name at parse time. Brakeman was passing in the full absolute path to use for that file name. That would cause fingerprints of warnings involving `__FILE__` to change based on where the code happened to be when it was scanned.

Instead, changed to passing in a relative file path for better fingerprint stability.

This also affects parse error messages.