### PR TITLE
All old warnings are fixed if no warnings reported

### DIFF
--- a/lib/brakeman/differ.rb
+++ b/lib/brakeman/differ.rb
@@ -1,8 +1,6 @@
 # extracting the diff logic to it's own class for consistency. Currently handles
 # an array of Brakeman::Warnings or plain hash representations.  
 class Brakeman::Differ
-  DEFAULT_HASH = {:new => [], :fixed => []}
-  OLD_WARNING_KEYS = [:warning_type, :location, :code, :message, :file, :link, :confidence, :user_input]
   attr_reader :old_warnings, :new_warnings
 
   def initialize new_warnings, old_warnings
@@ -11,9 +9,6 @@ class Brakeman::Differ
   end
 
   def diff
-    # get the type of elements
-    return DEFAULT_HASH if @new_warnings.empty?
-
     warnings = {}
     warnings[:new] = @new_warnings - @old_warnings
     warnings[:fixed] = @old_warnings - @new_warnings

--- a/test/tests/differ.rb
+++ b/test/tests/differ.rb
@@ -81,4 +81,22 @@ class DifferTests < Minitest::Test
     assert_new 0
     assert_fixed 0
   end
+
+  # If the new report has no warnings, then
+  # all the old warnings have been fixed.
+  def test_no_new_warnings
+    run_diff [], @warnings
+
+    assert_new 0
+    assert_fixed @warnings.length
+  end
+
+  # If the old report has no warnings, then
+  # all the warnings are new.
+  def test_no_old_warnings
+    run_diff @warnings, []
+
+    assert_new @warnings.length
+    assert_fixed 0
+  end
 end


### PR DESCRIPTION
When using `--compare`, all old warnings should be reported as "fixed" if the new report is empty (has no warnings).

Currently, if there are no warnings in the new report, both "new" and "fixed" will be empty arrays, regardless of whether or not the old report had any warnings in it.

I'm guessing no one noticed because people mostly care about _new_ warnings. Matters a lot for testing for (new) false negatives, however.

(Also removed the now-unused `OLD_WARNING_KEYS`).