### PR TITLE
Fix safe_yaml YAML.load false positive

### DIFF
--- a/lib/brakeman/checks/check_deserialize.rb
+++ b/lib/brakeman/checks/check_deserialize.rb
@@ -27,6 +27,8 @@ class Brakeman::CheckDeserialize < Brakeman::BaseCheck
           check_deserialize result, :YAML
         end
       end
+    else
+      check_methods :YAML, :load
     end
   end
 

--- a/test/apps/rails6/Gemfile
+++ b/test/apps/rails6/Gemfile
@@ -28,6 +28,8 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.1', require: false
 
+gem 'safe_yaml'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -32,4 +32,10 @@ class GroupsController < ApplicationController
   def permit_bang_slice
     params.permit!.slice(:whatever)
   end
+
+  def safeish_yaml_load
+    YAML.load(params[:yaml_stuff], safe: true)
+    YAML.load(params[:yaml_stuff], safe: false) # not safe
+    YAML.load(params[:yaml_stuff]) # not safe
+  end
 end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,7 +13,7 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 18
+      :generic => 20
     }
   end
 
@@ -171,6 +171,45 @@ class Rails6Tests < Minitest::Test
       :relative_path => "config/initializers/cookies_serializer.rb",
       :code => s(:attrasgn, s(:call, s(:call, s(:call, s(:const, :Rails), :application), :config), :action_dispatch), :cookies_serializer=, s(:lit, :marshal)),
       :user_input => nil
+  end
+
+  def test_safe_yaml_load_option
+    assert_no_warning :type => :warning,
+      :warning_code => 25,
+      :fingerprint => "bf38405dcc489a459957bf515cb9f078686bb9316cc3d1f421c61c330a9005ec",
+      :warning_type => "Remote Code Execution",
+      :line => 37,
+      :message => /^`YAML\.load`\ called\ with\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:const, :YAML), :load, s(:call, s(:params), :[], s(:lit, :yaml_stuff)), s(:hash, s(:lit, :safe), s(:true))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :yaml_stuff))
+  end
+
+  def test_safe_yaml_load_option_false
+    assert_warning :type => :warning,
+      :warning_code => 25,
+      :fingerprint => "2798cec372112fdecfadf2cb30b41635742d93c5b0bfc0ba71a3f69eb21b7f48",
+      :warning_type => "Remote Code Execution",
+      :line => 38,
+      :message => /^`YAML\.load`\ called\ with\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:const, :YAML), :load, s(:call, s(:params), :[], s(:lit, :yaml_stuff)), s(:hash, s(:lit, :safe), s(:false))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :yaml_stuff))
+  end
+
+  def test_safe_yaml_load_option_missing
+    assert_warning :type => :warning,
+      :warning_code => 25,
+      :fingerprint => "baffe1ec42a14c076b7c7bf676f833a397b879ee8c8ae4bc697b2bcef0355399",
+      :warning_type => "Remote Code Execution",
+      :line => 39,
+      :message => /^`YAML\.load`\ called\ with\ parameter\ value/,
+      :confidence => 0,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:const, :YAML), :load, s(:call, s(:params), :[], s(:lit, :yaml_stuff))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :yaml_stuff))
   end
 
   def test_dup_call


### PR DESCRIPTION
If the `safe_yaml` gem is used, do not warn about deserialization with `YAML.load(..., safe: true)`.