### PR TITLE
Refactor Brakeman::Differ#second_pass

### DIFF
--- a/lib/brakeman/differ.rb
+++ b/lib/brakeman/differ.rb
@@ -24,43 +24,31 @@ class Brakeman::Differ
   # second pass to cleanup any vulns which have changed in line number only.
   # Given a list of new warnings, delete pairs of new/fixed vulns that differ
   # only by line number.
-  # Horrible O(n^2) performance.  Keep n small :-/
   def second_pass(warnings)
-    # keep track of the number of elements deleted because the index numbers
-    # won't update as the list is modified
-    elements_deleted_offset = 0
+    new_fingerprints = Set.new(warnings[:new].map(&method(:fingerprint)))
+    fixed_fingerprints = Set.new(warnings[:fixed].map(&method(:fingerprint)))
 
-    # dup this list since we will be deleting from it and the iterator gets confused.
-    # use _with_index for fast deletion as opposed to .reject!{|obj| obj == *_warning}
-    warnings[:new].dup.each_with_index do |new_warning, new_warning_id|
-      warnings[:fixed].each_with_index do |fixed_warning, fixed_warning_id|
-        if eql_except_line_number new_warning, fixed_warning
-          warnings[:new].delete_at(new_warning_id - elements_deleted_offset)
-          elements_deleted_offset += 1
-          warnings[:fixed].delete_at(fixed_warning_id)
-          break
-        end
+    # Remove warnings which fingerprints are both in :new and :fixed
+    shared_fingerprints = new_fingerprints.intersection(fixed_fingerprints)
+
+    unless shared_fingerprints.empty?
+      warnings[:new].delete_if do |warning|
+        shared_fingerprints.include?(fingerprint(warning))
+      end
+
+      warnings[:fixed].delete_if do |warning|
+        shared_fingerprints.include?(fingerprint(warning))
       end
     end
 
     warnings
   end
 
-  def eql_except_line_number new_warning, fixed_warning
-    # can't do this ahead of time, as callers may be expecting a Brakeman::Warning
-    if new_warning.is_a? Brakeman::Warning 
-      new_warning = new_warning.to_hash
-      fixed_warning = fixed_warning.to_hash
-    end
-
-    if new_warning[:fingerprint] and fixed_warning[:fingerprint]
-      new_warning[:fingerprint] == fixed_warning[:fingerprint]
+  def fingerprint(warning)
+    if warning.is_a?(Brakeman::Warning)
+      warning.fingerprint
     else
-     OLD_WARNING_KEYS.each do |attr|
-        return false if new_warning[attr] != fixed_warning[attr]
-      end
-
-      true
+      warning[:fingerprint]
     end
   end
 end

--- a/test/tests/differ.rb
+++ b/test/tests/differ.rb
@@ -9,7 +9,7 @@ class DifferTests < Minitest::Test
     @warnings ||= @@diffrun.warnings
   end
 
-  def diff new, old
+  def run_diff new, old
     @diff = Brakeman::Differ.new(new, old).diff
   end
 
@@ -22,7 +22,7 @@ class DifferTests < Minitest::Test
   end
 
   def test_sanity
-    diff @warnings, @warnings
+    run_diff @warnings, @warnings
 
     assert_fixed 0
     assert_new 0
@@ -33,7 +33,7 @@ class DifferTests < Minitest::Test
     new = @warnings.dup
     new.shift
 
-    diff new, old
+    run_diff new, old
 
     assert_fixed 1
     assert_new 0
@@ -44,7 +44,7 @@ class DifferTests < Minitest::Test
     old = @warnings.dup
     old.shift
 
-    diff new, old
+    run_diff new, old
 
     assert_fixed 0
     assert_new 1
@@ -57,7 +57,7 @@ class DifferTests < Minitest::Test
     new << old.pop
     old << new.shift
 
-    diff new, old
+    run_diff new, old
 
     assert_new 2
     assert_fixed 2
@@ -76,43 +76,9 @@ class DifferTests < Minitest::Test
 
     new << changed
 
-    diff new, old
+    run_diff new, old
 
     assert_new 0
     assert_fixed 0
-  end
-
-  def test_new_vs_old_warning_keys_same_warnings
-    new_keys = [:warning_code, :fingerprint, :render_path]
-
-    new = @warnings
-    old = @warnings.map do |warning|
-      warning.to_hash.reject do |k, v|
-        new_keys.include? k
-      end
-    end
-
-    diff new, old
-    assert_fixed 0
-    assert_new 0
-  end
-
-  def test_new_vs_old_warning_keys_changed_warning
-    new_keys = [:warning_code, :fingerprint, :render_path]
-
-    new = @warnings
-    old = @warnings.map do |warning|
-      warning.to_hash.reject do |k, v|
-        new_keys.include? k
-      end
-    end
-
-    changed = new.pop.to_hash
-    changed[:message] += "message has changed!"
-    new << changed #check for new warning with different message
-
-    diff new, old
-    assert_fixed 1
-    assert_new 1
   end
 end


### PR DESCRIPTION
## Issue
I had noticed that `Brakeman::Differ` can sometimes provide inaccurate results (for example:  missing new warnings or incorrectly reporting a warning as new) but I haven't really dug into the code until today.

Turns out the issue is in `Brakeman::Differ#second_pass` when it attempts to delete elements using indices while iterating the lists:
https://github.com/presidentbeef/brakeman/blob/5633686ddf653a4a811638e1ed6b54036d2e23b8/lib/brakeman/differ.rb#L38-L40

In my case, the output of both `delete_at` were not the same warning. This caused the fixed list to become empty when the new list still had warnings in it. This would cause the remaining warnings to be considered as new. 

## Solution

I've redone the algorithm by building a set of fingerprints from both warning lists which I then intersect to remove in bulk from both lists. It should have a better complexity than the previous algorithm.

Though, I left a similar algorithm afterwards for backward compatibility with old warning keys (I'm not sure if it's really needed).

Also, I renamed `DifferTests#diff` to `DifferTests#run_diff` because it shadowed `Minitest::Test#diff` which was quite confusing while coding this.