### PR TITLE
Fix flaky rails4 test

### DIFF
--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -1667,8 +1667,8 @@ class Rails4Tests < Minitest::Test
 
   #Verify checks external to Brakeman are loaded
   def test_external_checks
-    assert defined? Brakeman::CheckExternalCheckTest
     #Initial "Check" removed from check names
     assert report[:checks_run].include? "ExternalCheckTest"
+    assert defined? Brakeman::CheckExternalCheckTest
   end
 end


### PR DESCRIPTION
This fixes issue https://github.com/presidentbeef/brakeman/issues/1409

I found the failing seed with: `while rake; do :; done`
Failure can be reproduced with `rake TESTOPTS="--seed=42281"`

The cause is that the `test_external_checks` test is run first, so `report` hasn't been called yet. The result is that `Brakeman::CheckExternalCheckTest` isn't loaded yet, so the `defined?` assertion fails. Simply moving that assertion to after calling `report` fixes the test.