### PR TITLE
Treat Dir.glob as safe source of values in guards

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -82,7 +82,6 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   def replace exp, int = 0
     return exp if int > 3
 
-
     if replacement = env[exp] and not duplicate? replacement
       replace(replacement.deep_clone(exp.line), int + 1)
     elsif tracker and replacement = tracker.constant_lookup(exp) and not duplicate? replacement
@@ -731,14 +730,14 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   def array_include_all_literals? exp
     call? exp and
     exp.method == :include? and
-    all_literals? exp.target
+    (all_literals? exp.target or dir_glob? exp.target)
   end
 
   def array_detect_all_literals? exp
     call? exp and
     [:detect, :find].include? exp.method and
     exp.first_arg.nil? and
-    all_literals? exp.target
+    (all_literals? exp.target or dir_glob? exp.target)
   end
 
   #Sets @inside_if = true

--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -198,8 +198,10 @@ class Brakeman::Tracker
     @constants.add name, value, context unless @options[:disable_constant_tracking]
   end
 
+  # This method does not return all constants at this time,
+  # just ones with "simple" values.
   def constant_lookup name
-    @constants.get_literal name unless @options[:disable_constant_tracking]
+    @constants.get_simple_value name unless @options[:disable_constant_tracking]
   end
 
   def find_class name

--- a/lib/brakeman/tracker/constants.rb
+++ b/lib/brakeman/tracker/constants.rb
@@ -1,7 +1,10 @@
 require 'brakeman/processors/output_processor'
+require 'brakeman/util'
 
 module Brakeman
   class Constant
+    include Brakeman::Util
+
     attr_reader :name, :name_array, :file, :value, :context
 
     def initialize name, value, context = {}
@@ -107,13 +110,11 @@ module Brakeman
       @constants[base_name] << Constant.new(name, value, context)
     end
 
-    LITERALS = [:lit, :false, :str, :true, :array, :hash]
-    def literal? exp
-      exp.is_a? Sexp and LITERALS.include? exp.node_type
-    end
-
-    def get_literal name
-      if x = self[name] and literal? x
+    # Returns constant values that are not too complicated.
+    # Right now that means literal values (string, array, etc.)
+    # or calls on Dir.glob(..).whatever.
+    def get_simple_value name
+      if x = self[name] and (literal? x or dir_glob? x)
         x
       else
         nil

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -293,6 +293,22 @@ module Brakeman::Util
     exp.is_a? Sexp and types.include? exp.node_type
   end
 
+  LITERALS = [:lit, :false, :str, :true, :array, :hash]
+
+  def literal? exp
+    exp.is_a? Sexp and LITERALS.include? exp.node_type
+  end
+
+  DIR_CONST = s(:const, :Dir)
+
+  # Dir.glob(...).whatever
+  def dir_glob? exp
+    exp = exp.block_call if node_type? exp, :iter
+    return unless call? exp
+
+    (exp.target == DIR_CONST and exp.method == :glob) or dir_glob? exp.target
+  end
+
   #Returns true if the given _exp_ contains a :class node.
   #
   #Useful for checking if a module is just a module or if it is a namespace.

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -15,4 +15,13 @@ class GroupsController < ApplicationController
     ActiveRecord::Base.connection.execute "SELECT * FROM #{user_input}".squish
     ActiveRecord::Base.connection.execute "SELECT * FROM #{user_input}".strip
   end
+
+  def show
+    template = params[:template]
+
+    # Test file allowlist
+    return redirect_to '/groups' unless FILE_LIST.include? template
+
+    render "groups/#{template}"
+  end
 end

--- a/test/apps/rails6/config/environment.rb
+++ b/test/apps/rails6/config/environment.rb
@@ -1,5 +1,10 @@
 # Load the Rails application.
 require_relative 'application'
 
+# A Dir.glob constant for testing
+FILE_LIST = Dir.glob(File.join(Rails.root, "app", "views", "**", "*")).select do |f|
+  f.end_with? ".html"
+end
+
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/test/tests/constants.rb
+++ b/test/tests/constants.rb
@@ -69,23 +69,23 @@ class ConstantTests < Minitest::Test
   def test_constants_basic_lookup
     @constants.add :A, s(:lit, 1)
 
-    assert_equal s(:lit, 1), @constants.get_literal(s(:const, :A))
+    assert_equal s(:lit, 1), @constants.get_simple_value(s(:const, :A))
   end
 
-  def test_constants_get_literal
+  def test_constants_get_simple_value
     a_b_c = s(:colon2, s(:colon2, s(:const, :A), :B), :C)
     @constants.add :A, s(:lit, 1) # Simple X = 1 uses just symbol for const
     @constants.add a_b_c, s(:lit, 2)
     @constants.add :D, s(:const, :D)
 
-    assert_equal s(:lit, 1), @constants.get_literal(s(:const, :A))
-    assert_equal s(:lit, 2), @constants.get_literal(a_b_c)
-    assert_equal s(:lit, 2), @constants.get_literal(s(:colon2, s(:const, :B), :C))
-    assert_equal s(:lit, 2), @constants.get_literal(s(:colon2, s(:colon2, s(:colon3, :A), :B), :C) )
-    assert_nil @constants.get_literal(s(:colon2, s(:colon3, :B), :C)) # top-level B
-    assert_nil @constants.get_literal(s(:colon2, s(:const, :A), :C))
-    assert_nil @constants.get_literal(s(:colon2, s(:const, :C), :B)) # backwards
-    assert_nil @constants.get_literal(s(:const, :D)) # not a literal
+    assert_equal s(:lit, 1), @constants.get_simple_value(s(:const, :A))
+    assert_equal s(:lit, 2), @constants.get_simple_value(a_b_c)
+    assert_equal s(:lit, 2), @constants.get_simple_value(s(:colon2, s(:const, :B), :C))
+    assert_equal s(:lit, 2), @constants.get_simple_value(s(:colon2, s(:colon2, s(:colon3, :A), :B), :C) )
+    assert_nil @constants.get_simple_value(s(:colon2, s(:colon3, :B), :C)) # top-level B
+    assert_nil @constants.get_simple_value(s(:colon2, s(:const, :A), :C))
+    assert_nil @constants.get_simple_value(s(:colon2, s(:const, :C), :B)) # backwards
+    assert_nil @constants.get_simple_value(s(:const, :D)) # not a literal
   end
 
   def test_constants_lookup

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -263,6 +263,19 @@ class Rails6Tests < Minitest::Test
       :user_input => s(:call, s(:params), :require, s(:str, "name"))
   end
 
+  def test_dynamic_render_path_dir_glob_filter
+    assert_no_warning :type => :warning,
+      :warning_code => 15,
+      :fingerprint => "3ca5600705cf1e73b6213275bb2206480867176a80f0f1135a100019a29cb850",
+      :warning_type => "Dynamic Render Path",
+      :line => 25,
+      :message => /^Render\ path\ contains\ parameter\ value/,
+      :confidence => 1,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:render, :action, s(:dstr, "groups/", s(:evstr, s(:call, s(:params), :[], s(:lit, :template)))), s(:hash)),
+      :user_input => s(:call, s(:params), :[], s(:lit, :template))
+  end
+
   def test_mass_assignment_permit_bang_1
     assert_warning :type => :warning,
       :warning_code => 70,


### PR DESCRIPTION
For example, this should not warn about a "Dynamic Render Path":

```ruby
  def show
    template = params[:template]
    files = Dir.glob("/some/template/path/*")

    return redirect_to '/groups' unless files.include? template

    render "groups/#{template}"
  end
```

(This is not working nor recommended code :smile:)