### PR TITLE
Add check for CVE-2020-8159

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -467,7 +467,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
   end
 
   def gemfile_or_environment gem_name = :rails
-    if gem_name and info = tracker.config.get_gem(gem_name)
+    if gem_name and info = tracker.config.get_gem(gem_name.to_sym)
       info
     elsif @app_tree.exists?("Gemfile")
       @app_tree.file_path "Gemfile"

--- a/lib/brakeman/checks/check_page_caching_cve.rb
+++ b/lib/brakeman/checks/check_page_caching_cve.rb
@@ -1,0 +1,37 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckPageCachingCVE < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = "Check for page caching vulnerability (CVE-2020-8159)"
+
+  def run_check
+    gem_name = 'actionpack-page_caching'
+    gem_version = tracker.config.gem_version(gem_name.to_sym)
+    upgrade_version = '1.2.2'
+    cve = 'CVE-2020-8159'
+
+    return unless gem_version and version_between?('0.0.0', '1.2.1', gem_version)
+
+    message = msg("Directory traversal vulnerability in ", msg_version(gem_version, gem_name), " ", msg_cve(cve), ". Upgrade to ", msg_version(upgrade_version, gem_name))
+
+    if uses_caches_page?
+      confidence = :high
+    else
+      confidence = :weak
+    end
+
+    warn :warning_type => 'Directory Traversal',
+      :warning_code => :CVE_2020_8159,
+      :message => message,
+      :confidence => confidence,
+      :link_path => 'https://groups.google.com/d/msg/rubyonrails-security/CFRVkEytdP8/c5gmICECAgAJ',
+      :gem_info => gemfile_or_environment(gem_name)
+  end
+
+  def uses_caches_page?
+    tracker.controllers.any? do |name, controller|
+      controller.options.has_key? :caches_page
+    end
+  end
+end

--- a/lib/brakeman/tracker/config.rb
+++ b/lib/brakeman/tracker/config.rb
@@ -54,7 +54,7 @@ module Brakeman
     end
 
     def gem_version name
-      extract_version @gems.dig(name, :version)
+      extract_version @gems.dig(name.to_sym, :version)
     end
 
     def add_gem name, version, file, line
@@ -67,11 +67,11 @@ module Brakeman
     end
 
     def has_gem? name
-      !!@gems[name]
+      !!@gems[name.to_sym]
     end
 
     def get_gem name
-      @gems[name]
+      @gems[name.to_sym]
     end
 
     def set_rails_version version = nil

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -116,6 +116,7 @@ module Brakeman::WarningCodes
     :mass_assign_permit_all => 112,
     :json_html_escape_config => 113,
     :json_html_escape_module => 114,
+    :CVE_2020_8159 => 115,
 
     :custom_check => 9090,
   }

--- a/test/apps/rails5/Gemfile
+++ b/test/apps/rails5/Gemfile
@@ -21,6 +21,8 @@ gem 'jbuilder', '~> 2.0'
 # Use Puma as the app server
 gem 'puma'
 
+gem 'actionpack-page_caching', '1.2.0'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -13,7 +13,7 @@ class Rails5Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 19,
-      :generic => 21
+      :generic => 22
     }
   end
 
@@ -686,6 +686,19 @@ class Rails5Tests < Minitest::Test
       :message => /^sprockets\ 3\.5\.2\ has\ a\ path\ traversal\ vul/,
       :confidence => 0,
       :relative_path => "Gemfile.lock",
+      :code => nil,
+      :user_input => nil
+  end
+
+  def test_directory_traversal_caching_page_CVE_2020_8159
+    assert_warning :type => :warning,
+      :warning_code => 115,
+      :fingerprint => "4022cb6c8f1bdeb4feec0fe01ba0ddc34441c551ae40c84845d76edb47464b8f",
+      :warning_type => "Directory Traversal",
+      :line => 24,
+      :message => /^Directory\ traversal\ vulnerability\ in\ act/,
+      :confidence => 2,
+      :relative_path => "Gemfile",
       :code => nil,
       :user_input => nil
   end


### PR DESCRIPTION
Category type is debatable. Root issue is directory traversal and then arbitrary file write. Overwriting a template file could get an attacker to remote code execution.

