### PR TITLE
Adding a user-friendly message when ignore config file has invalid JSON

### DIFF
--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -97,7 +97,11 @@ module Brakeman
     # Read configuration to file
     def read_from_file file = @file
       if File.exist? file
-        @already_ignored = JSON.parse(File.read(file), :symbolize_names => true)[:ignored_warnings]
+        begin
+          @already_ignored = JSON.parse(File.read(file), :symbolize_names => true)[:ignored_warnings]
+        rescue => e
+          raise e, "\nError[#{e.class}] while reading brakeman ignore file: #{file}\n"
+        end
       else
         Brakeman.notify "[Notice] Could not find ignore configuration in #{file}"
         @already_ignored = []

--- a/test/tests/ignore.rb
+++ b/test/tests/ignore.rb
@@ -176,6 +176,21 @@ class IgnoreConfigTests < Minitest::Test
     assert new_config.ignored? first_ignored
   end
 
+  def test_bad_ignore_json_error_message
+    file = Tempfile.new("brakeman.ignore2")
+    file.write "{[ This is bad json cuz I don't have a closing square bracket, bwahahaha...}"
+    file.close
+    begin
+      c = Brakeman::IgnoreConfig.new file.path, report.warnings
+      c.read_from_file
+    rescue => e
+      # The message should clearly show that there was a problem parsing the json
+      assert e.message.index("JSON::ParserError") > 0
+      # The message should clearly reference the file containing the bad json
+      assert e.message.index(file.path) > 0
+    end
+  end
+
   def test_relative_paths_everywhere
     require 'pathname'
 


### PR DESCRIPTION
We had a case where the brakeman.ignore file was manually edited resulting in invalid JSON.  

It was more of an effort than it seems like it should have been to determine what had happened.  

