### PR TITLE
Better handling of template output in branches

### DIFF
--- a/lib/brakeman/processors/template_processor.rb
+++ b/lib/brakeman/processors/template_processor.rb
@@ -77,9 +77,13 @@ class Brakeman::TemplateProcessor < Brakeman::BaseProcessor
   end
 
   def add_output output, type = :output
-    s = Sexp.new(type, output)
-    s.line(output.line)
-    @current_template.add_output s
-    s
+    if node_type? output, :or
+      Sexp.new(:or, add_output(output.lhs, type), add_output(output.rhs, type)).line(output.line)
+    else
+      s = Sexp.new(type, output)
+      s.line(output.line)
+      @current_template.add_output s
+      s
+    end
   end
 end

--- a/test/apps/rails6/app/views/users/show.html.erb
+++ b/test/apps/rails6/app/views/users/show.html.erb
@@ -3,6 +3,9 @@
 <p>
   <strong>Name:</strong>
   <%= @user.name.html_safe %>
+  <%= @user.name.html_safe if x %>
+  <%= @user.name.html_safe unless x %>
+  <%= x ? @user.name.html_safe : y %>
 </p>
 
 <%= link_to 'Edit', edit_user_path(@user) %> |

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -12,7 +12,7 @@ class Rails6Tests < Minitest::Test
     @@expected ||= {
       :controller => 0,
       :model => 0,
-      :template => 1,
+      :template => 4,
       :generic => 2
     }
   end
@@ -49,6 +49,45 @@ class Rails6Tests < Minitest::Test
       :fingerprint => "9e949d88329883f879b7ff46bdb096ba43e791aacb6558f47beddc34b9d42c4c",
       :warning_type => "Cross-Site Scripting",
       :line => 5,
+      :message => /^Unescaped\ model\ attribute/,
+      :confidence => 0,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, s(:call, s(:const, :User), :new, s(:call, nil, :user_params)), :name),
+      :user_input => nil
+  end
+
+  def test_cross_site_scripting_2
+    assert_warning :type => :template,
+      :warning_code => 2,
+      :fingerprint => "9e949d88329883f879b7ff46bdb096ba43e791aacb6558f47beddc34b9d42c4c",
+      :warning_type => "Cross-Site Scripting",
+      :line => 6,
+      :message => /^Unescaped\ model\ attribute/,
+      :confidence => 0,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, s(:call, s(:const, :User), :new, s(:call, nil, :user_params)), :name),
+      :user_input => nil
+  end
+
+  def test_cross_site_scripting_3
+    assert_warning :type => :template,
+      :warning_code => 2,
+      :fingerprint => "9e949d88329883f879b7ff46bdb096ba43e791aacb6558f47beddc34b9d42c4c",
+      :warning_type => "Cross-Site Scripting",
+      :line => 7,
+      :message => /^Unescaped\ model\ attribute/,
+      :confidence => 0,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, s(:call, s(:const, :User), :new, s(:call, nil, :user_params)), :name),
+      :user_input => nil
+  end
+
+  def test_cross_site_scripting_4
+    assert_warning :type => :template,
+      :warning_code => 2,
+      :fingerprint => "9e949d88329883f879b7ff46bdb096ba43e791aacb6558f47beddc34b9d42c4c",
+      :warning_type => "Cross-Site Scripting",
+      :line => 8,
       :message => /^Unescaped\ model\ attribute/,
       :confidence => 0,
       :relative_path => "app/views/users/show.html.erb",


### PR DESCRIPTION
This was not generating an XSS warning:

```erb
<%= blah ? x : params[:x].html_safe %>
```

Now each branch in an `if` expression will be its own "output" and handled separately.