### PR TITLE
Add --ensure-ignore-notes flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 test/coverage/
 .bundle
 bundle
+*.gem

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -502,17 +502,16 @@ module Brakeman
     end
   end
 
-  # Returns false if the specified ignore file exists and contains an ignored
-  # warning without a note.
-  # Returns true otherwise.
-  def self.all_ignore_file_entries_have_notes? file
-    return true unless file
+  # Returns an array of alert fingerprints for any ignored warnings without
+  # notes found in the specified ignore file (if it exists).
+  def self.ignore_file_entries_with_empty_notes file
+    return [] unless file
 
     require 'brakeman/report/ignore/config'
 
     config = IgnoreConfig.new(file, nil)
     config.read_from_file
-    config.already_ignored_entries_with_empty_notes.empty?
+    config.already_ignored_entries_with_empty_notes.map { |i| i[:fingerprint] }
   end
 
   def self.filter_warnings tracker, options

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -512,7 +512,7 @@ module Brakeman
 
     config = IgnoreConfig.new(file, nil)
     config.read_from_file
-    config.already_ignored_entries_without_notes.empty?
+    config.already_ignored_entries_with_empty_notes.empty?
   end
 
   def self.filter_warnings tracker, options

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -508,6 +508,8 @@ module Brakeman
   def self.all_ignore_file_entries_have_notes? file
     return true unless file
 
+    require 'brakeman/report/ignore/config'
+
     config = IgnoreConfig.new(file, nil)
     config.read_from_file
     config.already_ignored_entries_without_notes.empty?

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -20,6 +20,10 @@ module Brakeman
   #option is set
   Errors_Found_Exit_Code = 7
 
+  #Exit code returned when an ignored warning has no note and
+  #--ensure-ignore-notes is set
+  Empty_Ignore_Note_Exit_Code = 8
+
   @debug = false
   @quiet = false
   @loaded_dependencies = []
@@ -496,6 +500,17 @@ module Brakeman
         exit!(-1)
       end
     end
+  end
+
+  # Returns false if the specified ignore file exists and contains an ignored
+  # warning without a note.
+  # Returns true otherwise.
+  def self.all_ignore_file_entries_have_notes? file
+    return true unless file
+
+    config = IgnoreConfig.new(file, nil)
+    config.read_from_file
+    config.already_ignored_entries_without_notes.empty?
   end
 
   def self.filter_warnings tracker, options

--- a/lib/brakeman/commandline.rb
+++ b/lib/brakeman/commandline.rb
@@ -127,6 +127,7 @@ module Brakeman
 
         if tracker.options[:ensure_ignore_notes] and
            not Brakeman::all_ignore_file_entries_have_notes? tracker.ignored_filter&.file
+
           quit Brakeman::Empty_Ignore_Note_Exit_Code,
                'error: notes required for all ignored warnings when --ensure-ignore-notes is set'
         end

--- a/lib/brakeman/commandline.rb
+++ b/lib/brakeman/commandline.rb
@@ -125,11 +125,16 @@ module Brakeman
           quit Brakeman::Errors_Found_Exit_Code
         end
 
-        if tracker.options[:ensure_ignore_notes] and
-           not Brakeman::all_ignore_file_entries_have_notes? tracker.ignored_filter&.file
+        if tracker.options[:ensure_ignore_notes]
+          fingerprints = Brakeman::ignore_file_entries_with_empty_notes tracker.ignored_filter&.file
 
-          quit Brakeman::Empty_Ignore_Note_Exit_Code,
-               'error: notes required for all ignored warnings when --ensure-ignore-notes is set'
+          unless fingerprints.empty?
+            quit Brakeman::Empty_Ignore_Note_Exit_Code,
+                 'Error: notes required for all ignored warnings when ' \
+                 '--ensure-ignore-notes is set. No notes provided for these ' \
+                 'alerts: ' \
+                 "#{fingerprints}"
+          end
         end
       end
 

--- a/lib/brakeman/commandline.rb
+++ b/lib/brakeman/commandline.rb
@@ -102,6 +102,13 @@ module Brakeman
           app_path = "."
         end
 
