### PR TITLE
Adding git blame in that warnings

### DIFF
--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -289,6 +289,7 @@ class Brakeman::Warning
       :message => self.message.to_s,
       :file => (absolute_paths ? self.file.absolute : self.file.relative),
       :line => self.line,
+      :blame => blame(absolute_paths),
       :link => self.link,
       :code => (@code && self.format_code(false)),
       :render_path => render_path,
@@ -296,6 +297,10 @@ class Brakeman::Warning
       :user_input => (@user_input && self.format_user_input(false)),
       :confidence => TEXT_CONFIDENCE[self.confidence]
     }
+  end
+
+  def blame(absolute_paths)
+    `git blame -L #{self.line},#{self.line} #{absolute_paths ? self.file.absolute : self.file.relative}`
   end
 
   def to_json

--- a/test/tests/json_output.rb
+++ b/test/tests/json_output.rb
@@ -52,7 +52,7 @@ class JSONOutputTests < Minitest::Test
 
   def test_for_expected_warning_keys
     expected = ["warning_type", "check_name", "message", "file", "link", "code", "location",
-      "render_path", "user_input", "confidence", "line", "warning_code", "fingerprint"]
+      "render_path", "user_input", "confidence", "line", "blame", "warning_code", "fingerprint"]
 
     @@json["warnings"].each do |warning|
       assert (warning.keys - expected).empty?, "#{(warning.keys - expected).inspect} did not match expected keys"


### PR DESCRIPTION
## Subject
Add Git blame for brakeman warnings!!!!
## Description
We have all the informations in  warnings.
but, we missed Who has done unsecured code? . so, I added `git blame` code.
## Summary of CodeChanges
` lib/brakeman/warning.rb`
## Reviewer
  - [ ] @presidentbeef 
  - [ ] @brynary 
