### PR TITLE
prevent rails 5.2+ without defaults being oked

### DIFF
--- a/lib/brakeman/tracker/config.rb
+++ b/lib/brakeman/tracker/config.rb
@@ -20,9 +20,7 @@ module Brakeman
 
     def default_protect_from_forgery?
       if version_between? "5.2.0.beta1", "9.9.9"
-        if @rails.dig(:action_controller, :default_protect_from_forgery) == Sexp.new(:false)
-          return false
-        else
+        if @rails.dig(:action_controller, :default_protect_from_forgery) == Sexp.new(:true)
           return true
         end
       end


### PR DESCRIPTION
On rails 5.2+ installations that are missing the defaults, or where upgraded to rails 5.2+ without applying all the defaults - the `default_protect_from_forgery?` method returns the wrong result.

if the defaults are not present, dig returns nil which also does not match `Sexp.new(:false)` and the original method returns true.

This new logic both simplifies the logic and returns correctly false when the defaults are not present.

It appears this problem was introduced here https://github.com/presidentbeef/brakeman/pull/1138 