### PR TITLE
Add check for unsafe cookie serialization configuration

### DIFF
--- a/lib/brakeman/checks/check_cookie_serialization.rb
+++ b/lib/brakeman/checks/check_cookie_serialization.rb
@@ -1,0 +1,22 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckCookieSerialization < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = "Check for use of Marshal for cookie serialization"
+
+  def run_check
+    tracker.find_call(target: :'Rails.application.config.action_dispatch', method: :cookies_serializer=).each do |result|
+      setting = result[:call].first_arg
+
+      if symbol? setting and setting.value == :marshal or setting.value == :hybrid
+        warn :result => result,
+          :warning_type => "Remote Code Execution",
+          :warning_code => :unsafe_cookie_serialization,
+          :message => msg("Use of unsafe cookie serialization strategy ", msg_code(setting.value.inspect), " might lead to remote code execution"),
+          :confidence => :medium,
+          :link_path => "unsafe_deserialization"
+      end
+    end
+  end
+end

--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -264,6 +264,12 @@ class Brakeman::Tracker
       method_sets << self.controllers
     end
 
+    if locations.include? :initializers
+      self.initializers.each do |file_name, src|
+        @call_index.remove_indexes_by_file file_name
+      end
+    end
+
     @call_index.remove_indexes_by_class classes_to_reindex
 
     finder = Brakeman::FindAllCalls.new self

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -111,6 +111,7 @@ module Brakeman::WarningCodes
     :CVE_2018_3741 => 107,
     :CVE_2018_3760 => 108,
     :force_ssl_disabled => 109,
+    :unsafe_cookie_serialization => 110,
     :custom_check => 8888
   }
 

--- a/test/apps/rails5.2/config/initializers/cookies_serializer.rb
+++ b/test/apps/rails5.2/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid

--- a/test/apps/rails6/config/initializers/cookies_serializer.rb
+++ b/test/apps/rails6/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json
+Rails.application.config.action_dispatch.cookies_serializer = :marshal

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -13,7 +13,7 @@ class Rails52Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 5,
-      :generic => 17
+      :generic => 18
     }
   end
 
@@ -483,6 +483,19 @@ class Rails52Tests < Minitest::Test
       :relative_path => "app/controllers/users_controller.rb",
       :code => s(:call, s(:const, :Oj), :object_load, s(:call, s(:params), :[], s(:lit, :json)), s(:hash, s(:lit, :mode), s(:lit, :strict))),
       :user_input => s(:call, s(:params), :[], s(:lit, :json))
+  end
+
+  def test_remote_code_execution_cookie_serialization_config
+    assert_warning :type => :warning,
+      :warning_code => 110,
+      :fingerprint => "9ae68e59cfee3e5256c0540dadfeb74e6b72c91997fdb60411063a6e8518144a",
+      :warning_type => "Remote Code Execution",
+      :line => 5,
+      :message => /^Use\ of\ unsafe\ cookie\ serialization\ strat/,
+      :confidence => 1,
+      :relative_path => "config/initializers/cookies_serializer.rb",
+      :code => s(:attrasgn, s(:call, s(:call, s(:call, s(:const, :Rails), :application), :config), :action_dispatch), :cookies_serializer=, s(:lit, :hybrid)),
+      :user_input => nil
   end
 
   def test_missing_encryption_force_ssl

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,7 +13,7 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 2
+      :generic => 3
     }
   end
 
@@ -92,6 +92,19 @@ class Rails6Tests < Minitest::Test
       :confidence => 0,
       :relative_path => "app/views/users/show.html.erb",
       :code => s(:call, s(:call, s(:const, :User), :new, s(:call, nil, :user_params)), :name),
+      :user_input => nil
+  end
+
+  def test_remote_code_execution_cookie_serialization
+    assert_warning :type => :warning,
+      :warning_code => 110,
+      :fingerprint => "d882f63ce96c28fb6c6e0982f2a171460e4b933bfd9b9a5421dca21eef3f76da",
+      :warning_type => "Remote Code Execution",
+      :line => 5,
+      :message => /^Use\ of\ unsafe\ cookie\ serialization\ strat/,
+      :confidence => 1,
+      :relative_path => "config/initializers/cookies_serializer.rb",
+      :code => s(:attrasgn, s(:call, s(:call, s(:call, s(:const, :Rails), :application), :config), :action_dispatch), :cookies_serializer=, s(:lit, :marshal)),
       :user_input => nil
   end
 end


### PR DESCRIPTION
The `:hybrid` and `:marshal` cookie serialization strategies use Marshal to (de)serialization cookie values. If an attacker is able to send a forged cookie, they may be able to [execute arbitrary Ruby code](https://www.elttam.com.au/blog/ruby-deserialization/) on the server.

`:json` is the preferred cookie serialization strategy.