### PR TITLE
Scan most Ruby files

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -66,6 +66,7 @@ module Brakeman
   #  * :run_checks - array of checks to run (run all if not specified)
   #  * :safe_methods - array of methods to consider safe
   #  * :skip_libs - do not process lib/ directory (default: false)
+  #  * :skip_vendor - do not process vendor/ directory (default: true)
   #  * :skip_checks - checks not to run (run all if not specified)
   #  * :absolute_paths - show absolute path of each file (default: false)
   #  * :summary_only - only output summary section of report for plain/table (:summary_only, :no_summary, true)
@@ -191,6 +192,7 @@ module Brakeman
       :report_progress => true,
       :safe_methods => Set.new,
       :skip_checks => Set.new,
+      :skip_vendor => true,
     }
   end
 

--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -96,6 +96,28 @@ module Brakeman
       end
     end
 
+    EXCLUDED_PATHS = %w[
+    /generators/
+    lib/tasks/
+    lib/templates/
+    db/
+    spec/
+    test/
+    tmp/
+    public/
+    log/
+    ]
+
+    def ruby_file_paths
+      find_paths(".").reject do |path|
+        relative_path = path.relative
+
+        EXCLUDED_PATHS.any? do |excluded|
+          relative_path.include? excluded
+        end
+      end.uniq
+    end
+
     def initializer_paths
       @initializer_paths ||= prioritize_concerns(find_paths("config/initializers"))
     end
@@ -109,8 +131,8 @@ module Brakeman
     end
 
     def template_paths
-      @template_paths ||= find_paths("app/**/views", "*.{#{VIEW_EXTENSIONS}}") +
-                          find_paths("app/**/views", "*.{erb,haml,slim}").reject { |path| File.basename(path).count(".") > 1 }
+      @template_paths ||= find_paths(".", "*.{#{VIEW_EXTENSIONS}}") +
+        find_paths("**", "*.{erb,haml,slim}").reject { |path| File.basename(path).count(".") > 1 }
     end
 
     def layout_exists?(name)

--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -167,8 +167,8 @@ module Brakeman
     def select_files(paths)
       paths = select_only_files(paths)
       paths = reject_skipped_files(paths)
-      paths = reject_global_excludes(paths)
-      convert_to_file_paths(paths)
+      paths = convert_to_file_paths(paths)
+      reject_global_excludes(paths)
     end
 
     def select_only_files(paths)
@@ -201,8 +201,10 @@ module Brakeman
 
     def reject_global_excludes(paths)
       paths.reject do |path|
+        relative_path = path.relative
+
         EXCLUDED_PATHS.any? do |excluded|
-          path.include? excluded
+          relative_path.include? excluded
         end
       end
     end

--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -96,26 +96,8 @@ module Brakeman
       end
     end
 
-    EXCLUDED_PATHS = %w[
-    /generators/
-    lib/tasks/
-    lib/templates/
-    db/
-    spec/
-    test/
-    tmp/
-    public/
-    log/
-    ]
-
     def ruby_file_paths
-      find_paths(".").reject do |path|
-        relative_path = path.relative
-
-        EXCLUDED_PATHS.any? do |excluded|
-          relative_path.include? excluded
-        end
-      end.uniq
+      find_paths(".").uniq
     end
 
     def initializer_paths
@@ -185,6 +167,7 @@ module Brakeman
     def select_files(paths)
       paths = select_only_files(paths)
       paths = reject_skipped_files(paths)
+      paths = reject_global_excludes(paths)
       convert_to_file_paths(paths)
     end
 
@@ -201,6 +184,26 @@ module Brakeman
 
       paths.reject do |path|
         match_path @skip_files, path
+      end
+    end
+
+    EXCLUDED_PATHS = %w[
+      /generators/
+      lib/tasks/
+      lib/templates/
+      db/
+      spec/
+      test/
+      tmp/
+      public/
+      log/
+    ]
+
+    def reject_global_excludes(paths)
+      paths.reject do |path|
+        EXCLUDED_PATHS.any? do |excluded|
+          path.include? excluded
+        end
       end
     end
 

--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -21,6 +21,7 @@ module Brakeman
       end
       init_options[:additional_libs_path] = options[:additional_libs_path]
       init_options[:engine_paths] = options[:engine_paths]
