### PR TITLE
Add reverse tabnabbing check

### DIFF
--- a/lib/brakeman/checks/check_reverse_tabnabbing.rb
+++ b/lib/brakeman/checks/check_reverse_tabnabbing.rb
@@ -1,0 +1,43 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckReverseTabnabbing < Brakeman::BaseCheck
+  Brakeman::Checks.add_optional self
+
+  @description = "Checks for reverse tabnabbing cases on 'link_to' calls"
+
+  def run_check
+    calls = tracker.find_call :methods => :link_to
+    calls.each do |call|
+      process_result call
+    end
+  end
+
+  def process_result result
+    return unless original? result and result[:call].third_arg
+
+    html_opts = result[:call].third_arg
+    _, target = hash_access html_opts, :target
+    _, rel = hash_access html_opts, :rel
+    return unless target
+
+    target_url = result[:call].second_arg
+
+    # `_url` and `_path` lead to urls on to the same origin.
+    # That means that an adversary would need to run javascript on
+    # the victim application's domain. If that is the case, the adversary
+    # already has the ability to redirect the victim user anywhere.
+    if target_url[0] == :call then
+      func_s = target_url.method.to_s
+      return unless !func_s.end_with?("url") && !func_s.end_with?("path")
+    end
+
+    if target == "_blank" && (!rel || (rel && !rel.include?("noopener"))) then
+      warn :result => result,
+        :warning_type => "Reverse Tabnabbing",
+        :warning_code => :reverse_tabnabbing,
+        :message => "The newly opened tab can control the parent tab's " +
+                    "location, thus redirect it to a phishing page",
+        :confidence => :weak
+    end
+  end
+end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -112,6 +112,7 @@ module Brakeman::WarningCodes
     :CVE_2018_3760 => 108,
     :force_ssl_disabled => 109,
     :unsafe_cookie_serialization => 110,
+    :reverse_tabnabbing => 111,
     :custom_check => 8888
   }
 

--- a/test/apps/rails5/app/views/users/show.html.erb
+++ b/test/apps/rails5/app/views/users/show.html.erb
@@ -8,4 +8,14 @@
 
 <%= link_to(image_tag("icons/twitter-gray.svg"), sanitize(@user.home_page), target: "_blank") %>
 
-<%= link_to("", "", target: "_blank", rel: "noopener") %>
+<%= link_to '', 'something_static', target: '_blank' %> No warning
+<%= link_to '', some_url, target: '_blank' %> Warn
+<%= link_to some_url, target: '_blank' do -%>
+  Warn
+<% end %>
+<%= link_to '', some_url, target: '_blank', rel: 'noopener' %> Weak warning
+<%= link_to '', some_url, target: '_blank', rel: 'noreferrer' %> Weak warning
+<%= link_to '', some_url, target: '_blank', rel: 'noopener noreferrer' %> No warning
+<%= link_to some_url, target: '_blank', rel: 'noopener noreferrer' do -%>
+  No Warning
+<% end %>

--- a/test/apps/rails5/app/views/users/show.html.erb
+++ b/test/apps/rails5/app/views/users/show.html.erb
@@ -19,3 +19,4 @@
 <%= link_to some_url, target: '_blank', rel: 'noopener noreferrer' do -%>
   No Warning
 <% end %>
+<%= link_to '', target: '_blank' %> No warning

--- a/test/apps/rails5/app/views/users/show.html.erb
+++ b/test/apps/rails5/app/views/users/show.html.erb
@@ -7,3 +7,5 @@
 <%= link_to("xss", url_for(params[:bad])) %>
 
 <%= link_to(image_tag("icons/twitter-gray.svg"), sanitize(@user.home_page), target: "_blank") %>
+
+<%= link_to("", "", target: "_blank", rel: "noopener") %>

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -12,7 +12,7 @@ class Rails5Tests < Minitest::Test
     @@expected ||= {
       :controller => 0,
       :model => 0,
-      :template => 11,
+      :template => 16,
       :generic => 21
     }
   end
