### PR TITLE
README: Brakeman requires 2.3.0+ to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Outside of Rails root (note that the output file is relative to path/to/rails/ap
 
 Brakeman should work with any version of Rails from 2.3.x to 5.x.
 
-Brakeman can analyze code written with Ruby 1.8 syntax and newer, but requires at least Ruby 1.9.3 to run.
+Brakeman can analyze code written with Ruby 1.8 syntax and newer, but requires at least Ruby 2.3.0 to run.
 
 # Basic Options
 


### PR DESCRIPTION
This PR updates the README to reflect the updated Ruby requirements to run the tool.

This information is based on the 4.5.0 release blog post.