### PR TITLE
Ensure RubyParser is passed path as a string

### DIFF
--- a/lib/brakeman/file_parser.rb
+++ b/lib/brakeman/file_parser.rb
@@ -32,7 +32,12 @@ module Brakeman
       end
     end
 
+    # _path_ can be a string or a Brakeman::FilePath
     def parse_ruby input, path
+      if path.is_a? Brakeman::FilePath
+        path = path.relative
+      end
+
       begin
         Brakeman.debug "Parsing #{path}"
         RubyParser.new.parse input, path, @timeout

--- a/test/tests/file_parser.rb
+++ b/test/tests/file_parser.rb
@@ -33,4 +33,14 @@ class FileParserTests < Minitest::Test
       assert_match(/parse error on value \"\$end\" \(\$end\)/, @tracker.errors.first[:error])
     end
   end
+
+  def test_parse_ruby_accepts_file_path
+    file_path = Brakeman::FilePath.from_app_tree @tracker.app_tree, "config/test.rb"
+
+    parsed = @file_parser.parse_ruby <<-'RUBY', file_path
+      "#{__FILE__}"
+    RUBY
+
+    assert_equal s(:str, "config/test.rb"), parsed
+  end
 end


### PR DESCRIPTION
Fixes #1534