@@ -749,35 +749,93 @@ class Rails5Tests < Minitest::Test
   end
 
   def test_reverse_tabnabbing
-    assert_warning :type => :template,
-      :warning_type => "Reverse Tabnabbing",
-      :warning_code => :reverse_tabnabbing,
-      :line => 9,
-      :message => /^The newly opened tab can control/,
-      :relative_path => "app/views/users/show.html.erb"
-  end
 
-  def test_reverse_tabnabbing
     assert_warning :type => :template,
       :warning_code => 111,
-      :fingerprint => "aef50775245520547ce753ac26a6a857b90292350f4d1df76d31a5644cac47ce",
+      :fingerprint => "a72829f1e36e4d7c4fd71a1b9e39b011137dc3b317a17df2fc7795e08b37cf75",
       :warning_type => "Reverse Tabnabbing",
       :line => 9,
       :message => /^The\ newly\ opened\ tab\ can\ control\ the\ par/,
-      :confidence => 2,
+      :confidence => 1,
       :relative_path => "app/views/users/show.html.erb",
       :code => s(:call, nil, :link_to, s(:call, nil, :image_tag, s(:str, "icons/twitter-gray.svg")), s(:call, nil, :sanitize, s(:call, s(:call, s(:const, :User), :new, s(:call, nil, :user_params)), :home_page)), s(:hash, s(:lit, :target), s(:str, "_blank"))),
       :user_input => nil
 
-    assert_no_warning :type => :template,
+    assert_warning :type => :template,
       :warning_code => 111,
-      :fingerprint => "8850f2c03e8f044db915e90b2e33f77f7836f6bd910bbbfecac94b8ac20c04fc",
+      :fingerprint => "19baa582a2e584150460db2b4a13e95a826e556e6bf3dc98b7b48afd01b1bd19",
       :warning_type => "Reverse Tabnabbing",
       :line => 11,
       :message => /^The\ newly\ opened\ tab\ can\ control\ the\ par/,
+      :confidence => 1,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, ""), s(:str, "something_static"), s(:hash, s(:lit, :target), s(:str, "_blank"))),
+      :user_input => nil
+
+    assert_warning :type => :template,
+      :warning_code => 111,
+      :fingerprint => "24b8934e896e96588d39e012e8ad1eb77d10a9daaaac1c08e9e0e920b6b82748",
+      :warning_type => "Reverse Tabnabbing",
+      :line => 12,
+      :message => /^The\ newly\ opened\ tab\ can\ control\ the\ par/,
+      :confidence => 1,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, ""), s(:call, nil, :some_url), s(:hash, s(:lit, :target), s(:str, "_blank"))),
+      :user_input => nil
+
+    assert_warning :type => :template,
+      :warning_code => 111,
+      :fingerprint => "d81b4e129ad9a43a905c335deb5ca98ef62ce9509cd29d536fcff70c2431dccf",
+      :warning_type => "Reverse Tabnabbing",
+      :line => 13,
+      :message => /^The\ newly\ opened\ tab\ can\ control\ the\ par/,
+      :confidence => 1,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:call, nil, :some_url), s(:hash, s(:lit, :target), s(:str, "_blank"))),
+      :user_input => nil
+
+    assert_warning :type => :template,
+      :warning_code => 111,
+      :fingerprint => "7678f236bb756de38a16d0aeb753a47db32e44c1371aee64e86f04f7bcd7c067",
+      :warning_type => "Reverse Tabnabbing",
+      :line => 15,
+      :message => /^The\ newly\ opened\ tab\ can\ control\ the\ par/,
       :confidence => 2,
       :relative_path => "app/views/users/show.html.erb",
