### PR TITLE
Always set line number for joined arrays

### DIFF
--- a/lib/brakeman/processors/lib/call_conversion_helper.rb
+++ b/lib/brakeman/processors/lib/call_conversion_helper.rb
@@ -10,7 +10,7 @@ module Brakeman
     def join_arrays lhs, rhs, original_exp = nil
       if array? lhs and array? rhs
         result = Sexp.new(:array)
-        result.line(lhs.line || rhs.line)
+        result.line(lhs.line || rhs.line || 1)
         result.concat lhs[1..-1]
         result.concat rhs[1..-1]
         result

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -171,12 +171,23 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
-  def test_array_plu
+  def test_array_plus
     assert_alias '[1, 2, 3]', <<-RUBY
     x = [1]
     y = x + [2, 3]
     y
     RUBY
+  end
+
+  def test_array_plus_no_lines
+    a1 = s(:array, s(:lit, 1))
+    a2 = s(:array, s(:lit, 2))
+    joined = Brakeman::AliasProcessor.new.join_arrays(a1, a2)
+    expected = s(:array,
+                 s(:lit, 1),
+                 s(:lit, 2))
+
+    assert_equal expected, joined
   end
 
   def test_hash_index


### PR DESCRIPTION
Fixes #1499

Would be nice to understand under what circumstances this may happen... but at least fixing the symptom for now.