### PR TITLE
Fix typo in example code in message for reverse tabnabbing

### DIFF
--- a/lib/brakeman/checks/check_reverse_tabnabbing.rb
+++ b/lib/brakeman/checks/check_reverse_tabnabbing.rb
@@ -46,7 +46,7 @@ class Brakeman::CheckReverseTabnabbing < Brakeman::BaseCheck
     warn :result => result,
       :warning_type => "Reverse Tabnabbing",
       :warning_code => :reverse_tabnabbing,
-      :message => msg("When opening a link in a new tab without setting ", msg_code('rel: "noopener noreferr"'),
+      :message => msg("When opening a link in a new tab without setting ", msg_code('rel: "noopener noreferrer"'),
                       ", the new tab can control the parent tab's location. For example, an attacker could redirect to a phishing page."),
       :confidence => confidence,
       :user_input => rel


### PR DESCRIPTION
Hi!

When brakemen detects Reverse Tabnabbing there is a type in the example code (`noreferr`).

```
Confidence: Medium
Category: Reverse Tabnabbing
Check: ReverseTabnabbing
Message: When opening a link in a new tab without setting `rel: "noopener noreferr"`, the new tab can control the parent tab's location. For example, an attacker could redirect to a phishing page.
```