### PR TITLE
Fix authenticate_or_request_with_http_basic check for passed blocks

### DIFF
--- a/lib/brakeman/checks/check_basic_auth.rb
+++ b/lib/brakeman/checks/check_basic_auth.rb
@@ -57,6 +57,8 @@ class Brakeman::CheckBasicAuth < Brakeman::BaseCheck
 
   # Check if the block of a result contains a comparison of password to string
   def include_password_literal? result
+    return false if result[:block_args].nil?
+
     @password_var = result[:block_args].last
     @include_password = false
     process result[:block]

--- a/test/apps/rails3.1/app/controllers/admin_controller.rb
+++ b/test/apps/rails3.1/app/controllers/admin_controller.rb
@@ -52,4 +52,14 @@ class AdminController < ApplicationController
   def use_lambda_filter
     eval @thing
   end
+
+  def authenticate_token!
+    authenticate_token_or_basic do |username, password|
+      username == "foo"
+    end
+  end
+
+  def authenticate_token_or_basic(&block)
+    authenticate_or_request_with_http_basic(&block)
+  end
 end


### PR DESCRIPTION
### Background

Brakeman version: 4.8.0
Rails version: 4.2.11
Ruby version: 2.5.8

### Issue

Running brakeman against a rails application with a method that calls `authenticate_or_request_with_http_basic` without a non direct call (as in the test).

Stack trace:

```
== Errors ==
Error: undefined method `last' for nil:NilClass
Location: /usr/local/bundle/gems/brakeman-4.8.0/lib/brakeman/checks/check_basic_auth.rb:60:in `include_password_literal?'
```
