### PR TITLE
Ignore development environments

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -161,6 +161,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   ARRAY_CONST = s(:const, :Array)
   HASH_CONST = s(:const, :Hash)
   RAILS_TEST = s(:call, s(:call, s(:const, :Rails), :env), :test?)
+  RAILS_DEV = s(:call, s(:call, s(:const, :Rails), :env), :development?)
 
   #Process a method call.
   def process_call exp
@@ -197,7 +198,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       return Sexp.new(:array, *exp.args)
     elsif target == HASH_CONST and method == :new and first_arg.nil? and !node_type?(@exp_context.last, :iter)
       return Sexp.new(:hash)
-    elsif exp == RAILS_TEST
+    elsif exp == RAILS_TEST or exp == RAILS_DEV
       return Sexp.new(:false)
     end
 

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -45,4 +45,10 @@ class GroupsController < ApplicationController
     Kernel.tap(&params[:method].to_sym)
     User.method("#{User.first.some_method_thing}_stuff")
   end
+
+  def only_for_dev
+    if Rails.env.development?
+      eval(params[:x]) # should not warn
+    end
+  end
 end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -509,4 +509,17 @@ class Rails6Tests < Minitest::Test
       :code => s(:if, s(:call, s(:call, nil, :request), :get?), nil, nil),
       :user_input => s(:call, s(:call, nil, :request), :get?)
   end
+
+  def test_skip_dev_environment
+    assert_no_warning :type => :warning,
+      :warning_code => 13,
+      :fingerprint => "a7759c4ad34056fffc847aff31c9b40d90803cd5637a7189b0edfd7615132f37",
+      :warning_type => "Dangerous Eval",
+      :line => 51,
+      :message => /^User\ input\ in\ eval/,
+      :confidence => 0,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, nil, :eval, s(:call, s(:params), :[], s(:lit, :x))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :x))
+  end
 end


### PR DESCRIPTION
Do not warn about code guarded by `if Rails.env.development?` conditions.

This is the same as `if Rails.env.test?` is currently handled.