### PR TITLE
Better handling of gems with no version declared

### DIFF
--- a/lib/brakeman/processors/gem_processor.rb
+++ b/lib/brakeman/processors/gem_processor.rb
@@ -59,8 +59,8 @@ class Brakeman::GemProcessor < Brakeman::BasicProcessor
         end
       end
     elsif @inside_gemspec and exp.method == :add_dependency
-      if string? exp.first_arg and string? exp.last_arg
-        @tracker.config.add_gem exp.first_arg.value, exp.last_arg.value, @gemspec, exp.line
+      if string? exp.first_arg and string? exp.second_arg
+        @tracker.config.add_gem exp.first_arg.value, exp.second_arg.value, @gemspec, exp.line
       end
     end
 

--- a/lib/brakeman/tracker/config.rb
+++ b/lib/brakeman/tracker/config.rb
@@ -19,10 +19,6 @@ module Brakeman
       @ruby_version = ""
     end
 
-    def allow_forgery_protection?
-      @rails.dig(:action_controller, :allow_forgery_protection) == Sexp.new(:false)
-    end
-
     def default_protect_from_forgery?
       if version_between? "5.2.0", "9.9.9"
         if @rails.dig(:action_controller, :default_protect_from_forgery) == Sexp.new(:false)

--- a/lib/brakeman/tracker/config.rb
+++ b/lib/brakeman/tracker/config.rb
@@ -20,15 +20,12 @@ module Brakeman
     end
 
     def allow_forgery_protection?
-      @rails[:action_controller] and
-        @rails[:action_controller][:allow_forgery_protection] == Sexp.new(:false)
+      @rails.dig(:action_controller, :allow_forgery_protection) == Sexp.new(:false)
     end
 
     def default_protect_from_forgery?
       if version_between? "5.2.0", "9.9.9"
-        if @rails[:action_controller] and
-            @rails[:action_controller][:default_protect_from_forgery] == Sexp.new(:false)
-
+        if @rails.dig(:action_controller, :default_protect_from_forgery) == Sexp.new(:false)
           return false
         else
           return true
@@ -48,17 +45,15 @@ module Brakeman
 
     def escape_html_entities_in_json?
       #TODO add version-specific information here
-      @rails[:active_support] and
-        true? @rails[:active_support][:escape_html_entities_in_json]
+      true? @rails.dig(:active_support, :escape_html_entities_in_json)
     end
 
     def whitelist_attributes?
-      @rails[:active_record] and
-        @rails[:active_record][:whitelist_attributes] == Sexp.new(:true)
+      @rails.dig(:active_record, :whitelist_attributes) == Sexp.new(:true)
     end
 
     def gem_version name
-      @gems[name] and @gems[name][:version]
+      @gems.dig(name, :version)
     end
 
     def add_gem name, version, file, line
@@ -154,8 +149,7 @@ module Brakeman
     end
 
     def session_settings
-      @rails[:action_controller] &&
-        @rails[:action_controller][:session]
+      @rails.dig(:action_controller, :session)
     end
 
     private
@@ -199,7 +193,10 @@ module Brakeman
     # included '5.99.99' in the list so that this method might stand a chance of
     # working in the future.
     def supported_haml_version?
-      requirement = Gem::Requirement.new(gem_version(:haml))
+      haml_version = gem_version(:haml)
+      return true unless haml_version
+
+      requirement = Gem::Requirement.new(haml_version)
       ['5.99.99', '5.1.1', '5.1.0', '5.0.4', '5.0.3', '5.0.2', '5.0.1', '5.0.0'].none? do |v|
         requirement.satisfied_by?(Gem::Version.new(v))
       end

--- a/test/apps/rails4/Gemfile
+++ b/test/apps/rails4/Gemfile
@@ -5,6 +5,8 @@ gem 'rails', '4.0.0'
 
 gem 'pg'
 
+gem 'haml'
+
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do

--- a/test/apps/rails4_non_standard_structure/rails4test.gemspec
+++ b/test/apps/rails4_non_standard_structure/rails4test.gemspec
@@ -5,4 +5,5 @@ Gem::Specification.new do |s|
   s.description = "And this file is to test Brakeman's handling of gemspecs"
 
   s.add_dependency 'rails', '>= 4.1.8'
+  s.add_dependency 'haml'
 end

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -3,21 +3,25 @@ require_relative '../test'
 
 class BrakemanTests < Minitest::Test
   def test_haml_5_warning
-    config = Tempfile.new("config")
-    config.write <<-YAML.strip
-    ---
-    :quiet: false
-    YAML
-    config.close
     options = {
       :quiet => :command_line,
-      :config_file => config.path,
       :app_path => "#{TEST_PATH}/apps/rails5.2",
       :run_checks => []
     }
+
     _out, err = capture_io { Brakeman.run options }
-    config.unlink
     assert_includes err, "Brakeman does not fully support Haml 5 yet."
+  end
+
+  def test_no_haml_5_warning
+    options = {
+      :quiet => :command_line,
+      :app_path => "#{TEST_PATH}/apps/rails3.2",
+      :run_checks => []
+    }
+
+    _out, err = capture_io { Brakeman.run options }
+    refute_includes err, "Brakeman does not fully support Haml 5 yet."
   end
 
   def test_exception_on_no_application


### PR DESCRIPTION
Dependencies like this:

```
gem 'haml'
```

Where returning the gem name as the version, which is...obviously wrong.

Also cleaned up some code by using `Hash#dig`.