### PR TITLE
Check SQL query strings using .strip or .squish

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -393,7 +393,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     nil
   end
 
-  TO_STRING_METHODS = [:to_s, :strip_heredoc]
+  TO_STRING_METHODS = [:to_s, :squish, :strip, :strip_heredoc]
 
   #Returns value if interpolated value is not something safe
   def unsafe_string_interp? exp

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -10,4 +10,9 @@ class GroupsController < ApplicationController
     render text: `#{params.require('name')} some optional text`
     render json: `#{params.require('name')} some optional text`
   end
+
+  def squish_sql
+    ActiveRecord::Base.connection.execute "SELECT * FROM #{user_input}".squish
+    ActiveRecord::Base.connection.execute "SELECT * FROM #{user_input}".strip
+  end
 end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,7 +13,7 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 13
+      :generic => 15
     }
   end
 
@@ -54,6 +54,32 @@ class Rails6Tests < Minitest::Test
       :relative_path => "app/models/user.rb",
       :code => s(:call, nil, :where, s(:call, s(:dstr, "      name = '", s(:evstr, s(:lvar, :name)), s(:str, "'\n")), :strip_heredoc)),
       :user_input => s(:lvar, :name)
+  end
+
+  def test_sql_injection_squish_string
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "061b514e5a37df58d8b64ec0c9c10002dcd9d7253d0e1c1a9bd61bdb27be158f",
+      :warning_type => "SQL Injection",
+      :line => 15,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 1,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:call, s(:colon2, s(:const, :ActiveRecord), :Base), :connection), :execute, s(:call, s(:dstr, "SELECT * FROM ", s(:evstr, s(:call, nil, :user_input))), :squish)),
+      :user_input => s(:call, nil, :user_input)
+  end
+
+  def test_sql_injection_strip_string
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "07fe35888f23cd4125c862d041b9ab3257c01c1263b66cd8c63804d55b8e1549",
+      :warning_type => "SQL Injection",
+      :line => 16,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 1,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:call, s(:colon2, s(:const, :ActiveRecord), :Base), :connection), :execute, s(:call, s(:dstr, "SELECT * FROM ", s(:evstr, s(:call, nil, :user_input))), :strip)),
+      :user_input => s(:call, nil, :user_input)
   end
 
   def test_cross_site_scripting_sanity


### PR DESCRIPTION
Fixes #1469

Perhaps in the future we can check all calls with string interpolation targets, but doing so naively introduced false positives.