### PR TITLE
Redo CSV report to make it useful

### DIFF
--- a/lib/brakeman/report/report_base.rb
+++ b/lib/brakeman/report/report_base.rb
@@ -11,8 +11,6 @@ class Brakeman::Report::Base
 
   attr_reader :tracker, :checks
 
-  TEXT_CONFIDENCE = Brakeman::Warning::TEXT_CONFIDENCE
-
   def initialize tracker
     @app_tree = tracker.app_tree
     @tracker = tracker

--- a/lib/brakeman/report/report_csv.rb
+++ b/lib/brakeman/report/report_csv.rb
@@ -1,72 +1,49 @@
 require 'csv'
-require "brakeman/report/report_table"
 
-class Brakeman::Report::CSV < Brakeman::Report::Table
+class Brakeman::Report::CSV < Brakeman::Report::Base
   def generate_report
-    output = csv_header
-    output << "\nSUMMARY\n"
+    headers = [
+      "Confidence",
+      "Warning Type",
+      "File",
+      "Line",
+      "Message",
+      "Code",
+      "User Input",
+      "Check Name",
+      "Warning Code",
+      "Fingerprint",
+      "Link"
+    ]
 
-    output << table_to_csv(generate_overview) << "\n"
-
-    output << table_to_csv(generate_warning_overview) << "\n"
-
-    #Return output early if only summarizing
-    if tracker.options[:summary_only]
-      return output
+    rows = tracker.filtered_warnings.sort_by do |w|
+      [w.confidence, w.warning_type, w.file, w.line, w.fingerprint]
+    end.map do |warning|
+      generate_row(headers, warning)
     end
 
-    if tracker.options[:report_routes] or tracker.options[:debug]
-      output << "CONTROLLERS\n"
-      output << table_to_csv(generate_controllers) << "\n"
-    end
+    table = CSV::Table.new(rows)
 
-    if tracker.options[:debug]
-      output << "TEMPLATES\n\n"
-      output << table_to_csv(generate_templates) << "\n"
-    end
-
-    res = generate_errors
-    output << "ERRORS\n" << table_to_csv(res) << "\n" if res
-
-    res = generate_warnings
-    output << "SECURITY WARNINGS\n" << table_to_csv(res) << "\n" if res
-
-    output << "Controller Warnings\n"
-    res = generate_controller_warnings
-    output << table_to_csv(res) << "\n" if res
-
-    output << "Model Warnings\n"
-    res = generate_model_warnings
-    output << table_to_csv(res) << "\n" if res
-
-    res = generate_template_warnings
-    output << "Template Warnings\n"
-    output << table_to_csv(res) << "\n" if res
-
-    output
+    table.to_csv
   end
 
-  #Generate header for CSV output
-  def csv_header
-    header = CSV.generate_line(["Application Path", "Report Generation Time", "Checks Performed", "Rails Version"])
-    header << CSV.generate_line([File.expand_path(tracker.app_path), Time.now.to_s, checks.checks_run.sort.join(", "), rails_version])
-    "BRAKEMAN REPORT\n\n" + header
+  def generate_row headers, warning
+    CSV::Row.new headers, warning_row(warning)
   end
 
-  # rely on Terminal::Table to build the structure, extract the data out in CSV format
-  def table_to_csv table
-    return "" unless table
-
-    Brakeman.load_brakeman_dependency 'terminal-table'
-    headings = table.headings
-    if headings.is_a? Array
-      headings = headings.first
-    end
-
-    output = CSV.generate_line(headings.cells.map{|cell| cell.to_s.strip})
-    table.rows.each do |row|
-      output << CSV.generate_line(row.cells.map{|cell| cell.to_s.strip})
-    end
-    output
+  def warning_row warning
+    [
+      warning.confidence_name,
+      warning.warning_type,
+      warning_file(warning),
+      warning.line,
+      warning.message,
+      warning.code && warning.format_code(false),
+      warning.user_input && warning.format_user_input(false),
+      warning.check_name,
+      warning.warning_code,
+      warning.fingerprint,
+      warning.link,
+    ]
   end
 end

--- a/lib/brakeman/report/report_junit.rb
+++ b/lib/brakeman/report/report_junit.rb
@@ -47,7 +47,7 @@ class Brakeman::Report::JUnit < Brakeman::Report::Base
       warning.add_attribute 'brakeman:file', warning_file(w)
       warning.add_attribute 'brakeman:line', w.line
       warning.add_attribute 'brakeman:fingerprint', w.fingerprint
-      warning.add_attribute 'brakeman:confidence', TEXT_CONFIDENCE[w.confidence]
+      warning.add_attribute 'brakeman:confidence', w.confidence_name 
       warning.add_attribute 'brakeman:code', w.format_code
       warning.add_text w.to_s
     }
