### PR TITLE
Remove re-parsing with latest ruby_parser

### DIFF
--- a/lib/brakeman/file_parser.rb
+++ b/lib/brakeman/file_parser.rb
@@ -33,17 +33,13 @@ module Brakeman
       end
     end
 
-    def parse_ruby input, path, parser = RubyParser.new
+    def parse_ruby input, path
       begin
         Brakeman.debug "Parsing #{path}"
-        parser.parse input, path, @timeout
+        RubyParser.new.parse input, path, @timeout
       rescue Racc::ParseError => e
-        if parser.class == RubyParser
-          return parse_ruby(input, path, RubyParser.latest)
-        else
-          @tracker.error e, "Could not parse #{path}"
-          nil
-        end
+        @tracker.error e, "Could not parse #{path}"
+        nil
       rescue Timeout::Error => e
         @tracker.error Exception.new("Parsing #{path} took too long (> #{@timeout} seconds). Try increasing the limit with --parser-timeout"), caller
         nil


### PR DESCRIPTION
That was added for better parser messages, but shortly afterwards ruby_parser fixed the error message behavior to achieve the same thing.