### PR TITLE
Add cve 2019 5418

### DIFF
--- a/lib/brakeman/checks/check_file_content_disclosure.rb
+++ b/lib/brakeman/checks/check_file_content_disclosure.rb
@@ -9,11 +9,11 @@ class Brakeman::CheckFileContentDisclosure < Brakeman::BaseCheck
     fix_version = case
       when version_between?('0.0.0', '4.2.11')
         '4.2.11.1 '
-      when version_between?('5.0.0', '5.0.7.2')
+      when version_between?('5.0.0.beta1', '5.0.7.2')
         '5.0.7.2'
-      when version_between?('5.1.0', '5.1.6.1')
+      when version_between?('5.1.0.beta1', '5.1.6.1')
         '5.1.6.2'
-      when version_between?('5.2.0', '5.2.2')
+      when version_between?('5.2.0.beta1', '5.2.2')
         '5.2.2.1'
       when version_between?('6.0.0.beta1', '6.0.0.beta2')
         '6.0.0.beta3'

--- a/lib/brakeman/checks/check_file_content_disclosure.rb
+++ b/lib/brakeman/checks/check_file_content_disclosure.rb
@@ -44,19 +44,19 @@ class Brakeman::CheckFileContentDisclosure < Brakeman::BaseCheck
 
     case result[:call].render_type
     when :file
-      !check_for_formats_option(result)
+      check_for_absence_of_formats_option(result)
     end
   end
 
   # vulnerability can be mitigated with a specific format:
   # render file: "#{Rails.root}/some/file", formats: [:html]
-  def check_for_formats_option result
+  def check_for_absence_of_formats_option result
     exp = result[:call].last
 
     if sexp? exp and exp.node_type == :hash
       exp.each_sexp do |e|
         Match.new(:formats, e)
       end
-    end
+    end.empty?
   end
 end

--- a/lib/brakeman/checks/check_file_content_disclosure.rb
+++ b/lib/brakeman/checks/check_file_content_disclosure.rb
@@ -1,0 +1,62 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckFileContentDisclosure < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = 'Checks for versions with file content disclosure vulnerability'
+
+  def run_check
+    fix_version = case
+      when version_between?('0.0.0', '4.2.11')
+        '4.2.11.1 '
+      when version_between?('5.0.0', '5.0.7.2')
+        '5.0.7.2'
+      when version_between?('5.1.0', '5.1.6.1')
+        '5.1.6.2'
+      when version_between?('5.2.0', '5.2.2')
+        '5.2.2.1'
+      when version_between?('6.0.0.beta1', '6.0.0.beta2')
+        '6.0.0.beta3'
+      else
+        nil
+      end
+
+    if fix_version and render_file_with_no_specific_format?
+      warn :warning_type => "File Access",
+        :warning_code => :CVE_2019_5418,
+        :message => msg(msg_version(rails_version), " has a file content disclosure vulnerability. Upgrade to ", msg_version(fix_version), " or specify a file format"),
+        :confidence => :high,
+        :gem_info => gemfile_or_environment,
+        :link_path => "https://groups.google.com/g/rubyonrails-security/c/pFRKI96Sm8Q"
+    end
+  end
+
+  def render_file_with_no_specific_format?
+    tracker.find_call(:target => nil, :method => :render).each do |result|
+      process_render_result result
+    end
+  end
+
+  # vulnerable controllers will use:
+  # render file: "#{Rails.root}/some/file"
+  def process_render_result result
+    return unless node_type? result[:call], :render
+
+    case result[:call].render_type
+    when :file
+      !check_for_formats_option(result)
+    end
+  end
+
+  # vulnerability can be mitigated with a specific format:
+  # render file: "#{Rails.root}/some/file", formats: [:html]
+  def check_for_formats_option result
+    exp = result[:call].last
+
+    if sexp? exp and exp.node_type == :hash
+      exp.each_sexp do |e|
+        Match.new(:formats, e)
+      end
+    end
+  end
+end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -119,6 +119,7 @@ module Brakeman::WarningCodes
     :CVE_2020_8159 => 115,
     :CVE_2020_8166 => 116,
     :erb_template_injection => 117,
+    :CVE_2019_5418 => 118,
 
     :custom_check => 9090,
   }

--- a/test/tests/markdown_output.rb
+++ b/test/tests/markdown_output.rb
@@ -10,6 +10,6 @@ class TestMarkdownOutput < Minitest::Test
   end
 
   def test_reported_warnings
-    assert_equal 173, @@report.lines.to_a.count
+    assert_equal 174, @@report.lines.to_a.count
   end
 end

--- a/test/tests/only_files_option.rb
+++ b/test/tests/only_files_option.rb
@@ -10,7 +10,7 @@ class OnlyFilesOptionTests < Minitest::Test
       :controller => 8,
       :model => 0,
       :template => 1,