@@ -88,7 +88,7 @@ class Brakeman::Report::JUnit < Brakeman::Report::Base
           failure.add_attribute 'brakeman:fingerprint', warning.fingerprint
           failure.add_attribute 'brakeman:file', warning_file(warning)
           failure.add_attribute 'brakeman:line', warning.line
-          failure.add_attribute 'brakeman:confidence', TEXT_CONFIDENCE[warning.confidence]
+          failure.add_attribute 'brakeman:confidence', warning.confidence_name 
           failure.add_attribute 'brakeman:code', warning.format_code
           failure.add_text warning.to_s
         }

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -27,7 +27,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::Base
   def rules
     @rules ||= unique_warnings_by_warning_code.map do |warning|
       rule_id = render_id warning
-      check_name = warning.check.gsub(/^Brakeman::Check/, '')
+      check_name = warning.check_name
       check_description = render_message check_descriptions[check_name]
       {
         :id => rule_id,

--- a/lib/brakeman/report/report_tabs.rb
+++ b/lib/brakeman/report/report_tabs.rb
@@ -10,7 +10,7 @@ class Brakeman::Report::Tabs < Brakeman::Report::Table
       self.send(meth).map do |w|
         line = w.line || 0
         w.warning_type.gsub!(/[^\w\s]/, ' ')
-        "#{(w.file.absolute)}\t#{line}\t#{w.warning_type}\t#{category}\t#{w.format_message}\t#{TEXT_CONFIDENCE[w.confidence]}"
+        "#{(w.file.absolute)}\t#{line}\t#{w.warning_type}\t#{category}\t#{w.format_message}\t#{w.confidence_name}"
       end.join "\n"
 
     end.join "\n"

--- a/lib/brakeman/report/report_text.rb
+++ b/lib/brakeman/report/report_text.rb
@@ -160,7 +160,7 @@ class Brakeman::Report::Text < Brakeman::Report::Base
     when :category
       label('Category', w.warning_type.to_s)
     when :check
-      label('Check', w.check.gsub(/^Brakeman::Check/, ''))
+      label('Check', w.check_name)
     when :message
       label('Message', w.message)
     when :code

--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -275,6 +275,14 @@ class Brakeman::Warning
     self.file.relative
   end
 
+  def check_name
+    @check_name ||= self.check.sub(/^Brakeman::Check/, '')
+  end
+
+  def confidence_name
+    TEXT_CONFIDENCE[self.confidence]
+  end
+
   def to_hash absolute_paths: true
     if self.called_from and not absolute_paths
       render_path = self.called_from.with_relative_paths
@@ -285,7 +293,7 @@ class Brakeman::Warning
     { :warning_type => self.warning_type,
       :warning_code => @warning_code,
       :fingerprint => self.fingerprint,
-      :check_name => self.check.gsub(/^Brakeman::Check/, ''),
+      :check_name => self.check_name,
       :message => self.message.to_s,
       :file => (absolute_paths ? self.file.absolute : self.file.relative),
       :line => self.line,
@@ -294,7 +302,7 @@ class Brakeman::Warning
       :render_path => render_path,
       :location => self.location(false),
       :user_input => (@user_input && self.format_user_input(false)),
-      :confidence => TEXT_CONFIDENCE[self.confidence]
+      :confidence => self.confidence_name
     }
   end
 

--- a/test/tests/report_generation.rb
+++ b/test/tests/report_generation.rb
@@ -40,13 +40,13 @@ class TestReportGeneration < Minitest::Test
   end
 
   def test_csv_sanity
+    headers = ["Confidence", "Warning Type", "File", "Line", "Message", "Code", "User Input", "Check Name", "Warning Code", "Fingerprint", "Link"]
     report = @@report.to_csv
-    parsed = CSV.parse report
-    summary_header = ["Application Path", "Report Generation Time", "Checks Performed", "Rails Version"]
+    parsed = CSV.parse report, headers: true
+    row = parsed.first
 
-    assert report.is_a? String
-    assert_equal ["BRAKEMAN REPORT"], parsed[0]
-    assert_equal summary_header, parsed[2]
+    assert_equal row.headers, headers
+    assert_equal parsed.length, @@report.tracker.filtered_warnings.length
   end
 
   def test_csv_report_no_warnings


### PR DESCRIPTION
The CSV report was originally intended to be more like an Excel format, but that was clearly wrong. It also was mirroring the old table format which had different information for different warnings, a summary of the scan, etc.

This PR changes the CSV report to only list the warnings, plus updates the columns to be more consistent with other report formats.

Example:

```csv
Confidence,Warning Type,File,Line,Message,Code,User Input,Check Name,Warning Code,Fingerprint,Link
High,Command Injection,app/controllers/groups_controller.rb,10,Possible command injection,"`#{params.require(""name"")} some optional text`","params.require(""name"")",Execute,14,6c1c068078e37b94af882d43bd6e239dd8e28912b7f0a56f11b82a504915c064,https://brakemanscanner.org/docs/warning_types/command_injection/
```