### PR TITLE
Ignore Tempfile paths in shell commands

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -151,6 +151,12 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
     method[-1] == "?"
   end
 
+  TEMP_FILE_PATH = s(:call, s(:call, s(:const, :Tempfile), :new), :path).freeze
+
+  def temp_file_path? exp
+    exp == TEMP_FILE_PATH
+  end
+
   #Report a warning
   def warn options
     extra_opts = { :check => self.class.to_s }

--- a/lib/brakeman/checks/check_execute.rb
+++ b/lib/brakeman/checks/check_execute.rb
@@ -204,6 +204,7 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
       next if node_type? e, :lit, :str
       next if SAFE_VALUES.include? e
       next if shell_escape? e
+      next if temp_file_path? e
 
       if node_type? e, :if
         # If we're in a conditional, evaluate the `then` and `else` clauses to

--- a/test/apps/rails6/lib/run_stuff.rb
+++ b/test/apps/rails6/lib/run_stuff.rb
@@ -1,0 +1,7 @@
+class RunStuff
+  def run
+    Tempfile.open("cool_stuff.txt") do |temp_file|
+      `cat #{temp_file.path}`
+    end
+  end
+end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -393,6 +393,19 @@ class Rails6Tests < Minitest::Test
       :user_input => s(:lvar, :thing)
   end
 
+  def test_command_injection_with_temp_file_path
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :fingerprint => "0e28d1629630acaf62f873043ad128de709ac423f86256bed8fa73fdc8756f20",
+      :warning_type => "Command Injection",
+      :line => 4,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 1,
+      :relative_path => "lib/run_stuff.rb",
+      :code => s(:dxstr, "cat ", s(:evstr, s(:call, s(:lvar, :temp_file), :path))),
+      :user_input => s(:call, s(:lvar, :temp_file), :path)
+  end
+
   def test_dynamic_render_path_dir_glob_filter
     assert_no_warning :type => :warning,
       :warning_code => 15,


### PR DESCRIPTION
Ignore uses of `Tempfile#path` in shell commands.

Also adds support for Tempfiles like:

```ruby
Tempfile.open('...') do |file|
  # Brakeman knows `file` is a Tempfile
end