### PR TITLE
Add check for CVE-2020-8166

### DIFF
--- a/lib/brakeman/checks/check_csrf_token_forgery_cve.rb
+++ b/lib/brakeman/checks/check_csrf_token_forgery_cve.rb
@@ -1,0 +1,28 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckCSRFTokenForgeryCVE < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = "Checks for versions with CSRF token forgery vulnerability (CVE-2020-8166)"
+
+  def run_check
+    fix_version = case
+      when version_between?('0.0.0', '5.2.4.2')
+        '5.2.4.3'
+      when version_between?('6.0.0', '6.0.3')
+        '6.0.3.1'
+      else
+        nil
+      end
+
+    if fix_version
+      warn :warning_type => "Cross-Site Request Forgery",
+        :warning_code => :CVE_2020_8166,
+        :message => msg(msg_version(rails_version), " has a vulnerability that may allow CSRF token forgery. Upgrade to ", msg_version(fix_version), " or patch"),
+        :confidence => :medium,
+        :gem_info => gemfile_or_environment,
+        :link => "https://groups.google.com/g/rubyonrails-security/c/NOjKiGeXUgw"
+    end
+  end
+end
+

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -117,6 +117,7 @@ module Brakeman::WarningCodes
     :json_html_escape_config => 113,
     :json_html_escape_module => 114,
     :CVE_2020_8159 => 115,
+    :CVE_2020_8166 => 116,
 
     :custom_check => 9090,
   }

--- a/test/tests/cves.rb
+++ b/test/tests/cves.rb
@@ -328,4 +328,14 @@ class CVETests < Minitest::Test
     assert_fixed 1
     assert_new 1
   end
+
+  def test_CVE_2020_8166
+    before_rescan_of "Gemfile.lock", "rails5.2" do
+      replace "Gemfile.lock", " rails (5.2.0.beta2)", " rails (5.2.4.3)"
+    end
+
+    assert_new 0
+    assert_version "5.2.4.3"
+    assert_no_warning type: :controller, :warning_code => 116
+  end
 end

--- a/test/tests/markdown_output.rb
+++ b/test/tests/markdown_output.rb
@@ -10,6 +10,6 @@ class TestMarkdownOutput < Minitest::Test
   end
 
   def test_reported_warnings
-    assert_equal 172, @@report.lines.to_a.count
+    assert_equal 173, @@report.lines.to_a.count
   end
 end

--- a/test/tests/only_files_option.rb
+++ b/test/tests/only_files_option.rb
@@ -10,7 +10,7 @@ class OnlyFilesOptionTests < Minitest::Test
       :controller => 8,
       :model => 0,
       :template => 1,
-      :generic => 15 }
+      :generic => 16 }
 
     if RUBY_PLATFORM == 'java'
       @expected[:generic] += 1

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -14,7 +14,7 @@ class Rails2Tests < Minitest::Test
       :controller => 1,
       :model => 4,
       :template => 47,
-      :generic => 58 }
+      :generic => 59 }
   end
 
   def report
@@ -1506,7 +1506,7 @@ class Rails2WithOptionsTests < Minitest::Test
       :controller => 1,
       :model => 4,
       :template => 47,
-      :generic => 58 }
+      :generic => 59 }
   end
 
   def report

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -14,7 +14,7 @@ class Rails3Tests < Minitest::Test
       :controller => 1,
       :model => 9,
       :template => 41,
-      :generic => 74
+      :generic => 75
     }
 
     if RUBY_PLATFORM == 'java'

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -13,7 +13,7 @@ class Rails31Tests < Minitest::Test
       :model => 3,
       :template => 23,
       :controller => 4,
-      :generic => 87 }
+      :generic => 88 }
   end
 
   def test_without_protection

--- a/test/tests/rails32.rb
+++ b/test/tests/rails32.rb
@@ -14,7 +14,7 @@ class Rails32Tests < Minitest::Test
       :controller => 8,
       :model => 5,
       :template => 11,
-      :generic => 21 }
+      :generic => 22 }
 
     if RUBY_PLATFORM == 'java'
       @expected[:generic] += 1

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Minitest::Test
       :controller => 0,
       :model => 3,
       :template => 8,
-      :generic => 86
+      :generic => 87
     }
   end
 

--- a/test/tests/rails4_with_engines.rb
+++ b/test/tests/rails4_with_engines.rb
@@ -9,7 +9,7 @@ class Rails4WithEnginesTests < Minitest::Test
       :controller => 2,
       :model => 5,
       :template => 12,
-      :generic => 13 }
+      :generic => 14 }
   end
 
   def report

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -13,7 +13,7 @@ class Rails5Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 19,
-      :generic => 22
+      :generic => 23
     }
   end
 

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -13,7 +13,7 @@ class Rails52Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 5,
-      :generic => 22
+      :generic => 23
     }
   end
 

--- a/test/tests/rails_with_xss_plugin.rb
+++ b/test/tests/rails_with_xss_plugin.rb
@@ -9,7 +9,7 @@ class RailsWithXssPluginTests < Minitest::Test
       :controller => 1,
       :model => 4,
       :template => 4,
-      :generic => 30 }
+      :generic => 31 }
   end
 
   def report

--- a/test/tests/tabs_output.rb
+++ b/test/tests/tabs_output.rb
@@ -10,6 +10,6 @@ class TestTabsOutput < Minitest::Test
   end
 
   def test_reported_warnings
-    assert_equal 110, @@report.lines.to_a.count
+    assert_equal 111, @@report.lines.to_a.count
   end
 end


### PR DESCRIPTION
This adds a simple check for the CSRF token forgery issue, CVE-2020-8166 (https://groups.google.com/g/rubyonrails-security/c/NOjKiGeXUgw).

It's based purely on Rails version #s & I used https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_basic_auth_timing_attack.rb for inspiration.