### PR TITLE
Index calls in initializers

### DIFF
--- a/lib/brakeman/call_index.rb
+++ b/lib/brakeman/call_index.rb
@@ -91,6 +91,16 @@ class Brakeman::CallIndex
     end
   end
 
+  def remove_indexes_by_file file
+    [@calls_by_method, @calls_by_target].each do |calls_by|
+      calls_by.each do |_name, calls|
+        calls.delete_if do |call|
+          call[:location][:file] == file
+        end
+      end
+    end
+  end
+
   def index_calls calls
     calls.each do |call|
       @calls_by_method[call[:method]] ||= []

--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -45,7 +45,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
 
   #Add result to result list, which is used to check for duplicates
   def add_result result, location = nil
-    location ||= (@current_template && @current_template.name) || @current_class || @current_module || @current_set || result[:location][:class] || result[:location][:template]
+    location ||= (@current_template && @current_template.name) || @current_class || @current_module || @current_set || result[:location][:class] || result[:location][:template] || result[:location][:file].to_s
     location = location[:name] if location.is_a? Hash
     location = location.name if location.is_a? Brakeman::Collection
     location = location.to_sym
@@ -258,7 +258,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
       raise ArgumentError
     end
 
-    location ||= (@current_template && @current_template.name) || @current_class || @current_module || @current_set || result[:location][:class] || result[:location][:template]
+    location ||= (@current_template && @current_template.name) || @current_class || @current_module || @current_set || result[:location][:class] || result[:location][:template] || result[:location][:file].to_s
 
     location = location[:name] if location.is_a? Hash
     location = location.name if location.is_a? Brakeman::Collection

--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -182,19 +182,6 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
       end
 
       unless @mass_assign_disabled
-        tracker.find_call(target: :"ActiveRecord::Base", method: :send).each do |result|
-          call = result[:call]
-
-          if call? call
-            if call.first_arg == Sexp.new(:lit, :attr_accessible) and call.second_arg == Sexp.new(:nil)
-              @mass_assign_disabled = true
-              break
-            end
-          end
-        end
-      end
-
-      unless @mass_assign_disabled
         #Check for
         #  class ActiveRecord::Base
         #    attr_accessible nil

--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -316,11 +316,11 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
     end
 
     json_escape_on = false
-    initializers = tracker.check_initializers :ActiveSupport, :escape_html_entities_in_json=
-    initializers.each {|result| json_escape_on = true?(result.call.first_arg) }
+    initializers = tracker.find_call(target: :ActiveSupport, method: :escape_html_entities_in_json=)
+    initializers.each {|result| json_escape_on = true?(result[:call].first_arg) }
 
     if tracker.config.escape_html_entities_in_json?
-        json_escape_on = true
+      json_escape_on = true
     elsif version_between? "4.0.0", "9.9.9"
       json_escape_on = true
     end

--- a/lib/brakeman/checks/check_deserialize.rb
+++ b/lib/brakeman/checks/check_deserialize.rb
@@ -80,13 +80,10 @@ class Brakeman::CheckDeserialize < Brakeman::BaseCheck
   def oj_safe_default?
     safe_default = false
 
-    # TODO: Can we just index initializers already??
-    if tracker.check_initializers(:Oj, :mimic_JSON).any?
+    if tracker.find_call(target: :Oj, method: :mimic_JSON).any?
       safe_default = true
-    end
-
-    if result = tracker.check_initializers(:Oj, :default_options=).first
-      options = result.call.first_arg
+    elsif result = tracker.find_call(target: :Oj, method: :default_options=).first
+      options = result[:call].first_arg
 
       if oj_safe_mode? options
         safe_default = true

--- a/lib/brakeman/checks/check_header_dos.rb
+++ b/lib/brakeman/checks/check_header_dos.rb
@@ -25,7 +25,7 @@ class Brakeman::CheckHeaderDoS < Brakeman::BaseCheck
   end
 
   def has_workaround?
