### PR TITLE
Freeze call index results

### DIFF
--- a/lib/brakeman/checks/check_content_tag.rb
+++ b/lib/brakeman/checks/check_content_tag.rb
@@ -55,8 +55,7 @@ class Brakeman::CheckContentTag < Brakeman::CheckCrossSiteScripting
 
     @current_file = result[:location][:file]
 
-    call = result[:call] = result[:call].dup
-
+    call = result[:call]
     args = call.arglist
 
     tag_name = args[1]

--- a/lib/brakeman/checks/check_link_to.rb
+++ b/lib/brakeman/checks/check_link_to.rb
@@ -34,7 +34,7 @@ class Brakeman::CheckLinkTo < Brakeman::CheckCrossSiteScripting
 
     #Have to make a copy of this, otherwise it will be changed to
     #an ignored method call by the code above.
-    call = result[:call] = result[:call].dup
+    call = result[:call]
 
     first_arg = call.first_arg
     second_arg = call.second_arg

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -30,9 +30,7 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
   end
 
   def process_result result
-    #Have to make a copy of this, otherwise it will be changed to
-    #an ignored method call by the code above.
-    call = result[:call] = result[:call].dup
+    call = result[:call]
     @matched = false
 
     url_arg = if result[:block]

--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -60,7 +60,7 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
   end
 
   def process_call exp
-    @calls << create_call_hash(exp)
+    @calls << create_call_hash(exp).freeze
     exp
   end
 
@@ -72,6 +72,7 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
 
       call_hash[:block] = exp.block
       call_hash[:block_args] = exp.block_args
+      call_hash.freeze
 
       @calls << call_hash
 
@@ -136,7 +137,7 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
                 :call => exp,
                 :nested => false,
                 :location => make_location,
-                :parent => @current_call }
+                :parent => @current_call }.freeze
   end
 
   #Gets the target of a call as a Symbol


### PR DESCRIPTION
Prevent some modification of call index results (matching call sites) which is not thread-safe across checks.

Also, I think this duping of calls in `CheckContentTag`, `CheckLinkTo`, and `CheckLinkToHref` is outdated. All these checks subclass `CheckCrossSiteScripting` which I _think_ used to modify results in some way but as far as I can tell this no longer happens.