### PR TITLE
Fix test with newer Minitest

### DIFF
--- a/test/tests/commandline.rb
+++ b/test/tests/commandline.rb
@@ -54,7 +54,7 @@ class CommandlineTests < Minitest::Test
 
   def scan_app *opts
     opts << "#{TEST_PATH}/apps/rails4"
-    assert_output do
+    capture_io do
       cl_with_options(*opts)
     end
   end


### PR DESCRIPTION
Use `capture_io` instead of `assert_output` to ignore output in commandline test