+        if options[:ensure_ignore_notes] and options[:previous_results_json]
+          warn '[Notice] --ensure-ignore-notes may not be used at the same ' \
+               'time as --compare. Deactivating --ensure-ignore-notes. ' \
+               'Please see `brakeman --help` for valid options'
+          options[:ensure_ignore_notes] = false
+        end
+
         return options, app_path
       end
 

--- a/lib/brakeman/commandline.rb
+++ b/lib/brakeman/commandline.rb
@@ -115,7 +115,7 @@ module Brakeman
 
       # Runs a regular report based on the options provided.
       def regular_report options
-        tracker = run_brakeman options 
+        tracker = run_brakeman options
 
         if tracker.options[:exit_on_warn] and not tracker.filtered_warnings.empty?
           quit Brakeman::Warnings_Found_Exit_Code
@@ -123,6 +123,12 @@ module Brakeman
 
         if tracker.options[:exit_on_error] and tracker.errors.any?
           quit Brakeman::Errors_Found_Exit_Code
+        end
+
+        if tracker.options[:ensure_ignore_notes] and
+           not Brakeman::all_ignore_file_entries_have_notes? tracker.ignored_filter&.file
+          quit Brakeman::Empty_Ignore_Note_Exit_Code,
+               'error: notes required for all ignored warnings when --ensure-ignore-notes is set'
         end
       end
 

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -67,7 +67,7 @@ module Brakeman::Options
           options[:ensure_latest] = true
         end
 
-        opts.on "--ensure-ignore-notes", "Fail when an ignored warnings does not include a note. No effect if used with --compare" do
+        opts.on "--ensure-ignore-notes", "Fail when an ignored warnings does not include a note" do
           options[:ensure_ignore_notes] = true
         end
 
@@ -329,7 +329,7 @@ module Brakeman::Options
           options[:min_confidence] =  3 - level.to_i
         end
 
-        opts.on "--compare FILE", "Compare the results of a previous Brakeman scan (only JSON is supported). Deactivates --ensure-ignore-notes" do |file|
+        opts.on "--compare FILE", "Compare the results of a previous Brakeman scan (only JSON is supported)" do |file|
           options[:previous_results_json] = File.expand_path(file)
         end
 

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -67,6 +67,10 @@ module Brakeman::Options
           options[:ensure_latest] = true
         end
 
+        opts.on "--ensure-ignore-notes", "Fail when an ignored warnings does not include a note. No effect if used with --compare" do
+          options[:ensure_ignore_notes] = true
+        end
+
         opts.on "-3", "--rails3", "Force Rails 3 mode" do
           options[:rails3] = true
         end
@@ -325,7 +329,7 @@ module Brakeman::Options
           options[:min_confidence] =  3 - level.to_i
         end
 
-        opts.on "--compare FILE", "Compare the results of a previous Brakeman scan (only JSON is supported)" do |file|
+        opts.on "--compare FILE", "Compare the results of a previous Brakeman scan (only JSON is supported). Deactivates --ensure-ignore-notes" do |file|
           options[:previous_results_json] = File.expand_path(file)
         end
 

--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -94,6 +94,10 @@ module Brakeman
       end
     end
 
+    def already_ignored_entries_without_notes
+      @already_ignored.filter_map { |i| i if !i[:note] || i[:note] == '' }
+    end
+
     # Read configuration to file
     def read_from_file file = @file
       if File.exist? file

--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -95,7 +95,7 @@ module Brakeman
     end
 
     def already_ignored_entries_without_notes
-      @already_ignored.filter_map { |i| i if !i[:note] || i[:note] == '' }
+      @already_ignored.map { |i| i if !i[:note] || i[:note] == '' }.compact
     end
 
     # Read configuration to file

--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -94,8 +94,8 @@ module Brakeman
       end
     end
 
-    def already_ignored_entries_without_notes
-      @already_ignored.map { |i| i if !i[:note] || i[:note] == '' }.compact
+    def already_ignored_entries_with_empty_notes
+      @already_ignored.select { |i| i if i[:note].strip.empty? }
     end
 
     # Read configuration to file

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -372,19 +372,24 @@ class ConfigTests < Minitest::Test
     end
   end
 
