### PR TITLE
Adds support for sonarqube output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To specify an output file for the results:
 
     brakeman -o output_file
 
-The output format is determined by the file extension or by using the `-f` option. Current options are: `text`, `html`, `tabs`, `json`, `junit`, `markdown`, `csv`, and `codeclimate`.
+The output format is determined by the file extension or by using the `-f` option. Current options are: `text`, `html`, `tabs`, `json`, `junit`, `markdown`, `csv`, `codeclimate`, and `sonar`.
 
 Multiple output files can be specified:
 

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -239,6 +239,8 @@ module Brakeman
       [:to_junit]
     when :sarif, :to_sarif
       [:to_sarif]
+    when :sonar, :to_sonar
+      [:to_sonar]
     else
       [:to_text]
     end
@@ -270,6 +272,8 @@ module Brakeman
         :to_junit
       when /\.sarif$/i
         :to_sarif
+      when /\.sonar$/i
+        :to_sonar
       else
         :to_text
       end

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -229,7 +229,7 @@ module Brakeman::Options
 
         opts.on "-f",
           "--format TYPE",
-          [:pdf, :text, :html, :csv, :tabs, :json, :markdown, :codeclimate, :cc, :plain, :table, :junit, :sarif],
+          [:pdf, :text, :html, :csv, :tabs, :json, :markdown, :codeclimate, :cc, :plain, :table, :junit, :sarif, :sonar],
           "Specify output formats. Default is text" do |type|
 
           type = "s" if type == :text

--- a/lib/brakeman/report.rb
+++ b/lib/brakeman/report.rb
@@ -46,7 +46,8 @@ class Brakeman::Report
     when :to_sarif
       return self.to_sarif
     when :to_sonar
-      return self.to_sonar
+      require_report 'sonar'
+      Brakeman::Report::Sonar
     else
       raise "Invalid format: #{format}. Should be one of #{VALID_FORMATS.inspect}"
     end

--- a/lib/brakeman/report.rb
+++ b/lib/brakeman/report.rb
@@ -45,6 +45,8 @@ class Brakeman::Report
       Brakeman::Report::JUnit
     when :to_sarif
       return self.to_sarif
+    when :to_sonar
+      return self.to_sonar
     else
       raise "Invalid format: #{format}. Should be one of #{VALID_FORMATS.inspect}"
     end
@@ -67,6 +69,11 @@ class Brakeman::Report
   def to_json
     require_report 'json'
     generate Brakeman::Report::JSON
+  end
+
+  def to_sonar
+    require_report 'sonar'
+    generate Brakeman::Report::Sonar
   end
 
   def to_table

--- a/lib/brakeman/report/report_sonar.rb
+++ b/lib/brakeman/report/report_sonar.rb
@@ -1,8 +1,9 @@
 class Brakeman::Report::Sonar < Brakeman::Report::Base
   def generate_report
-    return {
+    report_object = {
       issues: all_warnings.map { |warning| issue_json(warning) }
-    }.to_json
+    }
+    return JSON.pretty_generate report_object
   end
   
   private

--- a/lib/brakeman/report/report_sonar.rb
+++ b/lib/brakeman/report/report_sonar.rb
@@ -15,7 +15,7 @@ class Brakeman::Report::Sonar < Brakeman::Report::Base
       severity: severity_level_for(warning.confidence),
       primaryLocation: {
         message: warning.message,
-        filePath: file_path(warning),
+        filePath: warning.file.relative,
         textRange: {
           "startLine": warning.line || 1,
           "endLine": warning.line || 1,
@@ -32,14 +32,6 @@ class Brakeman::Report::Sonar < Brakeman::Report::Base
       "MAJOR"
     else
       "MINOR"
-    end
-  end
-
-  def file_path(warning)
-    if tracker.options[:path_prefix]
-      (Pathname.new(tracker.options[:path_prefix]) + Pathname.new(warning.file.relative)).to_s
-    else
-      warning.file
     end
   end
 end

--- a/test/tests/sonar_output.rb
+++ b/test/tests/sonar_output.rb
@@ -1,0 +1,19 @@
+require_relative '../test'
+require 'json'
+
+class SonarOutputTests < Minitest::Test
+  def setup
+    @@sonar ||= JSON.parse(Brakeman.run("#{TEST_PATH}/apps/rails3.2").report.to_sonar)
+  end
+
+  def test_for_expected_keys
+    assert (@@sonar.keys - ["issues"]).empty?
+  end
+
+  def test_for_issues_keys
+    issues_keys = ["engineId", "ruleId", "severity", "type", "primaryLocation", "effortMinutes"]
+    puts @@sonar["issues"][0].keys
+    assert (@@sonar["issues"][0].keys - issues_keys).empty?
+  end
+
+end

--- a/test/tests/sonar_output.rb
+++ b/test/tests/sonar_output.rb
@@ -12,8 +12,10 @@ class SonarOutputTests < Minitest::Test
 
   def test_for_issues_keys
     issues_keys = ["engineId", "ruleId", "severity", "type", "primaryLocation", "effortMinutes"]
-    puts @@sonar["issues"][0].keys
-    assert (@@sonar["issues"][0].keys - issues_keys).empty?
+    @@sonar["issues"].each do |warning|
+      assert (warning.keys - issues_keys).empty?
+    end
+    
   end
 
 end


### PR DESCRIPTION
This PR adds support for the sonarqube [Generic Issue Import Format](https://docs.sonarqube.org/latest/analysis/generic-issue/)

In general, the change just requires adding `sonar` as an output format, implementing `Brakeman::Report::Sonar < Brakeman::Report::Base` and testing.

Has been successfully tested with sonarqube 8.4.1 (current production version).