### PR TITLE
Updated CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   default: &default
     docker:
-      - image: circleci/ruby:latest
+      - image: cimg/ruby:latest
     steps:
       - checkout
       - run: bundle check || bundle install
@@ -39,19 +39,19 @@ jobs:
   test-2-4:
     <<: *default
     docker:
-      - image: circleci/ruby:2.4
+      - image: cimg/ruby:2.4
   test-2-5:
     <<: *default
     docker:
-      - image: circleci/ruby:2.5
+      - image: cimg/ruby:2.5
   test-2-6:
     <<: *default
     docker:
-      - image: circleci/ruby:2.6
+      - image: cimg/ruby:2.6
   test-latest:
     <<: *default
     docker:
-      - image: circleci/ruby:latest
+      - image: cimg/ruby:latest
   upload-coverage:
     <<: *default
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   default: &default
     docker:
-      - image: cimg/ruby:latest
+      - image: circleci/ruby:latest
     steps:
       - checkout
       - run: bundle check || bundle install


### PR DESCRIPTION
I guess we're supposed to use these now?

Ruby 2.3 and "latest" are not available with the `cimg/ruby` image, so keeping those on the older ones for now.