### PR TITLE
Update tests for ruby_parser 3.14.0

### DIFF
--- a/test/tests/file_parser.rb
+++ b/test/tests/file_parser.rb
@@ -21,6 +21,11 @@ class FileParserTests < Minitest::Test
     RUBY
 
     assert_equal 1, @tracker.errors.length
-    assert_match(/parse error on value \"\$end\" \(\$end\)/, @tracker.errors.first[:error])
+
+    if RubyParser::Parser::VERSION.split(".").map(&:to_i).zip([3,14,0]).all? { |a, b| a >= b }
+      assert_match(/parse error on value false \(\$end\)/, @tracker.errors.first[:error])
+    else
+      assert_match(/parse error on value \"\$end\" \(\$end\)/, @tracker.errors.first[:error])
+    end
   end
 end

--- a/test/tests/sexp.rb
+++ b/test/tests/sexp.rb
@@ -101,7 +101,11 @@ class SexpTests < Minitest::Test
   def test_stabby_lambda_no_args
     exp = parse "->{ hi }"
 
-    assert_equal s(:call, nil, :lambda), exp.block_call
+    if RubyParser::Parser::VERSION.split(".").map(&:to_i).zip([3,14,0]).all? { |a, b| a >= b }
+      assert_equal s(:lambda), exp.block_call
+    else
+      assert_equal s(:call, nil, :lambda), exp.block_call
+    end
     assert_equal s(:args), exp.block_args
     assert_equal s(:call, nil, :hi), exp.block
   end


### PR DESCRIPTION
Not explicitly moving to 3.14.0 yet, so the tests are conditional on the ruby_parser version number for now.