### PR TITLE
Suggest using --force if no Rails application is detected

### DIFF
--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -24,7 +24,10 @@ class Brakeman::Scanner
     @app_tree = Brakeman::AppTree.from_options(options)
 
     if (!@app_tree.root || !@app_tree.exists?("app")) && !options[:force_scan]
-      raise Brakeman::NoApplication, "Please supply the path to a Rails application (looking in #{@app_tree.root})."
+      message = "Please supply the path to a Rails application (looking in #{@app_tree.root}).\n" <<
+                "  Use `--force` to run a scan anyway - for example if there are many applications in one directory."
+
+      raise Brakeman::NoApplication, message
     end
 
     @processor = processor || Brakeman::Processor.new(@app_tree, options)


### PR DESCRIPTION
In Brakeman 5.0, Brakeman _can_ scan applications even if there is no `app/` directory at the top level.

For the 5.0 release, using `--force` will still be required. This will likely change to just a warning in a future release (5.1, 5.2?).