### PR TITLE
Add check for ERB.new that includes user input

### DIFF
--- a/docs/warning_types/template_injection/index.markdown
+++ b/docs/warning_types/template_injection/index.markdown
@@ -1,0 +1,5 @@
+User input passed into ruby templates that are evaluated is VERY dangerous, so this will always raise a warning. Brakeman looks foir calls of the form:
+
+```ruby
+  ERB.new(user_input).result
+```

--- a/lib/brakeman/checks/check_template_injection.rb
+++ b/lib/brakeman/checks/check_template_injection.rb
@@ -1,0 +1,32 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckTemplateInjection < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = "Searches for evaluation of user input through template injection"
+
+  #Process calls
+  def run_check
+    Brakeman.debug "Finding ERB.new calls"
+    erb_calls = tracker.find_call :target => :ERB, :method => :new, :chained => true
+
+    Brakeman.debug "Processing ERB.new calls"
+    erb_calls.each do |call|
+      process_result call
+    end
+  end
+
+  #Warns if eval includes user input
+  def process_result result
+    return unless original? result
+
+    if input = include_user_input?(result[:call].arglist)
+      warn :result => result,
+        :warning_type => "Template Injection",
+        :warning_code => :template_injection,
+        :message => "User input in ruby template",
+        :user_input => input,
+        :confidence => :high
+    end
+  end
+end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -113,6 +113,7 @@ module Brakeman::WarningCodes
     :force_ssl_disabled => 109,
     :unsafe_cookie_serialization => 110,
     :reverse_tabnabbing => 111,
+    :template_injection => 112,
     :custom_check => 9090,
   }
 

--- a/test/apps/rails5/app/models/user.rb
+++ b/test/apps/rails5/app/models/user.rb
@@ -1,4 +1,8 @@
 class User < ApplicationRecord
+  def self.render_user_input
+    ERB.new(params).result
+  end
+
   def self.evaluate_user_input
     eval(params)
   end

--- a/test/apps/rails6/app/models/user.rb
+++ b/test/apps/rails6/app/models/user.rb
@@ -1,2 +1,5 @@
 class User < ApplicationRecord
+  def self.render_user_input
+    ERB.new(params)
+  end
 end

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -13,7 +13,7 @@ class Rails5Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 15,
-      :generic => 21
+      :generic => 22
     }
   end
 
@@ -189,7 +189,7 @@ class Rails5Tests < Minitest::Test
       :warning_code => 0,
       :fingerprint => "46cda22e00dca87a8715682bd7d8d52cc4a8e705257b27c5e36595ebd1f654f8",
       :warning_type => "SQL Injection",
-      :line => 4,
+      :line => 7,
       :message => /^Possible\ SQL\ injection/,
       :confidence => 0,
       :relative_path => "app/models/user.rb",
@@ -434,7 +434,7 @@ class Rails5Tests < Minitest::Test
       :warning_code => 0,
       :fingerprint => "2a77f56c4c09590a4cac1fe68dd00c0fa0a7820ea6f0d4bad20451ecc07dc68e",
       :warning_type => "SQL Injection",
-      :line => 17,
+      :line => 21,
       :message => /^Possible\ SQL\ injection/,
       :confidence => 0,
       :relative_path => "app/models/user.rb",
@@ -447,7 +447,7 @@ class Rails5Tests < Minitest::Test
       :warning_code => 0,
       :fingerprint => "dcfa0c30b2d303c58bde5b376f423cff6282bbc71ed460077478ca97e1f4d0f7",
       :warning_type => "SQL Injection",
-      :line => 20,
+      :line => 2,
       :message => /^Possible\ SQL\ injection/,
       :confidence => 0,
       :relative_path => "app/models/user.rb",
@@ -695,11 +695,24 @@ class Rails5Tests < Minitest::Test
       :warning_code => 13,
       :fingerprint => "7fe3142d1d11b7118463e45a82b4b7a2b5b5bac95cf8904050c101fae16b8168",
       :warning_type => "Dangerous Eval",
-      :line => 3,
-      :message => /User input in eval near line 3/,
+      :line => 7,
+      :message => /User input in eval near line 7/,
       :method => :"User.evaluate_user_input",
       :confidence => 0,
       :relative_path => "app/models/user.rb",
+      :user_input => s(:params)
+  end
+
+  def test_template_injection
+    assert_warning :type => :warning,
+      :warning_code => 112,
+      :fingerprint => "fcb73faa61714b6a6469ceb53ec1d2aff596ea38affec7fac3dd18ba92f54938",
+      :warning_type => "Template Injection",
+      :line => 3,
+      :message => /^User\ input\ in\ ruby\ template/,
+      :confidence => 0,
+      :relative_path => "app/models/user.rb",
+      :code => s(:call, s(:const, :ERB), :new, s(:params)),
       :user_input => s(:params)
   end
 

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,7 +13,7 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 3
+      :generic => 4
     }
   end
 
@@ -119,5 +119,18 @@ class Rails6Tests < Minitest::Test
       :relative_path => "app/controllers/groups_controller.rb",
       :code => s(:call, nil, :redirect_to, s(:call, s(:call, s(:const, :Group), :find, s(:call, s(:params), :[], s(:lit, :id))), :dup)),
       :user_input => s(:call, s(:call, s(:const, :Group), :find, s(:call, s(:params), :[], s(:lit, :id))), :dup)
+  end
+
+  def test_template_injection
+    assert_warning :type => :warning,
+      :warning_code => 112,
+      :fingerprint => "fcb73faa61714b6a6469ceb53ec1d2aff596ea38affec7fac3dd18ba92f54938",
+      :warning_type => "Template Injection",
+      :line => 3,
+      :message => /^User\ input\ in\ ruby\ template/,
+      :confidence => 0,
+      :relative_path => "app/models/user.rb",
+      :code => s(:call, s(:const, :ERB), :new, s(:params)),
+      :user_input => s(:params)
   end
 end


### PR DESCRIPTION
This is pretty much just as bad as eval

example:
```ruby
bad_input = "<% User.delete_all %>"
ERB.new(bad_input).result
```

Adding a check to check_evaluation to also check for dangerous calls to ERB.new