### PR TITLE
Add check for unsafe reflection to access methods

### DIFF
--- a/lib/brakeman/checks/check_unsafe_reflection_methods.rb
+++ b/lib/brakeman/checks/check_unsafe_reflection_methods.rb
@@ -50,17 +50,19 @@ class Brakeman::CheckUnsafeReflectionMethods < Brakeman::BaseCheck
     return unless original? result
     method = result[:call].method
 
-    confidence = :high
-
-    if confidence
-      message = msg("Unsafe reflection method ", msg_code(method), " called with ", msg_input(input))
-
-      warn :result => result,
-        :warning_type => "Remote Code Execution",
-        :warning_code => :unsafe_method_reflection,
-        :message => message,
-        :user_input => input,
-        :confidence => confidence
+    confidence = if input.type == :params
+      :high
+    else
+      :medium
     end
+
+    message = msg("Unsafe reflection method ", msg_code(method), " called with ", msg_input(input))
+
+    warn :result => result,
+      :warning_type => "Remote Code Execution",
+      :warning_code => :unsafe_method_reflection,
+      :message => message,
+      :user_input => input,
+      :confidence => confidence
   end
 end

--- a/lib/brakeman/checks/check_unsafe_reflection_methods.rb
+++ b/lib/brakeman/checks/check_unsafe_reflection_methods.rb
@@ -8,6 +8,7 @@ class Brakeman::CheckUnsafeReflectionMethods < Brakeman::BaseCheck
   def run_check
     check_method
     check_tap
+    check_to_proc
   end
 
   def check_method
@@ -30,6 +31,16 @@ class Brakeman::CheckUnsafeReflectionMethods < Brakeman::BaseCheck
       end
 
       if user_input = include_user_input?(argument)
+        warn_unsafe_reflection(result, user_input)
+      end
+    end
+  end
+
+  def check_to_proc
+    tracker.find_call(method: :to_proc, nested: true).each do |result|
+      target = result[:call].target
+
+      if user_input = include_user_input?(target)
         warn_unsafe_reflection(result, user_input)
       end
     end

--- a/lib/brakeman/checks/check_unsafe_reflection_methods.rb
+++ b/lib/brakeman/checks/check_unsafe_reflection_methods.rb
@@ -1,0 +1,39 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckUnsafeReflectionMethods < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = "Checks for unsafe reflection to access methods"
+
+  def run_check
+    check_method
+  end
+
+  def check_method
+    tracker.find_call(method: :method, nested: true).each do |result|
+      argument = result[:call].first_arg
+
+      if include_user_input? argument
+        warn_unsafe_reflection(result, argument)
+      end
+    end
+  end
+
+  def warn_unsafe_reflection result, input
+    return unless original? result
+    method = result[:call].method
+
+    confidence = :high
+
+    if confidence
+      message = msg("Unsafe reflection method ", msg_code(method), " called with ", msg_input(input))
+
+      warn :result => result,
+        :warning_type => "Remote Code Execution",
+        :warning_code => :unsafe_method_reflection,
+        :message => message,
+        :user_input => input,
+        :confidence => confidence
+    end
+  end
+end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -120,6 +120,7 @@ module Brakeman::WarningCodes
     :CVE_2020_8166 => 116,
     :erb_template_injection => 117,
     :http_verb_confusion => 118,
+    :unsafe_method_reflection => 119,
 
     :custom_check => 9090,
   }

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -43,5 +43,6 @@ class GroupsController < ApplicationController
     params[:method].to_sym.to_proc.call(Kernel)
     (params[:klass].to_s).method(params[:method]).(params[:argument])
     Kernel.tap(&params[:method].to_sym)
+    User.method("#{User.first.some_method_thing}_stuff")
   end
 end

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -38,4 +38,10 @@ class GroupsController < ApplicationController
     YAML.load(params[:yaml_stuff], safe: false) # not safe
     YAML.load(params[:yaml_stuff]) # not safe
   end
