### PR TITLE
Add SARIF output format

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -237,6 +237,8 @@ module Brakeman
       [:to_table]
     when :junit, :to_junit
       [:to_junit]
+    when :sarif, :to_sarif
+      [:to_sarif]
     else
       [:to_text]
     end
@@ -266,6 +268,8 @@ module Brakeman
         :to_table
       when /\.junit$/i
         :to_junit
+      when /\.sarif$/i
+        :to_sarif
       else
         :to_text
       end

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -229,7 +229,7 @@ module Brakeman::Options
 
         opts.on "-f",
           "--format TYPE",
-          [:pdf, :text, :html, :csv, :tabs, :json, :markdown, :codeclimate, :cc, :plain, :table, :junit],
+          [:pdf, :text, :html, :csv, :tabs, :json, :markdown, :codeclimate, :cc, :plain, :table, :junit, :sarif],
           "Specify output formats. Default is text" do |type|
 
           type = "s" if type == :text

--- a/lib/brakeman/report.rb
+++ b/lib/brakeman/report.rb
@@ -43,6 +43,8 @@ class Brakeman::Report
     when :to_junit
       require_report 'junit'
       Brakeman::Report::JUnit
+    when :to_sarif
+      return self.to_sarif
     else
       raise "Invalid format: #{format}. Should be one of #{VALID_FORMATS.inspect}"
     end
@@ -84,6 +86,11 @@ class Brakeman::Report
 
   alias to_plain to_text
   alias to_s to_text
+
+  def to_sarif
+    require_report 'sarif'
+    generate Brakeman::Report::SARIF
+  end
 
   def generate reporter
     reporter.new(@tracker).generate_report

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -1,0 +1,114 @@
+class Brakeman::Report::SARIF < Brakeman::Report::Base
+  def generate_report
+    sarif_log = {
+      :version => '2.1.0',
+      :$schema => 'https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json',
+      :runs => runs,
+    }
+    JSON.pretty_generate sarif_log
+  end
+
+  def runs
+    [
+      {
+        :tool => {
+          :driver => {
+            :name => 'Brakeman',
+            :informationUri => 'https://brakemanscanner.org',
+            :semanticVersion => Brakeman::Version,
+            :rules => rules,
+          },
+        },
+        :results => results,
+      },
+    ]
+  end
+
+  def rules
+    @rules ||= unique_warnings_by_warning_code.map do |warning|
+      rule_id = render_id warning
+      check_name = warning.check.gsub(/^Brakeman::Check/, '')
+      check_description = render_message check_descriptions[check_name]
+      {
+        :id => rule_id,
+        :name => "#{check_name}/#{warning.warning_type}",
+        :fullDescription => {
+          :text => check_description,
+        },
+        :helpUri => warning.link,
+        :help => {
+          :text => "More info: #{warning.link}.",
+          :markdown => "[More info](#{warning.link}).",
+        },
+        :properties => {
+          :tags => [check_name],
+        },
+      }
+    end
+  end
+
+  def results
+    @results ||= all_warnings.map do |warning|
+      rule_id = render_id warning
+      result_level = infer_level warning
+      message_text = render_message warning.message.to_s
+      result = {
+        :ruleId => rule_id,
+        :ruleIndex => rules.index { |r| r[:id] == rule_id },
+        :level => result_level,
+        :message => {
+          :text => message_text,
+        },
+        :locations => [
+          :physicalLocation => {
+            :artifactLocation => {
+              :uri => warning.file.relative,
+              :uriBaseId => '%SRCROOT%',
+            },
+            :region => {
+              :startLine => warning.line.is_a?(Integer) ? warning.line : 1,
+            },
+          },
+        ],
+      }
+
+      result
+    end
+  end
+
+  # Returns a hash of all check descriptions, keyed by check namne
+  def check_descriptions
+    @check_descriptions ||= Brakeman::Checks.checks.map do |check|
+      [check.name.gsub(/^Check/, ''), check.description]
+    end.to_h
+  end
+
+  # Returns a de-duplicated set of warnings, used to generate rules
+  def unique_warnings_by_warning_code
+    @unique_warnings_by_warning_code ||= all_warnings.uniq { |w| w.warning_code }
+  end
+
+  def render_id warning
+    # Include alpha prefix to provide 'compiler error' appearance
+    "BRAKE#{'%04d' % warning.warning_code}" # 46 becomes BRAKE0046, for example
+  end
+
+  def render_message message
+    # Ensure message ends with a period
+    if message.end_with? "."
+      message
+    else
+      "#{message}."
+    end
+  end
+
+  def infer_level warning
+    # Infer result level from warning confidence
+    @@levels_from_confidence ||= Hash.new('warning').update({
+      0 => 'error',    # 0 represents 'high confidence', which we infer as 'error'
+      1 => 'warning',  # 1 represents 'medium confidence' which we infer as 'warning'
+      2 => 'note',     # 2 represents 'weak, or low, confidence', which we infer as 'note'
+    })
+    @@levels_from_confidence[warning.confidence]
+  end
+end

