### PR TITLE
ActionController::Parameters.permit_all_parameters

### DIFF
--- a/lib/brakeman/checks/check_mass_assignment.rb
+++ b/lib/brakeman/checks/check_mass_assignment.rb
@@ -17,6 +17,7 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
   def run_check
     check_mass_assignment
     check_permit!
+    check_permit_all_parameters
   end
 
   def find_mass_assign_calls
@@ -192,5 +193,19 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
       :warning_code => :mass_assign_permit!,
       :message => "Parameters should be whitelisted for mass assignment",
       :confidence => confidence
+  end
+
+  def check_permit_all_parameters
+    tracker.find_call(target: :"ActionController::Parameters", method: :permit_all_parameters=).each do |result|
+      call = result[:call]
+
+      if true? call.first_arg
+        warn :result => result,
+          :warning_type => "Mass Assignment",
+          :warning_code => :mass_assign_permit_all,
+          :message => "Parameters should be whitelisted for mass assignment",
+          :confidence => :high
+      end
+    end
   end
 end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -113,6 +113,7 @@ module Brakeman::WarningCodes
     :force_ssl_disabled => 109,
     :unsafe_cookie_serialization => 110,
     :reverse_tabnabbing => 111,
+    :mass_assign_permit_all => 112,
     :custom_check => 9090,
   }
 

--- a/test/apps/rails6/config/initializers/allow_all_parameters.rb
+++ b/test/apps/rails6/config/initializers/allow_all_parameters.rb
@@ -1,0 +1,2 @@
+# Allows all parameters for StrongParameters
+ActionController::Parameters.permit_all_parameters = true

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,7 +13,7 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 12
+      :generic => 13
     }
   end
 
@@ -234,6 +234,19 @@ class Rails6Tests < Minitest::Test
       :confidence => 1,
       :relative_path => "app/controllers/users_controller.rb",
       :code => s(:call, s(:params), :permit!),
+      :user_input => nil
+  end
+
+  def test_mass_assignment_global_allow_all_parameters
+    assert_warning :type => :warning,
+      :warning_code => 112,
+      :fingerprint => "a02bb53bb433ffd7e52cfd58f9a3fdf20f53d082db36d2e47bf3c0aee32458ae",
+      :warning_type => "Mass Assignment",
+      :line => 2,
+      :message => /^Parameters\ should\ be\ whitelisted\ for\ mas/,
+      :confidence => 0,
+      :relative_path => "config/initializers/allow_all_parameters.rb",
+      :code => s(:attrasgn, s(:colon2, s(:const, :ActionController), :Parameters), :permit_all_parameters=, s(:true)),
       :user_input => nil
   end
 


### PR DESCRIPTION
Warn about (global!) mass assignment via:

```ruby
ActionController::Parameters.permit_all_parameters = true
```

This seems extremely rare but it's easy to check so why not?