### PR TITLE
Convert s(:lambda) to s(:call) in Sexp#block_call

### DIFF
--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -371,7 +371,12 @@ class Sexp
   #       s(:block, s(:lvar, :y), s(:call, nil, :z, s(:arglist))))
   def block_call
     expect :iter
-    self[1]
+
+    if self[1].node_type == :lambda
+      s(:call, nil, :lambda).line(self.line)
+    else
+      self[1]
+    end
   end
 
   #Returns block of a call with a block.

--- a/test/apps/rails6/config/routes.rb
+++ b/test/apps/rails6/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   resources :users
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  # https://github.com/presidentbeef/brakeman/issues/1410
+  x = ->(args) {
+  }
 end

--- a/test/tests/sexp.rb
+++ b/test/tests/sexp.rb
@@ -101,11 +101,7 @@ class SexpTests < Minitest::Test
   def test_stabby_lambda_no_args
     exp = parse "->{ hi }"
 
-    if RubyParser::Parser::VERSION.split(".").map(&:to_i).zip([3,14,0]).all? { |a, b| a >= b }
-      assert_equal s(:lambda), exp.block_call
-    else
-      assert_equal s(:call, nil, :lambda), exp.block_call
-    end
+    assert_equal s(:call, nil, :lambda), exp.block_call
     assert_equal s(:args), exp.block_args
     assert_equal s(:call, nil, :hi), exp.block
   end


### PR DESCRIPTION
Fixes #1410

This may be a little wasteful if `Sexp#block_call` is called often on `:iter` with `:lambda`s but I think it avoids modifying the AST too much and affecting fingerprints. I would prefer to stick with ruby_parser's AST nodes instead of modifying them the way Brakeman has in the past.