### PR TITLE
Properly handle empty partial name

### DIFF
--- a/lib/brakeman/processors/lib/render_helper.rb
+++ b/lib/brakeman/processors/lib/render_helper.rb
@@ -36,7 +36,7 @@ module Brakeman::RenderHelper
 
   #Determines file name for partial and then processes it
   def process_partial name, args, line
-    if name == "" or !(string? name or symbol? name)
+    if !(string? name or symbol? name) or name.value == ""
       return
     end
 

--- a/test/apps/rails5.2/app/controllers/users_controller.rb
+++ b/test/apps/rails5.2/app/controllers/users_controller.rb
@@ -58,4 +58,7 @@ class UsersController < ApplicationController
     si = ManualCSVImport.new(header_row: !!params[:header_row], archive: !!params[:archive])
     @errors = [si.results[:invalid_info], si.results[:ignored_info]].flatten
   end
+
+  def test_empty_partial_name
+  end
 end

--- a/test/apps/rails5.2/app/views/users/_empty_partial_name.html.erb
+++ b/test/apps/rails5.2/app/views/users/_empty_partial_name.html.erb
@@ -1,0 +1,1 @@
+<%= render(:partial => nested_partial) if nested_partial.present? %>

--- a/test/apps/rails5.2/app/views/users/test_empty_partial_name.html.erb
+++ b/test/apps/rails5.2/app/views/users/test_empty_partial_name.html.erb
@@ -1,0 +1,1 @@
+<%= render :partial => 'empty_partial_name', :locals => {:nested_partial => ''} %>


### PR DESCRIPTION
Funny, there already was a guard for the partial name being an empty string but it was expecting a string literal and not an s-expression. That code was apparently from initial public commit of Brakeman...

Fixes #1350