### PR TITLE
Collapse __send__ calls

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -187,7 +187,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     method = exp.method
     first_arg = exp.first_arg
 
-    if method == :send or method == :try
+    if method == :send or method == :__send__ or method == :try
       collapse_send_call exp, first_arg
     end
 

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -358,6 +358,13 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
+  def test_safe___send__
+    assert_alias 'X.y(:z)', <<-RUBY
+    a = X.__send__(:y, :z)
+    a
+    RUBY
+  end
+
   def test_try_collapse
     assert_alias 'x.y', <<-RUBY
       z = x.try(:y)


### PR DESCRIPTION
As is already done for send and try calls.

Example:

```ruby
X.__send__(:y,  'something')
```

becomes

```ruby
X.y('something')
```