### PR TITLE
Restore Warning#relative_path

### DIFF
--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -271,6 +271,10 @@ class Brakeman::Warning
     end
   end
 
+  def relative_path
+    self.file.relative
+  end
+
   def to_hash absolute_paths: true
     if self.called_from and not absolute_paths
       render_path = self.called_from.with_relative_paths

--- a/test/tests/warning.rb
+++ b/test/tests/warning.rb
@@ -27,4 +27,13 @@ class WarningTests < Minitest::Test
       Brakeman::Warning.new(confidence: 10)
     end
   end
+
+  def test_relative_path
+    tracker = BrakemanTester.new_tracker
+    path = tracker.app_tree.file_path("app/controllers/some_controller.rb")
+
+    w = Brakeman::Warning.new(file: path, confidence: :high)
+
+    refute w.relative_path.start_with? "/"
+  end
 end


### PR DESCRIPTION
I should not have removed this public API in #1354.

This is regarding https://github.com/guard/guard-brakeman/pull/36