### PR TITLE
Also track active_record for version detection

### DIFF
--- a/lib/brakeman/tracker/config.rb
+++ b/lib/brakeman/tracker/config.rb
@@ -79,7 +79,9 @@ module Brakeman
                   # Only used by Rails2ConfigProcessor right now
                   extract_version(version)
                 else
-                  gem_version(:rails) || gem_version(:railties)
+                  gem_version(:rails) ||
+                    gem_version(:railties) ||
+                    gem_version(:activerecord)
                 end
 
       if version

--- a/test/apps/active_record_only/Gemfile
+++ b/test/apps/active_record_only/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "activerecord", "~> 5.2.4.3"

--- a/test/apps/active_record_only/app/models/book.rb
+++ b/test/apps/active_record_only/app/models/book.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "active_record"
+
+class Book < ActiveRecord::Base
+end

--- a/test/apps/active_record_only/script/.gitkeep
+++ b/test/apps/active_record_only/script/.gitkeep
@@ -1,0 +1,1 @@
+Kept only to help guessing this is a rails 2 unless activerecord version is detected

--- a/test/tests/active_record_only.rb
+++ b/test/tests/active_record_only.rb
@@ -1,0 +1,32 @@
+require_relative '../test'
+
+class ActiveRecordOnlyTests < Minitest::Test
+  include BrakemanTester::FindWarning
+  include BrakemanTester::CheckExpected
+
+  def expected
+    @expected ||= {
+      :controller => 0,
+      :model => 0,
+      :template => 0,
+      :warning => 0 }
+  end
+
+  def report
+    @@report ||= BrakemanTester.run_scan "active_record_only", "ActiveRecordOnly"
+  end
+
+  def test_no_attribute_restriction
+    assert_no_warning :type => :model,
+      :warning_code => 19,
+      :fingerprint => "b660c00ebcf323130f61f3f402bd8ea067b472c785f9b069e1317216aa94360f",
+      :warning_type => "Attribute Restriction",
+      :line => 5,
+      :message => /^Mass\ assignment\ is\ not\ restricted\ using\ /,
+      :confidence => 0,
+      :relative_path => "app/models/book.rb",
+      :code => nil,
+      :user_input => nil
+  end
+
+end


### PR DESCRIPTION
Since a lot of brakeman's report are related to AR (for instance, SQLI),
we track AR's version so brakeman can be easier to use in projects that
do not include rails. Sinatra applications for instance.

Closes #1494. 