### PR TITLE
Set Rails configuration defaults based on `load_defaults` version

### DIFF
--- a/lib/brakeman/processors/lib/rails3_config_processor.rb
+++ b/lib/brakeman/processors/lib/rails3_config_processor.rb
@@ -57,6 +57,20 @@ class Brakeman::Rails3ConfigProcessor < Brakeman::BasicProcessor
     exp
   end
 
+  #Look for configuration settings that
+  #are just a call like
+  #
+  #  config.load_defaults 5.2
+  def process_call exp
+    return exp unless @inside_config
+
+    if exp.target == RAILS_CONFIG and exp.first_arg
+      @tracker.config.rails[exp.method] = exp.first_arg
+    end
+
+    exp
+  end
+
   #Look for configuration settings
   def process_attrasgn exp
     return exp unless @inside_config

--- a/lib/brakeman/processors/lib/rails3_config_processor.rb
+++ b/lib/brakeman/processors/lib/rails3_config_processor.rb
@@ -85,22 +85,8 @@ class Brakeman::Rails3ConfigProcessor < Brakeman::BasicProcessor
         @tracker.config.rails[attribute] = exp.first_arg
       end
     elsif include_rails_config? exp
-      options = get_rails_config exp
-      level = @tracker.config.rails
-      options[0..-2].each do |o|
-        level[o] ||= {}
-
-        option = level[o]
-
-        if not option.is_a? Hash
-          Brakeman.debug "[Notice] Skipping config setting: #{options.map(&:to_s).join(".")}"
-          return exp
-        end
-
-        level = level[o]
-      end
-
-      level[options.last] = exp.first_arg
+      options_path = get_rails_config exp
+      @tracker.config.set_rails_config(exp.first_arg, *options_path)
     end
 
     exp

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -139,6 +139,8 @@ class Brakeman::Scanner
     if @app_tree.exists? ".ruby-version"
       tracker.config.set_ruby_version @app_tree.file_path(".ruby-version").read
     end
+
+    tracker.config.load_rails_defaults
   end
 
   def process_config_file file

--- a/test/tests/config.rb
+++ b/test/tests/config.rb
@@ -6,6 +6,20 @@ class RailsConfiguration < Minitest::Test
 
     refute tracker.config.rails.empty?
 
-    assert_equal tracker.config.rails[:load_defaults], Sexp.new(:lit, 5.2)
+    # Settings like `config.load_defaults(5.2)` shold be included, not
+    # just settings like `config.some.attribute = ...`
+    assert_equal Sexp.new(:lit, 5.2), tracker.config.rails[:load_defaults]
+
+    # Rails 5.0 settings should be included
+    assert_equal Sexp.new(:true), tracker.config.rails[:action_controller][:per_form_csrf_tokens]
+
+    # Rails 5.1 settings should be included
+    assert_equal Sexp.new(:false), tracker.config.rails[:assets][:unknown_asset_fallback]
+
+    # Rails 5.2 settings should be included
+    assert_equal Sexp.new(:true), tracker.config.rails[:active_record][:belongs_to_required_by_default]
+
+    # Rails 6.0 settings should not be included
+    assert_nil tracker.config.rails[:action_dispatch][:use_cookies_with_metadata]
   end
 end

--- a/test/tests/config.rb
+++ b/test/tests/config.rb
@@ -1,9 +1,11 @@
 require_relative '../test'
 
 class RailsConfiguration < Minitest::Test
-  def test_rails5_configuration
-    tracker = Brakeman.run(File.join(TEST_PATH, "apps", "rails5"))
+  def test_rails5_2_configuration_load_defaults
+    tracker = Brakeman.run(File.join(TEST_PATH, "apps", "rails5.2"))
 
     refute tracker.config.rails.empty?
+
+    assert_equal tracker.config.rails[:load_defaults], Sexp.new(:lit, 5.2)
   end
 end


### PR DESCRIPTION
As pointed out in #1530, Rails sets a number of default configuration values based on `config.load_defaults` which is usually called in `application.rb`.

This PR will set those config values in `tracker.config.rails`.