-      :code => s(:call, nil, :link_to, s(:str, ""), s(:str, ""), s(:hash, s(:lit, :target), s(:str, "_blank"), s(:lit, :rel), s(:str, "noopene"))),
+      :code => s(:call, nil, :link_to, s(:str, ""), s(:call, nil, :some_url), s(:hash, s(:lit, :target), s(:str, "_blank"), s(:lit, :rel), s(:str, "noopener"))),
+      :user_input => nil
+
+    assert_warning :type => :template,
+      :warning_code => 111,
+      :fingerprint => "2a3657324d7d873ae9fb3667534ee2a4df0f7822ec0b379740828aecc2941d8c",
+      :warning_type => "Reverse Tabnabbing",
+      :line => 16,
+      :message => /^The\ newly\ opened\ tab\ can\ control\ the\ par/,
+      :confidence => 2,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, ""), s(:call, nil, :some_url), s(:hash, s(:lit, :target), s(:str, "_blank"), s(:lit, :rel), s(:str, "noreferrer"))),
+      :user_input => nil
+
+    assert_no_warning :type => :template,
+      :warning_code => 111,
+      :fingerprint => "8003277810880b3f1dcd5bb6090e149b49b068105013ab3c9ae6466fb8e0ae70",
+      :warning_type => "Reverse Tabnabbing",
+      :line => 17,
+      :message => /^The\ newly\ opened\ tab\ can\ control\ the\ par/,
+      :confidence => 2,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, ""), s(:call, nil, :some_url), s(:hash, s(:lit, :target), s(:str, "_blank"), s(:lit, :rel), s(:str, "noopener noreferrer"))),
+      :user_input => nil
+
+    assert_no_warning :type => :template,
+      :warning_code => 111,
+      :fingerprint => "2f4fa46d6094bcc3ddd85e9d705d9f3a717356aa9d19ccd724538b7ce43f3aad",
+      :warning_type => "Reverse Tabnabbing",
+      :line => 19,
+      :message => /^The\ newly\ opened\ tab\ can\ control\ the\ par/,
+      :confidence => 2,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:call, nil, :some_url), s(:hash, s(:lit, :target), s(:str, "_blank"), s(:lit, :rel), s(:str, "noopener noreferrer"))),
       :user_input => nil
   end
 end

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -12,7 +12,7 @@ class Rails5Tests < Minitest::Test
     @@expected ||= {
       :controller => 0,
       :model => 0,
-      :template => 10,
+      :template => 11,
       :generic => 21
     }
   end
@@ -746,5 +746,38 @@ class Rails5Tests < Minitest::Test
       :relative_path => "app/controllers/users_controller.rb",
       :code => s(:call, s(:const, :User), :find, s(:call, s(:params), :[], s(:lit, :id))),
       :user_input => s(:call, s(:params), :[], s(:lit, :id))
+  end
+
+  def test_reverse_tabnabbing
+    assert_warning :type => :template,
+      :warning_type => "Reverse Tabnabbing",
+      :warning_code => :reverse_tabnabbing,
+      :line => 9,
+      :message => /^The newly opened tab can control/,
+      :relative_path => "app/views/users/show.html.erb"
+  end
+
+  def test_reverse_tabnabbing
+    assert_warning :type => :template,
+      :warning_code => 111,
+      :fingerprint => "aef50775245520547ce753ac26a6a857b90292350f4d1df76d31a5644cac47ce",
+      :warning_type => "Reverse Tabnabbing",
+      :line => 9,
+      :message => /^The\ newly\ opened\ tab\ can\ control\ the\ par/,
+      :confidence => 2,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:call, nil, :image_tag, s(:str, "icons/twitter-gray.svg")), s(:call, nil, :sanitize, s(:call, s(:call, s(:const, :User), :new, s(:call, nil, :user_params)), :home_page)), s(:hash, s(:lit, :target), s(:str, "_blank"))),
+      :user_input => nil
+
+    assert_no_warning :type => :template,
+      :warning_code => 111,
+      :fingerprint => "8850f2c03e8f044db915e90b2e33f77f7836f6bd910bbbfecac94b8ac20c04fc",
+      :warning_type => "Reverse Tabnabbing",
+      :line => 11,
+      :message => /^The\ newly\ opened\ tab\ can\ control\ the\ par/,
+      :confidence => 2,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, ""), s(:str, ""), s(:hash, s(:lit, :target), s(:str, "_blank"), s(:lit, :rel), s(:str, "noopene"))),
+      :user_input => nil
   end
 end

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -12,7 +12,7 @@ class Rails5Tests < Minitest::Test
     @@expected ||= {
       :controller => 0,
       :model => 0,
-      :template => 16,
+      :template => 15,
       :generic => 21
     }
   end