-    tracker.check_initializers(:ActiveSupport, :on_load).any? and
-    tracker.check_initializers(:"ActionView::LookupContext::DetailsKey", :class_eval).any?
+    tracker.find_call(target: :ActiveSupport, method: :on_load).any? and
+      tracker.find_call(target: :"ActionView::LookupContext::DetailsKey", method: :class_eval).any?
   end
 end

--- a/lib/brakeman/checks/check_i18n_xss.rb
+++ b/lib/brakeman/checks/check_i18n_xss.rb
@@ -41,8 +41,8 @@ class Brakeman::CheckI18nXSS < Brakeman::BaseCheck
   end
 
   def has_workaround?
-    tracker.check_initializers(:I18n, :const_defined?).any? do |match|
-      match.last.first_arg == s(:lit, :MissingTranslation)
+    tracker.find_call(target: :I18n, method: :const_defined?, chained: true).any? do |match|
+      match[:call].first_arg == s(:lit, :MissingTranslation)
     end
   end
 end

--- a/lib/brakeman/checks/check_jruby_xml.rb
+++ b/lib/brakeman/checks/check_jruby_xml.rb
@@ -20,8 +20,8 @@ class Brakeman::CheckJRubyXML < Brakeman::BaseCheck
       end
 
     #Check for workaround
-    tracker.check_initializers(:"ActiveSupport::XmlMini", :backend=).each do |result|
-      arg = result.call.first_arg
+    tracker.find_call(target: :"ActiveSupport::XmlMini", method: :backend=, chained: true).each do |result|
+      arg = result[:call].first_arg
 
       return if string? arg and arg.value == "REXML"
     end

--- a/lib/brakeman/checks/check_json_parsing.rb
+++ b/lib/brakeman/checks/check_json_parsing.rb
@@ -44,13 +44,13 @@ class Brakeman::CheckJSONParsing < Brakeman::BaseCheck
 
   #Check for `ActiveSupport::JSON.backend = "JSONGem"`
   def uses_gem_backend?
-    matches = tracker.check_initializers(:'ActiveSupport::JSON', :backend=)
+    matches = tracker.find_call(target: :'ActiveSupport::JSON', method: :backend=, chained: true)
 
     unless matches.empty?
       json_gem = s(:str, "JSONGem")
 
       matches.each do |result|
-        if result.call.first_arg == json_gem
+        if result[:call].first_arg == json_gem
           return true
         end
       end

--- a/lib/brakeman/checks/check_mime_type_dos.rb
+++ b/lib/brakeman/checks/check_mime_type_dos.rb
@@ -30,8 +30,8 @@ class Brakeman::CheckMimeTypeDoS < Brakeman::BaseCheck
   end
 
   def has_workaround?
-    tracker.check_initializers(:Mime, :const_set).any? do |match|
-      arg = match.call.first_arg
+    tracker.find_call(target: :Mime, method: :const_set).any? do |match|
+      arg = match[:call].first_arg
 
       symbol? arg and arg.value == :LOOKUP
     end

--- a/lib/brakeman/checks/check_nested_attributes_bypass.rb
+++ b/lib/brakeman/checks/check_nested_attributes_bypass.rb
@@ -53,6 +53,6 @@ class Brakeman::CheckNestedAttributesBypass < Brakeman::BaseCheck
   end
 
   def workaround?
-    tracker.check_initializers([], :will_be_destroyed?).any?
+    tracker.find_call(method: :will_be_destroyed?).any?
   end
 end

--- a/lib/brakeman/checks/check_session_settings.rb
+++ b/lib/brakeman/checks/check_session_settings.rb
@@ -21,8 +21,11 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
 
     check_for_issues settings, @app_tree.file_path("config/environment.rb")
 
-    ["session_store.rb", "secret_token.rb"].each do |file|
-      if tracker.initializers[file] and not ignored? file
+    session_store = @app_tree.file_path("config/initializers/session_store.rb")
+    secret_token = @app_tree.file_path("config/initializers/secret_token.rb")
+
+    [session_store, secret_token].each do |file|
+      if tracker.initializers[file] and not ignored? file.basename
         process tracker.initializers[file]
       end
     end

