### PR TITLE
Sort by fingerprint and line number for ignorefile

### DIFF
--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -122,7 +122,7 @@ module Brakeman
 
         w[:note] = @notes[w[:fingerprint]] || ""
         w
-      end.sort_by { |w| w[:fingerprint] }
+      end.sort_by { |w| [w[:fingerprint], w[:line]] }
 
       output = {
         :ignored_warnings => warnings,


### PR DESCRIPTION
When fingerprints are the same, the sorting is not deterministic and causes diffs in ignorefile when it gets updated. Add line number to the sorting algo as a tie breaker.

This is done here as well:
https://github.com/presidentbeef/brakeman/blob/master/lib/brakeman/report/report_json.rb#L41