### PR TITLE
Use relative path in IgnoreConfig

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -511,10 +511,10 @@ module Brakeman
 
     if options[:interactive_ignore]
       require 'brakeman/report/ignore/interactive'
-      config = InteractiveIgnorer.new(file, tracker.warnings).start
+      config = InteractiveIgnorer.new(file, tracker).start
     else
       notify "[Notice] Using '#{file}' to filter warnings"
-      config = IgnoreConfig.new(file, tracker.warnings)
+      config = IgnoreConfig.new(file, tracker)
       config.read_from_file
       config.filter_ignored
     end

--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -3,12 +3,14 @@ require 'json'
 
 module Brakeman
   class IgnoreConfig
+    include Util
     attr_reader :shown_warnings, :ignored_warnings
     attr_accessor :file
 
-    def initialize file, new_warnings
+    def initialize file, tracker
       @file = file
-      @new_warnings = new_warnings
+      @tracker = tracker
+      @new_warnings = tracker.warnings
       @already_ignored = []
       @ignored_fingerprints = Set.new
       @used_fingerprints = Set.new
@@ -115,6 +117,7 @@ module Brakeman
         if w.is_a? Warning
           w_hash = w.to_hash
           w_hash[:file] = w.relative_path
+          w_hash[:render_path] = convert_render_path w_hash[:render_path]
           w = w_hash
         end
 

--- a/lib/brakeman/report/ignore/interactive.rb
+++ b/lib/brakeman/report/ignore/interactive.rb
@@ -2,9 +2,9 @@ Brakeman.load_brakeman_dependency 'highline'
 
 module Brakeman
   class InteractiveIgnorer
-    def initialize file, warnings
-      @ignore_config = Brakeman::IgnoreConfig.new(file, warnings)
-      @new_warnings = warnings
+    def initialize file, tracker
+      @ignore_config = Brakeman::IgnoreConfig.new(file, tracker)
+      @new_warnings = tracker.warnings
       @skip_ignored = false
       @skip_rest = false
       @ignore_rest = false

--- a/lib/brakeman/report/report_json.rb
+++ b/lib/brakeman/report/report_json.rb
@@ -44,23 +44,4 @@ class Brakeman::Report::JSON < Brakeman::Report::Base
       hash
     end.sort_by { |w| "#{w[:fingerprint]}#{w[:line]}" }
   end
-
-  def convert_render_path render_path
-    return unless render_path and not @tracker.options[:absolute_paths]
-
-    render_path.map do |r|
-      r = r.dup
-
-      if r[:file]
-        r[:file] = relative_path(r[:file])
-      end
-
-      if r[:rendered] and r[:rendered][:file]
-        r[:rendered] = r[:rendered].dup
-        r[:rendered][:file] = relative_path(r[:rendered][:file])
-      end
-
-      r
-    end
-  end
 end

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -475,4 +475,23 @@ module Brakeman::Util
       nil
     end
   end
+
+  def convert_render_path render_path
+    return unless render_path and not @tracker.options[:absolute_paths]
+
+    render_path.map do |r|
+      r = r.dup
+
+      if r[:file]
+        r[:file] = relative_path(r[:file])
+      end
+
+      if r[:rendered] and r[:rendered][:file]
+        r[:rendered] = r[:rendered].dup
+        r[:rendered][:file] = relative_path(r[:rendered][:file])
+      end
+
+      r
+    end
+  end
 end

--- a/test/tests/ignore.rb
+++ b/test/tests/ignore.rb
@@ -16,7 +16,7 @@ class IgnoreConfigTests < Minitest::Test
   end
 
   def make_config file = @config_file.path
-    c = Brakeman::IgnoreConfig.new file, report.all_warnings
+    c = Brakeman::IgnoreConfig.new file, report
     c.read_from_file
     c.filter_ignored
     c
@@ -27,7 +27,7 @@ class IgnoreConfigTests < Minitest::Test
   end
 
   def report
-    @@report ||= Brakeman.run(File.join(TEST_PATH, "apps", "rails5.2")).checks
+    @@report ||= Brakeman.run(File.join(TEST_PATH, "apps", "rails5.2"))
   end
 
   def test_sanity
@@ -39,7 +39,7 @@ class IgnoreConfigTests < Minitest::Test
   end
   
   def test_shown_warnings
-    expected = report.all_warnings.length - config.ignored_warnings.length
+    expected = report.warnings.length - config.ignored_warnings.length
 
     assert_equal expected, config.shown_warnings.length
   end


### PR DESCRIPTION
Previously, some paths under RenderPath were absolute and serialized
that way in the IgnoreConfig. This causes problems especially when
multiple devs would be managing the ignored warnings, because their home
directories would be included in the ignore config (and show on diff if
another dev reproduced the ignore).