-  def test_all_ignore_file_entries_have_notes?
-    assert Brakeman.all_ignore_file_entries_have_notes?(nil)
+  def test_ignore_file_entries_with_empty_notes
+    assert Brakeman.ignore_file_entries_with_empty_notes(nil).empty?
 
     ignore_file_missing_notes = Tempfile.new('brakeman.ignore')
     ignore_file_missing_notes.write IGNORE_WITH_MISSING_NOTES_JSON
     ignore_file_missing_notes.close
-    refute Brakeman.all_ignore_file_entries_have_notes?(ignore_file_missing_notes.path)
+    assert_equal(
+      Brakeman.ignore_file_entries_with_empty_notes(ignore_file_missing_notes.path).to_set,
+      [
+        '006ac5fe3834bf2e73ee51b67eb111066f618be46e391d493c541ea2a906a82f',
+      ].to_set
+    )
     ignore_file_missing_notes.unlink
 
     ignore_file_with_notes = Tempfile.new('brakeman.ignore')
     ignore_file_with_notes.write IGNORE_WITH_NOTES_JSON
     ignore_file_with_notes.close
-    assert Brakeman.all_ignore_file_entries_have_notes?(ignore_file_with_notes.path)
+    assert Brakeman.ignore_file_entries_with_empty_notes(ignore_file_with_notes.path).empty?
     ignore_file_with_notes.unlink
   end
 

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -372,6 +372,22 @@ class ConfigTests < Minitest::Test
     end
   end
 
+  def test_all_ignore_file_entries_have_notes?
+    assert Brakeman.all_ignore_file_entries_have_notes?(nil)
+
+    ignore_file_missing_notes = Tempfile.new('brakeman.ignore')
+    ignore_file_missing_notes.write IGNORE_WITH_MISSING_NOTES_JSON
+    ignore_file_missing_notes.close
+    refute Brakeman.all_ignore_file_entries_have_notes?(ignore_file_missing_notes.path)
+    ignore_file_missing_notes.unlink
+
+    ignore_file_with_notes = Tempfile.new('brakeman.ignore')
+    ignore_file_with_notes.write IGNORE_WITH_NOTES_JSON
+    ignore_file_with_notes.close
+    assert Brakeman.all_ignore_file_entries_have_notes?(ignore_file_with_notes.path)
+    ignore_file_with_notes.unlink
+  end
+
   def test_dump_config_with_file
     test_file = "test.cfg"
     options = {:create_config => test_file, :test_option => "test"}
@@ -385,6 +401,84 @@ class ConfigTests < Minitest::Test
   ensure
     assert File.delete test_file
   end
+
+  IGNORE_WITH_MISSING_NOTES_JSON = <<~JSON.freeze
+    {
+      "ignored_warnings": [
+        {
+          "warning_type": "Remote Code Execution",
+          "warning_code": 25,
+          "fingerprint": "006ac5fe3834bf2e73ee51b67eb111066f618be46e391d493c541ea2a906a82f",
+          "check_name": "Deserialize",
+          "message": "`Oj.load` called with parameter value",
+          "file": "app/controllers/users_controller.rb",
+          "line": 52,
+          "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+          "code": "Oj.load(params[:json], :mode => :object)",
+          "render_path": null,
+          "location": {
+            "type": "method",
+            "class": "UsersController",
+            "method": "some_api"
+          },
+          "user_input": "params[:json]",
+          "confidence": "High",
+          "note": ""
+        },
+        {
+          "warning_type": "Remote Code Execution",
+          "warning_code": 25,
+          "fingerprint": "97ecaa5677c8eadaed09217a704e59092921fab24cc751e05dfb7b167beda2cf",
+          "check_name": "Deserialize",
+          "message": "`Oj.load` called with parameter value",
+          "file": "app/controllers/users_controller.rb",
+          "line": 51,
+          "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+          "code": "Oj.load(params[:json])",
+          "render_path": null,
+          "location": {
+            "type": "method",
+            "class": "UsersController",
+            "method": "some_api"
+          },
+          "user_input": "params[:json]",
+          "confidence": "High",
+          "note": "Here's a note!"
+        }
+      ],
+      "updated": "2019-04-02 12:15:05 -0700",
+      "brakeman_version": "4.5.0"
+    }
+  JSON
+
+  IGNORE_WITH_NOTES_JSON = <<~JSON.freeze
+    {
+      "ignored_warnings": [
+        {
+          "warning_type": "Remote Code Execution",
+          "warning_code": 25,
+          "fingerprint": "006ac5fe3834bf2e73ee51b67eb111066f618be46e391d493c541ea2a906a82f",
+          "check_name": "Deserialize",
+          "message": "`Oj.load` called with parameter value",
+          "file": "app/controllers/users_controller.rb",
+          "line": 52,
+          "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+          "code": "Oj.load(params[:json], :mode => :object)",
+          "render_path": null,
+          "location": {
+            "type": "method",
+            "class": "UsersController",
+            "method": "some_api"
+          },
+          "user_input": "params[:json]",
+          "confidence": "High",
+          "note": "Note here."
+        }
+      ],
+      "updated": "2019-04-02 12:15:05 -0700",
+      "brakeman_version": "4.5.0"
+    }
+  JSON
 end
 
 class GemProcessorTests < Minitest::Test

