### PR TITLE
Symbol#to_s returns frozen string in Ruby 2.7.0

### DIFF
--- a/lib/brakeman/report/report_text.rb
+++ b/lib/brakeman/report/report_text.rb
@@ -140,7 +140,7 @@ class Brakeman::Report::Text < Brakeman::Report::Base
     end
 
     double_space "Template Output", template_rows.sort_by { |name, value| name.to_s }.map { |template|
-      [HighLine.new.color(template.first.to_s << "\n", :cyan)] + template[1]
+      [HighLine.new.color("#{template.first}\n", :cyan)] + template[1]
     }.compact
   end
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -58,13 +58,23 @@ module BrakemanTester::FindWarning
     assert_equal 0, warnings.length, "Found warning when no warning was expected"
   end
 
-  def find opts = {}, &block
-    t = opts[:type]
-    if t.nil? or t == :warning
-      warnings = report[:generic_warnings]
+  def warning_table type
+    case type
+    when :warning, :generic, nil
+      :generic_warnings
+    when :template
+      :template_warnings
+    when :controller
+      :controller_warnings
+    when :model
+      :model_warnings
     else
-      warnings = report[(t.to_s << "_warnings").to_sym]
+      raise "Unknown warning type: #{type.inspect}"
     end
+  end
+
+  def find opts = {}, &block
+    warnings = report[warning_table(opts[:type])]
 
     opts.delete :type
 
@@ -93,11 +103,7 @@ module BrakemanTester::CheckExpected
     require 'pp'
 
     expected.each do |type, number|
-      if type == :warning
-        warnings = report[:warnings]
-      else
-        warnings = report[(type.to_s << "_warnings").to_sym]
-      end
+      warnings = report[warning_table(type)]
 
       assert_equal number, warnings.length, lambda { "Expected #{number} #{type} warnings, but found #{warnings.length}:\n#{warnings.map { |w| w.message }.join("\n")}" }
     end


### PR DESCRIPTION
Better not to mangle them... probably better code, too.