### PR TITLE
Fix exception in CheckCookieSerialization

### DIFF
--- a/lib/brakeman/checks/check_cookie_serialization.rb
+++ b/lib/brakeman/checks/check_cookie_serialization.rb
@@ -9,7 +9,7 @@ class Brakeman::CheckCookieSerialization < Brakeman::BaseCheck
     tracker.find_call(target: :'Rails.application.config.action_dispatch', method: :cookies_serializer=).each do |result|
       setting = result[:call].first_arg
 
-      if symbol? setting and setting.value == :marshal or setting.value == :hybrid
+      if symbol? setting and [:marshal, :hybrid].include? setting.value
         warn :result => result,
           :warning_type => "Remote Code Execution",
           :warning_code => :unsafe_cookie_serialization,

--- a/test/apps/rails5.2/config/initializers/cookies_serializer.rb
+++ b/test/apps/rails5.2/config/initializers/cookies_serializer.rb
@@ -3,3 +3,10 @@
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
 Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+
+module Custom
+  module Serializer
+  end
+end
+
+Rails.application.config.action_dispatch.cookies_serializer = Custom::Serializer


### PR DESCRIPTION
The `and`/`or` precedence rules cause us to execute `setting.value == :hybrid`
even when `setting` is not a symbol, which raises an exception:

```
Sexp#value called on multi-item Sexp: `s(:colon2, s(:const, :Custom), :Serializer)`
```