### PR TITLE
Add --text-fields option

### DIFF
--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -301,6 +301,22 @@ module Brakeman::Options
           options[:github_repo] = repo
         end
 
+        opts.on "--text-fields field1,field2,etc.", Array, "Specify fields for text report format" do |format|
+          valid_options = [:category, :category_id, :check, :code, :confidence, :file, :fingerprint, :line, :link, :message, :render_path]
+
+          options[:text_fields] = format.map(&:to_sym)
+
+          if options[:text_fields] == [:all]
+            options[:text_fields] = valid_options
+          else
+            invalid_options = (options[:text_fields] - valid_options)
+
+            unless invalid_options.empty?
+              raise OptionParser::ParseError, "\nInvalid format options: #{invalid_options.inspect}"
+            end
+          end
+        end
+
         opts.on "-w",
           "--confidence-level LEVEL",
           ["1", "2", "3"],

--- a/lib/brakeman/report/report_text.rb
+++ b/lib/brakeman/report/report_text.rb
@@ -145,24 +145,45 @@ class Brakeman::Report::Text < Brakeman::Report::Base
   end
 
   def output_warning w
-    out = [
-      label('Confidence', confidence(w.confidence)),
-      label('Category', w.warning_type.to_s),
-      label('Check', w.check.gsub(/^Brakeman::Check/, '')),
+    text_format = tracker.options[:text_fields] ||
+      [:confidence, :category, :check, :message, :code, :file, :line]
+
+    text_format.map do |option|
+      format_line(w, option)
+    end.compact
+  end
+
+  def format_line w, option
+    case option
+    when :confidence
+      label('Confidence', confidence(w.confidence))
+    when :category
+      label('Category', w.warning_type.to_s)
+    when :check
+      label('Check', w.check.gsub(/^Brakeman::Check/, ''))
+    when :message
       label('Message', w.message)
-    ]
-
-    if w.code
-      out << label('Code', format_code(w))
+    when :code
+      if w.code
+        label('Code', format_code(w))
+      end
+    when :file
+      label('File', warning_file(w))
+    when :line
+      if w.line
+        label('Line', w.line)
+      end
+    when :link
+      label('Link', w.link)
+    when :fingerprint
+      label('Fingerprint', w.fingerprint)
+    when :category_id
+      label('Category ID', w.warning_code)
+    when :render_path
+      if w.called_from
+        label('Render Path', w.called_from.join(" > "))
+      end
     end
-
-    out << label('File', warning_file(w))
-
-    if w.line
-      out << label('Line', w.line)
-    end
-
-    out
   end
 
   def double_space title, values

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -342,6 +342,12 @@ class BrakemanOptionsTest < Minitest::Test
     assert_equal :no_summary, options[:summary_only]
   end
 
+  def test_text_report_fields
+    assert_raises OptionParser::ParseError do
+      setup_options_from_input("--text-fields not_a_real_field")
+    end
+  end
+
   private
 
   def setup_options_from_input(*args)

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -344,7 +344,7 @@ class BrakemanOptionsTest < Minitest::Test
 
   def test_text_report_fields
     assert_raises OptionParser::ParseError do
-      setup_options_from_input("--text-fields not_a_real_field")
+      setup_options_from_input("--text-fields", "not_a_real_field")
     end
   end
 


### PR DESCRIPTION
To allow specifying which fields to show in the text report and in what order.

Available options:
* all
* category
* category_id
* check
* code
* confidence
* file
* fingerprint
* line
* link
* message
* render_path

_Please keep in mind the JSON report should be used for structured reports/parsing._