### PR TITLE
Skip calls to `dup`

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -265,6 +265,10 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       unless target.nil?
         exp = target
       end
+    when :dup
+      unless target.nil?
+        exp = target
+      end
     when :join
       if array? target and target.length > 2 and (string? first_arg or first_arg.nil?)
         exp = process_array_join(target, first_arg)

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -1,0 +1,8 @@
+class GroupsController < ApplicationController
+  def new_group
+    @group = Group.find params[:id]
+    new_group = @group.dup
+    new_group.save!
+    redirect_to new_group
+  end
+end

--- a/test/apps/rails6/app/models/group.rb
+++ b/test/apps/rails6/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < ApplicationRecord
+end

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1124,6 +1124,13 @@ class AliasProcessorTests < Minitest::Test
     INPUT
   end
 
+  def test_ignore_dup
+    assert_alias "blah", <<-INPUT
+    x = blah.dup
+    x
+    INPUT
+  end
+
   def test_join_incompatible_strings
     # Fails to completely join strings
     # because of encoding issues, but that's better

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -107,4 +107,17 @@ class Rails6Tests < Minitest::Test
       :code => s(:attrasgn, s(:call, s(:call, s(:call, s(:const, :Rails), :application), :config), :action_dispatch), :cookies_serializer=, s(:lit, :marshal)),
       :user_input => nil
   end
+
+  def test_dup_call
+    assert_no_warning :type => :warning,
+      :warning_code => 18,
+      :fingerprint => "5c2a887ac2e7ba5ae8d27160c0b4540d9ddb93ae8cde64f84558544e2235c83e",
+      :warning_type => "Redirect",
+      :line => 6,
+      :message => /^Possible\ unprotected\ redirect/,
+      :confidence => 0,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, nil, :redirect_to, s(:call, s(:call, s(:const, :Group), :find, s(:call, s(:params), :[], s(:lit, :id))), :dup)),
+      :user_input => s(:call, s(:call, s(:const, :Group), :find, s(:call, s(:params), :[], s(:lit, :id))), :dup)
+  end
 end


### PR DESCRIPTION
as if they aren't even there.

Fixes #1374 

In the future, it would be nice to be able to do this globally *without* rewriting the AST, but this is how it's been done in the past.