@@ -761,7 +761,7 @@ class Rails5Tests < Minitest::Test
       :code => s(:call, nil, :link_to, s(:call, nil, :image_tag, s(:str, "icons/twitter-gray.svg")), s(:call, nil, :sanitize, s(:call, s(:call, s(:const, :User), :new, s(:call, nil, :user_params)), :home_page)), s(:hash, s(:lit, :target), s(:str, "_blank"))),
       :user_input => nil
 
-    assert_warning :type => :template,
+    assert_no_warning :type => :template,
       :warning_code => 111,
       :fingerprint => "19baa582a2e584150460db2b4a13e95a826e556e6bf3dc98b7b48afd01b1bd19",
       :warning_type => "Reverse Tabnabbing",
@@ -836,6 +836,17 @@ class Rails5Tests < Minitest::Test
       :confidence => 2,
       :relative_path => "app/views/users/show.html.erb",
       :code => s(:call, nil, :link_to, s(:call, nil, :some_url), s(:hash, s(:lit, :target), s(:str, "_blank"), s(:lit, :rel), s(:str, "noopener noreferrer"))),
+      :user_input => nil
+
+    assert_no_warning :type => :template,
+      :warning_code => 111,
+      :fingerprint => "0d587aec5157de1f19f4a92f4800c6a9da9fceb5c9b75bdb4b115a01d8fd5eb6",
+      :warning_type => "Reverse Tabnabbing",
+      :line => 20,
+      :message => /^The\ newly\ opened\ tab\ can\ control\ the\ par/,
+      :confidence => 1,
+      :relative_path => "app/views/users/show.html.erb",
+      :code => s(:call, nil, :link_to, s(:str, ""), s(:hash, s(:lit, :target), s(:str, "_blank"))),
       :user_input => nil
   end
 end


### PR DESCRIPTION
## Description
[Anchor HTML tags](https://en.ryte.com/wiki/Anchor_Tag) have an attribute that describes how the linked document should be opened, named `target`. Some of the accepted values are the following:
- `_blank` tells the browser to open the linked document in a new tab/window
- `_self` (the default value) opens the document on the same tab.

[Reverse tabnabbing](https://www.owasp.org/index.php/Reverse_Tabnabbing) is a security vulnerability where if an adversary can create anchor tags with `target: _blank`,  they can redirect the victim to any domain they want. This is possible because the newly opened tab is able to communication with the parent tab through `window.opener`. The most common exploitation route here is to redirect the victim to a phishing using the following PoC:
` window.opener.location = "https://attacker.co"; `.

Let's consider the following scenario:
We have a forum-type of website where users' comments can contain URLs. These URLs get automatically converted to `<a>` tags with the `target: _blank` element so that users original tab stays intact (clicked document opens in a new tab). In this case, a malicious user can submit a link that redirects the victim to their own malicious website and present them with our forum's (fake) login page. The user submits their credentials to the adversary's website.

### Fix
The fix for this is quite simple: add the `noopener` value to the `rel` attribute as such:
`<a href="//attacker.co" target="_blank" rel="noopener">`

## Proposed check
This PR adds a new _**optional**_ check that looks for such cases. More specifically, we look for `link_to` calls where `target: "_blank"` is passed to `html_opts` and either:

- the `rel` attribute is not supplied at all
- the `noopener` is not supplied.

I've tried to follow the projects conventions but there will be room for improvement.

Awaiting your feedback! :)