### PR TITLE
Avoid warning about missing `attr_accessible` if `protected_attributes` gem is used

### DIFF
--- a/lib/brakeman/checks/check_model_attributes.rb
+++ b/lib/brakeman/checks/check_model_attributes.rb
@@ -8,7 +8,7 @@ class Brakeman::CheckModelAttributes < Brakeman::BaseCheck
   @description = "Reports models which do not use attr_restricted and warns on models that use attr_protected"
 
   def run_check
-    return if mass_assign_disabled?
+    return if mass_assign_disabled? or tracker.config.has_gem?(:protected_attributes)
 
     #Roll warnings into one warning for all models
     if tracker.options[:collapse_mass_assignment]

--- a/test/tests/mass_assign_disable.rb
+++ b/test/tests/mass_assign_disable.rb
@@ -71,10 +71,12 @@ class MassAssignDisableTest < Minitest::Test
       append "gems.rb", "gem 'protected_attributes'"
     end
 
+    # I misunderstood this previously - the protected_attributes gem
+    # does not require use of attr_accessible, just allows it.
     assert_reindex :none
     assert_changes
     assert_fixed 0
-    assert_new 1
+    assert_new 0
   end
 
   def test_protected_attributes_gem_with_whitelist_attributes


### PR DESCRIPTION
Partially addresses #1512