+      init_options[:skip_vendor] = options[:skip_vendor]
       new(root, init_options)
     end
 
@@ -62,6 +63,7 @@ module Brakeman
       @engine_paths = init_options[:engine_paths] || []
       @absolute_engine_paths = @engine_paths.select { |path| path.start_with?(File::SEPARATOR) }
       @relative_engine_paths = @engine_paths - @absolute_engine_paths
+      @skip_vendor = init_options[:skip_vendor]
       @gemspec = nil
       @root_search_pattern = nil
     end
@@ -203,8 +205,12 @@ module Brakeman
       paths.reject do |path|
         relative_path = path.relative
 
-        EXCLUDED_PATHS.any? do |excluded|
-          relative_path.include? excluded
+        if @skip_vendor and relative_path.include? 'vendor/'
+          true
+        else
+          EXCLUDED_PATHS.any? do |excluded|
+            relative_path.include? excluded
+          end
         end
       end
     end

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -166,6 +166,10 @@ module Brakeman::Options
           options[:only_files].merge files
         end
 
+        opts.on "--[no-]skip-vendor", "Skip processing vendor directory (Default)" do |skip|
+          options[:skip_vendor] = skip
+        end
+
         opts.on "--skip-libs", "Skip processing lib directory" do
           options[:skip_libs] = true
         end

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -70,15 +70,7 @@ class Brakeman::Scanner
   def parse_files
     fp = Brakeman::FileParser.new(tracker.app_tree, tracker.options[:parser_timeout])
 
-    paths = @app_tree.initializer_paths +
-            @app_tree.controller_paths +
-            @app_tree.model_paths
-
-    unless options[:skip_libs]
-      paths.concat @app_tree.lib_paths
-    end
-
-    fp.parse_files paths
+    fp.parse_files tracker.app_tree.ruby_file_paths
 
     template_parser = Brakeman::TemplateParser.new(tracker, fp)
 

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -368,8 +368,13 @@ module Brakeman::Util
   #
   # views/test/something.html.erb -> test/something
   def template_path_to_name path
-    names = path.relative.split("/")
+    names = path.relative.split('/')
     names.last.gsub!(/(\.(html|js)\..*|\.(rhtml|haml|erb|slim))$/, '')
-    names[(names.index("views") + 1)..-1].join("/").to_sym
+
+    if names.include? 'views'
+      names[(names.index('views') + 1)..-1]
+    else
+      names
+    end.join('/').to_sym
   end
 end

--- a/test/apps/rails5.2/vendor/vendored_thing.rb
+++ b/test/apps/rails5.2/vendor/vendored_thing.rb
@@ -1,0 +1,5 @@
+class Vendored
+  def vendor
+    `rm -rf #{stuff}`
+  end
+end

--- a/test/apps/rails6/another_lib_dir/some_lib.rb
+++ b/test/apps/rails6/another_lib_dir/some_lib.rb
@@ -1,0 +1,5 @@
+class A
+  def something(thing)
+    `rm -rf #{thing}`
+  end
+end

--- a/test/apps/rails6/app/widgets/widget.rb
+++ b/test/apps/rails6/app/widgets/widget.rb
@@ -1,0 +1,5 @@
+class Widget < ApplicationRecord
+  def spin(direction)
+    where("direction = #{direction})").first.spin
+  end
+end

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -93,6 +93,18 @@ class UtilTests < Minitest::Test
   def test_params?
     assert util.params?(@ruby_parser.new.parse 'params[:x][:y][:z]')
   end
+
+  def test_template_path_to_name_with_views
+    path = Brakeman::FilePath.new('app/views/a/b/c/d.html.haml', 'app/views/a/b/c/d.html.haml')
+    name = util.template_path_to_name(path)
+    assert_equal :'a/b/c/d', name
+  end
+
+  def test_template_path_to_name_without_views
+    path = Brakeman::FilePath.new('lib/templates/a/b/c/d.js.erb', 'lib/templates/a/b/c/d.js.erb')
+    name = util.template_path_to_name(path)
+    assert_equal :'lib/templates/a/b/c/d', name
+  end
 end
 
 class BaseCheckTests < Minitest::Test

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -92,6 +92,14 @@ class BrakemanOptionsTest < Minitest::Test
     assert !options[:index_libs]
   end
 
