### PR TITLE
%W in system call

### DIFF
--- a/test/apps/rails5.2/lib/shell.rb
+++ b/test/apps/rails5.2/lib/shell.rb
@@ -89,4 +89,9 @@ class ShellStuff
     # __FILE__ should not change based on absolute path
     `cp #{__FILE__} #{somewhere_else}`
   end
+
+  def interpolated_in_percent_W
+    # Should not warn
+    system(*%W(foo bar #{value}))
+  end
 end

--- a/test/test.rb
+++ b/test/test.rb
@@ -55,7 +55,7 @@ module BrakemanTester::FindWarning
 
   def assert_no_warning opts
     warnings = find opts
-    assert_equal 0, warnings.length
+    assert_equal 0, warnings.length, "Found warning when no warning was expected"
   end
 
   def find opts = {}, &block

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -370,6 +370,18 @@ class Rails52Tests < Minitest::Test
       :user_input => s(:call, nil, :somewhere_else)
   end
 
+  def test_command_injection_percent_W
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :warning_type => "Command Injection",
+      :line => 95,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 1,
+      :relative_path => "lib/shell.rb",
+      :code => s(:call, nil, :system, s(:splat, s(:array, s(:str, "foo"), s(:str, "bar"), s(:dstr, "", s(:evstr, s(:call, nil, :value)))))),
+      :user_input => s(:call, nil, :value)
+  end
+
   def test_cross_site_scripting_haml_sass
     assert_warning :type => :template,
       :warning_code => 2,


### PR DESCRIPTION
Avoid treating this like regular interpolation:

```ruby
%W[#{a}]
```

Fixes #1399