### PR TITLE
initialize rails version with nil

### DIFF
--- a/lib/brakeman/tracker/config.rb
+++ b/lib/brakeman/tracker/config.rb
@@ -15,6 +15,7 @@ module Brakeman
       @escape_html = nil
       @erubis = nil
       @ruby_version = ""
+      @rails_version = nil
     end
 
     def default_protect_from_forgery?


### PR DESCRIPTION
while running the test with `rake` I got lots of following warnings: 
```
/Users/carstenwirth/Workspace/brakeman/lib/brakeman/tracker/config.rb:120: warning: instance variable @rails_version not initialized
```
these can easily be silenced by initializing the ivar as done in this PR
