### PR TITLE
Fix less invocation for busybox implementation

### DIFF
--- a/lib/brakeman/report/pager.rb
+++ b/lib/brakeman/report/pager.rb
@@ -90,10 +90,10 @@ module Brakeman
       @less_options = []
 
       if system("which less > /dev/null")
-        less_help = `less -?`
+        less_help = `less -? 2>&1`
 
-        ["-R ", "-F ", "-X "].each do |opt|
-          if less_help.include? opt
+        ["-R", "-F", "-X"].each do |opt|
+          if less_help.match(opt + '\s')
             @less_options << opt
           end
         end


### PR DESCRIPTION
Busybox implementation of less doesn't support -? parameter, which
results in redirecting help to stderr rather than stdout. Parameters in
help are separated from their description with tab rather than space.