+  def test_skip_vendor_option
+    options = setup_options_from_input("--skip-vendor")
+    assert options[:skip_vendor]
+
+    options = setup_options_from_input("--no-skip-vendor")
+    assert !options[:skip_vendor]
+  end
+
   def test_limit_options
     options = setup_options_from_input("--branch-limit", "17")
     assert_equal 17, options[:branch_limit]

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -434,6 +434,18 @@ class Rails52Tests < Minitest::Test
       :user_input => s(:call, nil, :foo)
   end
 
+  def test_command_injection_ignored_in_vendor_dir
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :warning_type => "Command Injection",
+      :line => 3,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 1,
+      :relative_path => "vendor/vendored_thing.rb",
+      :code => s(:dxstr, "rm -rf ", s(:evstr, s(:call, nil, :stuff))),
+      :user_input => s(:call, nil, :stuff)
+  end
+
   def test_cross_site_scripting_haml_sass
     assert_warning :type => :template,
       :warning_code => 2,
@@ -597,5 +609,25 @@ class Rails52Tests < Minitest::Test
       :confidence => 1,
       :relative_path => "Gemfile.lock",
       :user_input => nil
+  end
+end
+
+class Rails52WithVendorTests < Minitest::Test
+  include BrakemanTester::FindWarning
+
+  def report
+    @@report ||= BrakemanTester.run_scan "rails5.2", "Rails 5.2", skip_vendor: false 
+  end
+
+  def test_command_injection_ignored_vendor_dir
+    assert_warning :type => :warning,
+      :warning_code => 14,
+      :warning_type => "Command Injection",
+      :line => 3,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 1,
+      :relative_path => "vendor/vendored_thing.rb",
+      :code => s(:dxstr, "rm -rf ", s(:evstr, s(:call, nil, :stuff))),
+      :user_input => s(:call, nil, :stuff)
   end
 end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,7 +13,7 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 21
+      :generic => 23
     }
   end
 
@@ -93,6 +93,19 @@ class Rails6Tests < Minitest::Test
       :relative_path => "app/models/user.rb",
       :code => s(:call, s(:call, s(:colon2, s(:const, :ActiveRecord), :Base), :connection), :delete, s(:call, s(:dstr, "DELETE FROM ", s(:evstr, s(:call, nil, :table)), s(:str, " WHERE updated_at < now() - interval '"), s(:evstr, s(:call, nil, :period)), s(:str, "'\n")), :chomp)),
       :user_input => s(:call, nil, :table)
+  end
+
+  def test_sql_injection_nonstandard_directory
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "633da061d9412e2a270133526a45933e29553846c677254abfd0d0955e69f064",
+      :warning_type => "SQL Injection",
+      :line => 3,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 1,
+      :relative_path => "app/widgets/widget.rb",
+      :code => s(:call, nil, :where, s(:dstr, "direction = ", s(:evstr, s(:lvar, :direction)), s(:str, ")"))),
+      :user_input => s(:lvar, :direction)
   end
 
   def test_cross_site_scripting_sanity
@@ -313,6 +326,19 @@ class Rails6Tests < Minitest::Test
       :relative_path => "app/controllers/groups_controller.rb",
       :code => s(:dxstr, "", s(:evstr, s(:call, s(:params), :require, s(:str, "name"))), s(:str, " some optional text")),
       :user_input => s(:call, s(:params), :require, s(:str, "name"))
+  end
+
+  def test_command_injection_nonstandard_directory
+    assert_warning :type => :warning,
+      :warning_code => 14,
+      :fingerprint => "374fcec0e44933e90ee710b9a3975e29134d8a3725e3d7d7ab5e0e8f0c09f5a4",
+      :warning_type => "Command Injection",
+      :line => 3,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 1,
+      :relative_path => "another_lib_dir/some_lib.rb",
+      :code => s(:dxstr, "rm -rf ", s(:evstr, s(:lvar, :thing))),
+      :user_input => s(:lvar, :thing)
   end
 
   def test_dynamic_render_path_dir_glob_filter


### PR DESCRIPTION
Instead of only scanning files in particular directories, scan _most_ directories. This includes both `.rb` and template files (`.erb`, `.slim`, `.haml`).

Skips `vendor` by default but allow scanning it with `--no-skip-vendor`.

Probably need more flexibility on the other excluded paths, but leaving hardcoded for now.