### PR TITLE
Do not warn about mass assignment with params.permit!.slice()

### DIFF
--- a/lib/brakeman/checks/check_mass_assignment.rb
+++ b/lib/brakeman/checks/check_mass_assignment.rb
@@ -160,8 +160,8 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
   # Look for and warn about uses of Parameters#permit! for mass assignment
   def check_permit!
     tracker.find_call(:method => :permit!, :nested => true).each do |result|
-      if params? result[:call].target and not result[:chain].include? :slice
-        unless inside_safe_method? result
+      if params? result[:call].target
+        unless inside_safe_method? result or calls_slice? result
           warn_on_permit! result
         end
       end
@@ -174,6 +174,11 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
 
     call? parent_call and
       parent_call.method.match(/_path$/)
+  end
+
+  def calls_slice? result
+    result[:chain].include? :slice or
+      (result[:full_call] and result[:full_call][:chain].include? :slice)
   end
 
   # Look for actual use of params in mass assignment to avoid

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -28,4 +28,8 @@ class GroupsController < ApplicationController
   def permit_bang_path
     redirect_to groups_path(params.permit!)
   end
+
+  def permit_bang_slice
+    params.permit!.slice(:whatever)
+  end
 end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -328,6 +328,19 @@ class Rails6Tests < Minitest::Test
       :user_input => nil
   end
 
+  def test_mass_assignment_permit_bang_slice_false_positive
+    assert_no_warning :type => :warning,
+      :warning_code => 70,
+      :fingerprint => "5c1aa277503e9c28dda97731136240ab07800348c4ac296c25789d65bd158373",
+      :warning_type => "Mass Assignment",
+      :line => 33,
+      :message => /^Parameters\ should\ be\ whitelisted\ for\ mas/,
+      :confidence => 1,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:params), :permit!),
+      :user_input => nil
+  end
+
   def test_secrets_file_1
     assert_warning :type => :warning,
       :warning_code => 101,


### PR DESCRIPTION
Avoid warning about mass assignment when `slice` is called in conjunction with `permit!`.

A previous change (#867) stopped warning about `params.slice.permit!` but `params.permit!.slice` still generated a warning.

This PR also adds new information to call site matches. Now an intermediate link in a call chain (e.g. `a.b` of `a.b.c`) can access a reference to the full call (`a.b.c`). This should enable better matching in the future!

/cc @eliblock