--- a/lib/brakeman/checks/check_xml_dos.rb
+++ b/lib/brakeman/checks/check_xml_dos.rb
@@ -34,8 +34,8 @@ class Brakeman::CheckXMLDoS < Brakeman::BaseCheck
   end
 
   def has_workaround?
-    tracker.check_initializers(:"ActiveSupport::XmlMini", :backend=).any? do |match|
-      arg = match.call.first_arg
+    tracker.find_call(target: :"ActiveSupport::XmlMini", method: :backend=).any? do |match|
+      arg = match[:call].first_arg
       if string? arg
         value = arg.value
         value == 'Nokogiri' or value == 'LibXML'

--- a/lib/brakeman/file_path.rb
+++ b/lib/brakeman/file_path.rb
@@ -35,6 +35,11 @@ module Brakeman
       @relative = relative_path
     end
 
+    # Just the file name, no path
+    def basename
+      @basename ||= File.basename(self.relative)
+    end
+
     # Read file from absolute path.
     def read
       File.read self.absolute

--- a/lib/brakeman/processor.rb
+++ b/lib/brakeman/processor.rb
@@ -90,7 +90,7 @@ module Brakeman
     def process_initializer file_name, src
       res = BaseProcessor.new(@tracker).process_file src, file_name
       res = AliasProcessor.new(@tracker).process_safely res, nil, file_name
-      @tracker.initializers[Pathname.new(file_name).basename.to_s] = res
+      @tracker.initializers[file_name] = res
     end
 
     #Process source for a library file

--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -30,16 +30,24 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
   def process_all_source exp, opts
     @processing_class = true
     process_source exp, opts
+  ensure
+    @processing_class = false
   end
 
   #Process body of method
   def process_defn exp
     return exp unless @current_method or @processing_class
 
-    old_method = @current_method
-    @current_method = exp.method_name
-    process_all exp.body
-    @current_method = old_method
+    # 'Normal' processing assumes the method name was given
+    # as an option to `process_source` but for `process_all_source`
+    # we don't want to do that.
+    if @current_method.nil?
+      @current_method = exp.method_name
+      process_all exp.body
+      @current_method = nil
+    else
+      process_all exp.body
+    end
 
     exp
   end

--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -5,9 +5,9 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
 
   def initialize tracker
     super
-    @current_class = nil
-    @current_method = nil
+
     @in_target = false
+    @processing_class = false
     @calls = []
     @cache = {}
   end
@@ -23,10 +23,25 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
     process exp
   end
 
+  #For whatever reason, originally the indexing of calls
+  #was performed on individual method bodies (see process_defn).
+  #This method explicitly indexes all calls everywhere given any
+  #source.
+  def process_all_source exp, opts
+    @processing_class = true
+    process_source exp, opts
+  end
+
   #Process body of method
   def process_defn exp
-    return exp unless @current_method
+    return exp unless @current_method or @processing_class
+
+    old_method = @current_method
+    @current_method = exp.method_name
     process_all exp.body
+    @current_method = old_method
+
+    exp
   end
 
   alias process_defs process_defn

--- a/lib/brakeman/rescanner.rb
+++ b/lib/brakeman/rescanner.rb
@@ -226,9 +226,11 @@ class Brakeman::Rescanner < Brakeman::Scanner
   end
 
   def rescan_initializer path
+    tracker.reset_initializer path
     parse_ruby_files([path]).each do |astfile|
       process_initializer astfile
     end
+    @reindex << :initializers
   end
 
   #Handle rescanning when a file is deleted

--- a/lib/brakeman/rescanner.rb
+++ b/lib/brakeman/rescanner.rb
@@ -227,9 +227,11 @@ class Brakeman::Rescanner < Brakeman::Scanner
 
   def rescan_initializer path
     tracker.reset_initializer path
+
     parse_ruby_files([path]).each do |astfile|
       process_initializer astfile
     end
+
     @reindex << :initializers
   end
 

--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -241,9 +241,9 @@ class Brakeman::Tracker
   #
   #This will limit reindexing to the given sets
   def reindex_call_sites locations