+
+  def dynamic_method_invocations
+    params[:method].to_sym.to_proc.call(Kernel)
+    (params[:klass].to_s).method(params[:method]).(params[:argument])
+    Kernel.tap(&params[:method].to_sym)
+  end
 end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,7 +13,7 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 27
+      :generic => 28
     }
   end
 
@@ -236,6 +236,19 @@ class Rails6Tests < Minitest::Test
       :relative_path => "app/controllers/groups_controller.rb",
       :code => s(:call, s(:call, s(:call, s(:params), :[], s(:lit, :method)), :to_sym), :to_proc),
       :user_input => s(:call, s(:call, s(:params), :[], s(:lit, :method)), :to_sym)
+  end
+
+  def test_remote_code_execution_not_query_parameters
+    assert_warning :type => :warning,
+      :warning_code => 119,
+      :fingerprint => "78e2d9010374d26ef8fe31ed22f10a6de7dfc428e0387dd8502cd5833ffe4aa6",
+      :warning_type => "Remote Code Execution",
+      :line => 46,
+      :message => /^Unsafe\ reflection\ method\ `method`\ called/,
+      :confidence => 1,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:const, :User), :method, s(:dstr, "", s(:evstr, s(:call, s(:call, s(:const, :User), :first), :some_method_thing)), s(:str, "_stuff"))),
+      :user_input => s(:call, s(:call, s(:const, :User), :first), :some_method_thing)
   end
 
   def test_safe_yaml_load_option

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,7 +13,7 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 24
+      :generic => 27
     }
   end
 
@@ -197,6 +197,45 @@ class Rails6Tests < Minitest::Test
       :relative_path => "config/initializers/cookies_serializer.rb",
       :code => s(:attrasgn, s(:call, s(:call, s(:call, s(:const, :Rails), :application), :config), :action_dispatch), :cookies_serializer=, s(:lit, :marshal)),
       :user_input => nil
+  end
+
+  def test_remote_code_execution_method
+    assert_warning :type => :warning,
+      :warning_code => 119,
+      :fingerprint => "f4c435cdf78761be48879a05c84db905558d192cb6693640174ff3c0f18b61cd",
+      :warning_type => "Remote Code Execution",
+      :line => 44,
+      :message => /^Unsafe\ reflection\ method\ `method`\ called/,
+      :confidence => 0,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:call, s(:call, s(:params), :[], s(:lit, :klass)), :to_s), :method, s(:call, s(:params), :[], s(:lit, :method))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :method))
+  end
+
+  def test_remote_code_execution_tap
+    assert_warning :type => :warning,
+      :warning_code => 119,
+      :fingerprint => "988c82365b897a118c1c2b49059dc2b7202333ecc8bdd3a182ae0c126db2fca4",
+      :warning_type => "Remote Code Execution",
+      :line => 45,
+      :message => /^Unsafe\ reflection\ method\ `tap`\ called\ wi/,
+      :confidence => 0,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:const, :Kernel), :tap, s(:block_pass, s(:call, s(:call, s(:params), :[], s(:lit, :method)), :to_sym))),
+      :user_input => s(:call, s(:call, s(:params), :[], s(:lit, :method)), :to_sym)
+  end
+
+  def test_remote_code_execution_to_proc
+    assert_warning :type => :warning,
+      :warning_code => 119,
+      :fingerprint => "0eceb89cbf8d71f0aa8ada268bb0042f6efefee746e015adaa656d33e87c2f6e",
+      :warning_type => "Remote Code Execution",
+      :line => 43,
+      :message => /^Unsafe\ reflection\ method\ `to_proc`\ calle/,
+      :confidence => 0,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:call, s(:call, s(:params), :[], s(:lit, :method)), :to_sym), :to_proc),
+      :user_input => s(:call, s(:call, s(:params), :[], s(:lit, :method)), :to_sym)
   end
 
   def test_safe_yaml_load_option


### PR DESCRIPTION
Check for unsafe use of `method`, `to_proc`,  and `tap`.

Fixes #1488, #1507, and #1508