--- a/test/tests/commandline.rb
+++ b/test/tests/commandline.rb
@@ -1,5 +1,6 @@
 require_relative '../test'
 require 'brakeman/commandline'
+require 'tempfile'
 
 class CLExit < StandardError
   attr_reader :exit_code
@@ -27,6 +28,8 @@ class CommandlineTests < Minitest::Test
     rescue CLExit => e
       assert_equal exit_code, e.exit_code
       assert_equal message, e.message if message
+    else
+      assert_equal exit_code, 0
     end
   end
 
@@ -74,7 +77,7 @@ class CommandlineTests < Minitest::Test
 
   def test_default_scan_path
     options = {}
-    
+
     TestCommandline.set_options options
 
     assert_equal ".", options[:app_path]
@@ -131,4 +134,106 @@ class CommandlineTests < Minitest::Test
       scan_app "-t", "None"
     end
   end
+
+  def test_ensure_ignore_notes
+    ignore_file_missing_notes = Tempfile.new('brakeman.ignore')
+    ignore_file_missing_notes.write IGNORE_WITH_MISSING_NOTES_JSON
+    ignore_file_missing_notes.close
+
+    assert_exit Brakeman::Empty_Ignore_Note_Exit_Code do
+      scan_app '--no-exit-on-warn',
+               '--ensure-ignore-notes',
+               '-i', ignore_file_missing_notes.path.to_s
+    end
+    ignore_file_missing_notes.unlink
+
+    ignore_file_with_notes = Tempfile.new('brakeman.ignore')
+    ignore_file_with_notes.write IGNORE_WITH_NOTES_JSON
+    ignore_file_with_notes.close
+
+    assert_exit do
+      scan_app '--no-exit-on-warn',
+               '--ensure-ignore-notes',
+               '-i', ignore_file_with_notes.path.to_s
+    end
+    ignore_file_with_notes.unlink
+  end
+
+  IGNORE_WITH_MISSING_NOTES_JSON = <<~JSON.freeze
+    {
+      "ignored_warnings": [
+        {
+          "warning_type": "Remote Code Execution",
+          "warning_code": 25,
+          "fingerprint": "006ac5fe3834bf2e73ee51b67eb111066f618be46e391d493c541ea2a906a82f",
+          "check_name": "Deserialize",
+          "message": "`Oj.load` called with parameter value",
+          "file": "app/controllers/users_controller.rb",
+          "line": 52,
+          "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+          "code": "Oj.load(params[:json], :mode => :object)",
+          "render_path": null,
+          "location": {
+            "type": "method",
+            "class": "UsersController",
+            "method": "some_api"
+          },
+          "user_input": "params[:json]",
+          "confidence": "High",
+          "note": ""
+        },
+        {
+          "warning_type": "Remote Code Execution",
+          "warning_code": 25,
+          "fingerprint": "97ecaa5677c8eadaed09217a704e59092921fab24cc751e05dfb7b167beda2cf",
+          "check_name": "Deserialize",
+          "message": "`Oj.load` called with parameter value",
+          "file": "app/controllers/users_controller.rb",
+          "line": 51,
+          "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+          "code": "Oj.load(params[:json])",
+          "render_path": null,
+          "location": {
+            "type": "method",
+            "class": "UsersController",
+            "method": "some_api"
+          },
+          "user_input": "params[:json]",
+          "confidence": "High",
+          "note": "Here's a note!"
+        }
+      ],
+      "updated": "2019-04-02 12:15:05 -0700",
+      "brakeman_version": "4.5.0"
+    }
+  JSON
+
+  IGNORE_WITH_NOTES_JSON = <<~JSON.freeze
+    {
+      "ignored_warnings": [
+        {
+          "warning_type": "Remote Code Execution",
+          "warning_code": 25,
+          "fingerprint": "006ac5fe3834bf2e73ee51b67eb111066f618be46e391d493c541ea2a906a82f",
+          "check_name": "Deserialize",
+          "message": "`Oj.load` called with parameter value",
+          "file": "app/controllers/users_controller.rb",
+          "line": 52,
+          "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+          "code": "Oj.load(params[:json], :mode => :object)",
+          "render_path": null,
+          "location": {
+            "type": "method",
+            "class": "UsersController",
+            "method": "some_api"
+          },
+          "user_input": "params[:json]",
+          "confidence": "High",
+          "note": "Note here."
+        }
+      ],
+      "updated": "2019-04-02 12:15:05 -0700",
+      "brakeman_version": "4.5.0"
+    }
+  JSON
 end