-      :generic => 16 }
+      :generic => 17 }
 
     if RUBY_PLATFORM == 'java'
       @expected[:generic] += 1

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -14,7 +14,7 @@ class Rails2Tests < Minitest::Test
       :controller => 1,
       :model => 4,
       :template => 47,
-      :generic => 59 }
+      :generic => 60 }
   end
 
   def report
@@ -1506,7 +1506,7 @@ class Rails2WithOptionsTests < Minitest::Test
       :controller => 1,
       :model => 4,
       :template => 47,
-      :generic => 59 }
+      :generic => 60 }
   end
 
   def report

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -14,7 +14,7 @@ class Rails3Tests < Minitest::Test
       :controller => 1,
       :model => 9,
       :template => 41,
-      :generic => 75
+      :generic => 76
     }
 
     if RUBY_PLATFORM == 'java'
@@ -933,7 +933,7 @@ class Rails3Tests < Minitest::Test
   def test_translate_bug
     assert_warning :type => :warning,
       :warning_type => "Cross-Site Scripting",
-      :message => /^Rails\ 3\.0\.3\ has\ a\ vulnerability\ in\ the\ t/, 
+      :message => /^Rails\ 3\.0\.3\ has\ a\ vulnerability\ in\ the\ t/,
       :confidence => 1,
       :file => /Gemfile/
   end
@@ -1068,7 +1068,7 @@ class Rails3Tests < Minitest::Test
       :relative_path => "app/views/home/test_content_tag.html.erb",
       :code => s(:call, nil, :content_tag, s(:lit, :div), s(:str, "Blah!"), s(:hash, s(:lit, :class), s(:call, s(:params), :[], s(:lit, :class))), s(:true)),
       :user_input => s(:call, s(:params), :[], s(:lit, :class))
-  end 
+  end
 
   def test_cross_site_scripting_model_in_tag_name
     assert_warning :type => :template,

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -13,7 +13,7 @@ class Rails31Tests < Minitest::Test
       :model => 3,
       :template => 23,
       :controller => 4,
-      :generic => 88 }
+      :generic => 89 }
   end
 
   def test_without_protection

--- a/test/tests/rails32.rb
+++ b/test/tests/rails32.rb
@@ -1,7 +1,7 @@
 # NOTE: Please do not add any further tests to the Rails 3.2 application unless
 # the issue being tested specifically applies to Rails 3.2 and not the other
 # versions.
-# If possible, please use the rails5 app. 
+# If possible, please use the rails5 app.
 
 require_relative '../test'
 
@@ -14,7 +14,7 @@ class Rails32Tests < Minitest::Test
       :controller => 8,
       :model => 5,
       :template => 11,
-      :generic => 22 }
+      :generic => 23 }
 
     if RUBY_PLATFORM == 'java'
       @expected[:generic] += 1

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Minitest::Test
       :controller => 0,
       :model => 3,
       :template => 8,
-      :generic => 87
+      :generic => 88
     }
   end
 

--- a/test/tests/rails4_with_engines.rb
+++ b/test/tests/rails4_with_engines.rb
@@ -9,7 +9,7 @@ class Rails4WithEnginesTests < Minitest::Test
       :controller => 2,
       :model => 5,
       :template => 12,
-      :generic => 14 }
+      :generic => 15 }
   end
 
   def report

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -13,7 +13,7 @@ class Rails5Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 19,
-      :generic => 24
+      :generic => 25
     }
   end
 

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -13,7 +13,7 @@ class Rails52Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 5,
-      :generic => 23
+      :generic => 24
     }
   end
 

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,7 +13,7 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 20
+      :generic => 21
     }
   end
 

--- a/test/tests/rails_with_xss_plugin.rb
+++ b/test/tests/rails_with_xss_plugin.rb
@@ -9,7 +9,7 @@ class RailsWithXssPluginTests < Minitest::Test
       :controller => 1,
       :model => 4,
       :template => 4,
-      :generic => 31 }
+      :generic => 32 }
   end
 
   def report

--- a/test/tests/tabs_output.rb
+++ b/test/tests/tabs_output.rb
@@ -10,6 +10,6 @@ class TestTabsOutput < Minitest::Test
   end
 
   def test_reported_warnings
-    assert_equal 111, @@report.lines.to_a.count
+    assert_equal 112, @@report.lines.to_a.count
   end
 end


### PR DESCRIPTION
If you render files without templates in your controllers on affected versions of Rails, it is possible for attackers to read arbitrary files on your file system. It is possible to workaround this vulnerability without upgrading which is why I thought this would be a good CVE to check for in brakeman.

In general though, I'd just like to learn more about brakeman and how it implements static scans.

https://correkt.horse/ruby/2020/08/09/CVE-2019-5418/ has more details.