-    #If reindexing templates, models, controllers, and initializers,
+    #If reindexing templates, models, controllers,
     #just redo everything.
-    if locations.length == 4
+    if locations.length == 3
       return index_call_sites
     end
 

--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -227,6 +227,10 @@ class Brakeman::Tracker
       finder.process_source template.src, :template => template, :file => template.file
     end
 
+    self.initializers.each do |file_name, src|
+      finder.process_all_source src, :file => file_name
+    end
+
     @call_index = Brakeman::CallIndex.new finder.calls
   end
 
@@ -237,9 +241,9 @@ class Brakeman::Tracker
   #
   #This will limit reindexing to the given sets
   def reindex_call_sites locations
-    #If reindexing templates, models, and controllers, just redo
-    #everything
-    if locations.length == 3
+    #If reindexing templates, models, controllers, and initializers,
+    #just redo everything.
+    if locations.length == 4
       return index_call_sites
     end
 
@@ -276,6 +280,12 @@ class Brakeman::Tracker
     if locations.include? :templates
       self.each_template do |_name, template|
         finder.process_source template.src, :template => template, :file => template.file
+      end
+    end
+
+    if locations.include? :initializers
+      self.initializers.each do |file_name, src|
+        finder.process_all_source src, :file => file_name
       end
     end
 
@@ -362,5 +372,13 @@ class Brakeman::Tracker
   #Clear information about routes
   def reset_routes
     @routes = {}
+  end
+
+  def reset_initializer path
+    @initializers.delete_if do |file, src|
+      path.relative.include? file
+    end
+
+    @call_index.remove_indexes_by_file path
   end
 end

--- a/test/tests/mass_assign_disable.rb
+++ b/test/tests/mass_assign_disable.rb
@@ -60,7 +60,7 @@ class MassAssignDisableTest < Minitest::Test
 
     #We disable whitelist, but add strong_parameters globally, so
     #there should be no change.
-    assert_reindex :none
+    assert_reindex :initializers
     assert_changes
     assert_fixed 0
     assert_new 0
@@ -111,7 +111,7 @@ class MassAssignDisableTest < Minitest::Test
 
     #We disable whitelist, but add strong_parameters globally, so
     #there should be no change.
-    assert_reindex :none
+    assert_reindex :initializers
     assert_changes
     assert_fixed 0
     assert_new 0

--- a/test/tests/oj.rb
+++ b/test/tests/oj.rb
@@ -14,6 +14,7 @@ class OjSettingsTests < Minitest::Test
     end
 
     assert_changes
+    assert_reindex :initializers
     assert_fixed 1 # Fix default Oj.load() behavior
     assert_new 0
   end
@@ -24,6 +25,7 @@ class OjSettingsTests < Minitest::Test
     end
 
     assert_changes
+    assert_reindex :initializers
     assert_fixed 1 # Fix default Oj.load() behavior
     assert_new 0
   end
@@ -34,6 +36,7 @@ class OjSettingsTests < Minitest::Test
     end
 
     assert_changes
+    assert_reindex :initializers
     assert_fixed 0 # Default is still bad, no changes 
     assert_new 0
   end

--- a/test/tests/rescanner.rb
+++ b/test/tests/rescanner.rb
@@ -303,7 +303,7 @@ class RescannerTests < Minitest::Test
     end
 
     assert_changes
-    assert_reindex :none
+    assert_reindex :initializers
     assert_fixed 1
     assert_new 0
   end


### PR DESCRIPTION
In the past, initializers were one code location where Brakeman did not index the calls. This made it annoying to write checks involving initializers, because you had to use `Tracker#check_initializers` which traversed the AST looking for matching calls. Not only was this a separate (but similar) interface, it was also slower.

There is still some ugliness in how Brakeman indexes calls, but at least now the call index can be used for initializers. Yay! :tada:

Almost all uses of `Tracker#check_initializers` have been removed.

Edit: OH YEAH also we can find regular vulnerabilities in initializers now, too.