--- a/test/tests/commandline.rb
+++ b/test/tests/commandline.rb
@@ -135,6 +135,14 @@ class CommandlineTests < Minitest::Test
     end
   end
 
+  def test_compare_deactivates_ensure_ignore_notes
+    opts, = Brakeman::Commandline.parse_options [
+      '--ensure-ignore-notes',
+      '--compare', 'foo.json',
+    ]
+    assert_equal false, opts[:ensure_ignore_notes]
+  end
+
   def test_ensure_ignore_notes
     ignore_file_missing_notes = Tempfile.new('brakeman.ignore')
     ignore_file_missing_notes.write IGNORE_WITH_MISSING_NOTES_JSON

--- a/test/tests/ignore.rb
+++ b/test/tests/ignore.rb
@@ -216,10 +216,10 @@ class IgnoreConfigTests < Minitest::Test
     end
   end
 
-  def test_already_ignored_entries_without_notes
+  def test_already_ignored_entries_with_empty_notes
     require 'set'
     assert_equal(
-      config.already_ignored_entries_without_notes.map { |i| i[:fingerprint] }.to_set,
+      config.already_ignored_entries_with_empty_notes.map { |i| i[:fingerprint] }.to_set,
       [
         '3bc375c9cb79d8bcd9e7f1c09a574fa3deeab17f924cf20455cbd4c15e9c66eb',
         '006ac5fe3834bf2e73ee51b67eb111066f618be46e391d493c541ea2a906a82f',

--- a/test/tests/ignore.rb
+++ b/test/tests/ignore.rb
@@ -216,6 +216,17 @@ class IgnoreConfigTests < Minitest::Test
     end
   end
 
+  def test_already_ignored_entries_without_notes
+    require 'set'
+    assert_equal(
+      config.already_ignored_entries_without_notes.map { |i| i[:fingerprint] }.to_set,
+      [
+        '3bc375c9cb79d8bcd9e7f1c09a574fa3deeab17f924cf20455cbd4c15e9c66eb',
+        '006ac5fe3834bf2e73ee51b67eb111066f618be46e391d493c541ea2a906a82f',
+      ].to_set
+    )
+  end
+
   private
 
   def assert_relative path


### PR DESCRIPTION
Add a command line option, `--ensure-ignore-notes`, which causes Brakeman to exit with an error if the used ignore file contains any ignored warnings with blank notes.

This flag re-checks the ignore file after all other filtering operations, so it is safe to use in conjunction with `-I`.

This flag has no effect when used in conjunction with `--compare`.