### PR TITLE
Fix Ruby 3.0 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,10 @@ jobs:
     <<: *default
     docker:
       - image: cimg/ruby:2.6
+  test-3-0:
+    <<: *default
+    docker:
+      - image: circleci/ruby:3.0.0-rc1
   test-latest:
     <<: *default
     docker:
@@ -65,6 +69,7 @@ workflows:
       - test-2-4
       - test-2-5
       - test-2-6
+      - test-3-0
       - test-latest
       - upload-coverage:
           requires:

--- a/gem_common.rb
+++ b/gem_common.rb
@@ -21,6 +21,7 @@ module Brakeman
       spec.add_dependency "erubis", "~>2.6"
       spec.add_dependency "haml", "~>5.1"
       spec.add_dependency "slim", ">=1.3.6", "<=4.1"
+      spec.add_dependency "rexml", "~>3.0"
     end
   end
 end

--- a/lib/brakeman/checks/check_execute.rb
+++ b/lib/brakeman/checks/check_execute.rb
@@ -208,7 +208,7 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
       if node_type? e, :if
         # If we're in a conditional, evaluate the `then` and `else` clauses to
         # see if they're dangerous.
-        if res = dangerous?(e.values[1..-1])
+        if res = dangerous?(e.sexp_body.sexp_body)
           return res
         end
       elsif node_type? e, :or, :evstr, :dstr

--- a/lib/brakeman/checks/check_regex_dos.rb
+++ b/lib/brakeman/checks/check_regex_dos.rb
@@ -29,7 +29,7 @@ class Brakeman::CheckRegexDoS < Brakeman::BaseCheck
     return unless original? result
 
     call = result[:call]
-    components = call[1..-1]
+    components = call.sexp_body
 
     components.any? do |component|
       next unless sexp? component

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -236,7 +236,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
         env[target_var] = target
         return target
       elsif string? target and string_interp? first_arg
-        exp = Sexp.new(:dstr, target.value + first_arg[1]).concat(first_arg[2..-1])
+        exp = Sexp.new(:dstr, target.value + first_arg[1]).concat(first_arg.sexp_body(2))
         env[target_var] = exp
       elsif string? first_arg and string_interp? target
         if string? target.last
@@ -941,7 +941,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     args = exp.args
     exp.pop # remove last arg
     if args.length > 1
-      exp.arglist = args[1..-1]
+      exp.arglist = args.sexp_body
     end
   end
 

--- a/lib/brakeman/processors/controller_processor.rb
+++ b/lib/brakeman/processors/controller_processor.rb
@@ -202,7 +202,7 @@ class Brakeman::ControllerProcessor < Brakeman::BaseProcessor
     end
 
     if node_type? exp.block, :block
-      block_inner = exp.block[1..-1]
+      block_inner = exp.block.sexp_body
     else
       block_inner = [exp.block]
     end

--- a/lib/brakeman/processors/output_processor.rb
+++ b/lib/brakeman/processors/output_processor.rb
@@ -88,7 +88,7 @@ class Brakeman::OutputProcessor < Ruby2Ruby
 
   def process_iter exp
     call = process exp[1]
-    block = process_rlist exp[3..-1]
+    block = process_rlist exp.sexp_body(3)
     out = "#{call} do\n #{block}\n end"
 
     out

--- a/lib/brakeman/tracker/controller.rb
+++ b/lib/brakeman/tracker/controller.rb
@@ -125,7 +125,7 @@ module Brakeman
         value = args[-1][2]
         case value.node_type
         when :array
-          filter[option] = value[1..-1].map {|v| v[1] }
+          filter[option] = value.sexp_body.map {|v| v[1] }
         when :lit, :str
           filter[option] = value[1]
         else

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -321,7 +321,7 @@ module Brakeman::Util
       if node_type? current, :class
         return true
       elsif sexp? current
-        todo = current[1..-1].concat todo
+        todo = current.sexp_body.concat todo
       end
     end
 
@@ -334,7 +334,7 @@ module Brakeman::Util
     if args.empty? or args.first.empty?
       #nothing to do
     elsif node_type? args.first, :arglist
-      call.concat args.first[1..-1]
+      call.concat args.first.sexp_body
     elsif args.first.node_type.is_a? Sexp #just a list of args
       call.concat args.first
     else

--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -175,7 +175,7 @@ class Sexp
     start_index = 3
 
     if exp.is_a? Sexp and exp.node_type == :arglist
-      exp = exp[1..-1]
+      exp = exp.sexp_body
     end
 
     exp.each_with_index do |e, i|
@@ -198,10 +198,10 @@ class Sexp
 
     case self.node_type
     when :call, :attrasgn, :safe_call, :safe_attrasgn
-      self[3..-1].unshift :arglist
+      self.sexp_body(3).unshift :arglist
     when :super, :zsuper
       if self[1]
-        self[1..-1].unshift :arglist
+        self.sexp_body.unshift :arglist
       else
         Sexp.new(:arglist)
       end
@@ -218,13 +218,13 @@ class Sexp
     case self.node_type
     when :call, :attrasgn, :safe_call, :safe_attrasgn
       if self[3]
-        self[3..-1]
+        self.sexp_body(3)
       else
         Sexp.new
       end
     when :super, :zsuper
       if self[1]
-        self[1..-1]
+        self.sexp_body
       else
         Sexp.new
       end
@@ -512,7 +512,7 @@ class Sexp
     self.slice!(index..-1) #Remove old body
 
     if exp.first == :rlist
-      exp = exp[1..-1]
+      exp = exp.sexp_body
     end
 
     #Insert new body
@@ -529,11 +529,11 @@ class Sexp
 
     case self.node_type
     when :defn, :class
-      self[3..-1]
+      self.sexp_body(3)
     when :defs
-      self[4..-1]
+      self.sexp_body(4)
     when :module
-      self[2..-1]
+      self.sexp_body(2)
     end
   end
 


### PR DESCRIPTION
- Avoid slicing Sexps, as that now returns an Array instead of a Sexp
- Declare REXML as a dependency