### PR TITLE
Avoid setting Rails version directly

### DIFF
--- a/lib/brakeman/processors/lib/rails2_config_processor.rb
+++ b/lib/brakeman/processors/lib/rails2_config_processor.rb
@@ -75,7 +75,7 @@ class Brakeman::Rails2ConfigProcessor < Brakeman::BasicProcessor
   def process_cdecl exp
     #Set Rails version required
     if exp.lhs == :RAILS_GEM_VERSION
-      @tracker.config.rails_version = exp.rhs.value
+      @tracker.config.set_rails_version exp.rhs.value
     end
 
     exp

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -102,7 +102,7 @@ class BaseCheckTests < Minitest::Test
   end
 
   def version_between? version, low, high
-    @tracker.config.rails_version = version
+    @tracker.config.set_rails_version version
     @check.send(:version_between?, low, high)
   end
 
@@ -135,7 +135,7 @@ class BaseCheckTests < Minitest::Test
   end
 
   def test_lts_version
-    @tracker.config.rails_version = "2.3.18"
+    @tracker.config.set_rails_version "2.3.18"
     assert lts_version? '2.3.18.6', '2.3.18.6'
     assert !lts_version?('2.3.18.1', '2.3.18.6')
     assert !lts_version?(nil, '2.3.18.6')


### PR DESCRIPTION
Fixes handling Rails versions in *very* old Rails where the Rails version was declared in `config/environment.rb` with `RAILS_GEM_VERSION`.

Also cleans up the readers/accessors on `Tracker::Config`.