### PR TITLE
Sort text report output by file and line

### DIFF
--- a/lib/brakeman/report/report_text.rb
+++ b/lib/brakeman/report/report_text.rb
@@ -19,7 +19,7 @@ class Brakeman::Report::Text < Brakeman::Report::Base
     add_chunk generate_controllers if tracker.options[:debug] or tracker.options[:report_routes]
     add_chunk generate_templates if tracker.options[:debug]
     add_chunk generate_obsolete
-    add_chunk generate_errors 
+    add_chunk generate_errors
     add_chunk generate_warnings
   end
 
@@ -51,7 +51,7 @@ class Brakeman::Report::Text < Brakeman::Report::Base
 
   def generate_header
     [
-      header("Brakeman Report"), 
+      header("Brakeman Report"),
       label("Application Path", tracker.app_path),
       label("Rails Version", rails_version),
       label("Brakeman Version", Brakeman::Version),
@@ -92,7 +92,7 @@ class Brakeman::Report::Text < Brakeman::Report::Base
       HighLine.color("No warnings found", :bold, :green)
     else
       warnings = tracker.filtered_warnings.sort_by do |w|
-        [w.confidence, w.warning_type, w.fingerprint]
+        [w.confidence, w.warning_type, w.file, w.line, w.fingerprint]
       end.map do |w|
         output_warning w
       end
@@ -211,4 +211,3 @@ class Brakeman::Report::Text < Brakeman::Report::Base
     double_space "Controller Overview", controllers
   end
 end
-


### PR DESCRIPTION
When Brakeman gives a lot of output, I find it can be really confusing to scroll through it and fix everything when its output is jumping between files seemingly at random. This is especially true where a new version of brakeman finds many new warnings, and the same warning occurs multiple times within the same file. Because Brakeman's output is not sorted by file/line, it appears as though Brakeman "missed" some warnings in the file until you scroll through its entire output.

This commit simply has Brakeman include filename and line number in its sorting so output containing lots of warnings appears more coherent.