--- a/test/tests/sarif_output.rb
+++ b/test/tests/sarif_output.rb
@@ -1,0 +1,99 @@
+require_relative '../test'
+require 'json'
+
+class SARIFOutputTests < Minitest::Test
+  def setup
+    @@sarif ||= JSON.parse(Brakeman.run("#{TEST_PATH}/apps/rails3.2").report.to_sarif)
+  end
+
+  def test_log_shape
+    assert_equal '2.1.0', @@sarif['version']
+    assert_equal 'https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json', @@sarif['$schema']
+  end
+
+  def test_runs_shape
+    # Log includes runs, an array, of length 1
+    assert runs = @@sarif['runs']
+    assert_equal 1, runs.length
+
+    # The single run contains tool, and results
+    assert_equal runs[0].keys, ['tool', 'results']
+
+    # The single run contains a single tool
+    assert_equal 1, runs[0]['tool'].length
+  end
+
+  def test_driver_shape
+    # Tool includes a driver
+    assert driver = @@sarif.dig('runs', 0, 'tool', 'driver')
+
+    # Driver has a name, informationUri, semanticVersion, and rules
+    assert_equal driver.keys, ['name', 'informationUri', 'semanticVersion', 'rules']
+
+    # Driver name is 'Brakeman'
+    assert_equal driver['name'], 'Brakeman'
+
+    # Driver informationUri is 'https://brakemanscanner.org'
+    assert_equal driver['informationUri'], 'https://brakemanscanner.org'
+
+    # Driver semanticVersion is Brakeman::Version
+    assert_equal driver['semanticVersion'], Brakeman::Version
+  end
+
+  def test_rules_shape
+    assert rules = @@sarif.dig('runs', 0, 'tool', 'driver', 'rules')
+    rules.each do |rule|
+      # Each rule id starts with BRAKE
+      assert rule['id'].start_with? 'BRAKE'
+
+      # Each rule has a name, ...
+      assert rule['name']
+
+      # ... fullDescription, ...
+      assert rule['fullDescription']['text']
+
+      # ... helpUri, ...
+      assert rule['helpUri']
+
+      # ... help, ...
+      assert rule['help']['text']
+      assert rule['help']['markdown']
+
+      # ... and a property bag containing tags
+      assert rule['properties']['tags']
+    end
+
+    # Each rule id is unique
+    assert_equal rules.length, rules.map{ |rule| rule['id'] }.uniq.length
+  end
+
+  def test_results_shape
+    assert results = @@sarif.dig('runs', 0, 'results')
+    results.each do |result|
+      # Each result has message, ...
+      assert result['message']['text']
+
+      # ... ruleId, ...
+      assert result['ruleId']
+
+      # ... ruleIndex, ...
+      assert result['ruleIndex']
+
+      # ... level, ...
+      assert ['error', 'warning', 'note'].include? result['level']
+
+      # (and ruleIndex maps correctly onto the corresponding rule), ...
+      assert_equal result['ruleId'], @@sarif.dig('runs', 0, 'tool', 'driver', 'rules', result['ruleIndex'], 'id')
+
+      # ... locations, ...
+      assert locations = result['locations']
+      locations.each do |location|
+        # Each location has a physical location, ...
+        assert location['physicalLocation']
+
+        # Each location has a region
+        assert location['physicalLocation']['region']['startLine']
+      end
+    end
+  end
+end


### PR DESCRIPTION
:wave:  This PR adds support for the [SARIF](https://sarifweb.azurewebsites.net) (_Static Analysis Results Interchange Format_) output format to Brakeman.

## Todo
- [x] Add support for SARIF via `-f sarif` and `-o output.sarif` options.
- [x] Add SARIF generation logic, ensuring [valid output](https://sarifweb.azurewebsites.net/Validation).
- [x] Add unit tests (:hand: I plan to handle these next)
- [x] Consider pulling more documentation into the SARIF format, via https://github.com/presidentbeef/brakeman/tree/main/docs/warning_types.
- [ ] Review from @presidentbeef :bow:
- [ ] :shipit: 