### PR TITLE
Handle trailing comma in block args

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -372,6 +372,8 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
           elsif e.is_a? Symbol
             local = Sexp.new(:lvar, e)
             env.current[local] = local
+          elsif e.nil? # trailing comma, argument destructuring
+            next # Punt for now
           else
             raise "Unexpected value in block args: #{e.inspect}"
           end

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -576,6 +576,16 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
+  def test_block_args_trailing_comma
+    # Just testing it doesn't blow up
+    assert_alias '1', <<-RUBY
+    blah do |x,|
+    end
+
+    1
+    RUBY
+  end
+
   def test_block_with_local
     assert_output <<-INPUT, <<-OUTPUT
       def a


### PR DESCRIPTION
At least, don't throw an error with the next version of ruby_parser.