### PR TITLE
Do dataflow on all of 'library' code

### DIFF
--- a/lib/brakeman/processor.rb
+++ b/lib/brakeman/processor.rb
@@ -95,7 +95,8 @@ module Brakeman
 
     #Process source for a library file
     def process_lib src, file_name
-      LibraryProcessor.new(@tracker).process_library src, file_name
+      result = LibraryProcessor.new(@tracker).process_library src, file_name
+      AliasProcessor.new(@tracker, file_name).process result if result
     end
   end
 end

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -31,6 +31,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     @helper_method_info = Hash.new({})
     @or_depth_limit = (tracker && tracker.options[:branch_limit]) || 5 #arbitrary default
     @meth_env = nil
+    @initializer_envs = {}
     @current_file = current_file
     set_env_defaults
   end
@@ -432,7 +433,17 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   #Process a method definition.
   def process_defn exp
     meth_env do
+      unless exp.method_name == :initialize
+        env.current.merge! @initializer_envs.fetch(@current_class, {}).to_h
+      end
+
       exp.body = process_all! exp.body
+
+      if @current_class and exp.method_name == :initialize
+        # Call Env#current to get just a hash of
+        # instance variables and their values
+        @initializer_envs[@current_class] = only_ivars.current
+      end
     end
     exp
   end

--- a/lib/brakeman/processors/library_processor.rb
+++ b/lib/brakeman/processors/library_processor.rb
@@ -30,15 +30,6 @@ class Brakeman::LibraryProcessor < Brakeman::BaseProcessor
   end
 
   def process_defn exp
-    if exp.method_name == :initialize
-      @alias_processor.process_safely exp.body_list
-      @initializer_env = @alias_processor.only_ivars
-    elsif node_type? exp, :defn
-      exp = @alias_processor.process_safely exp, @initializer_env
-    else
-      exp = @alias_processor.process exp
-    end
-
     if @current_class
       exp.body = process_all! exp.body
       @current_class.add_method :public, exp.method_name, exp, @current_file

--- a/test/apps/rails6/config/initializers/deeper_dir/constants.rb
+++ b/test/apps/rails6/config/initializers/deeper_dir/constants.rb
@@ -1,0 +1,1 @@
+SOME_CONSTANT = '1'

--- a/test/apps/rails6/lib/run_stuff.rb
+++ b/test/apps/rails6/lib/run_stuff.rb
@@ -4,4 +4,12 @@ class RunStuff
       `cat #{temp_file.path}`
     end
   end
+
+  RUN_THINGS = {
+    SOME_CONSTANT => "ASafeString"
+  }
+
+  def use_group_things
+    RUN_THINGS[params[:key]].constantize.new
+  end
 end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -251,6 +251,19 @@ class Rails6Tests < Minitest::Test
       :user_input => s(:call, s(:call, s(:const, :User), :first), :some_method_thing)
   end
 
+  def test_constants_in_libraries
+    assert_no_warning :type => :warning,
+      :warning_code => 24,
+      :fingerprint => "bf29c627bcf090125caf10c73e33cd3f7b66f5f1a2d5ba03b418ed51e3e15b72",
+      :warning_type => "Remote Code Execution",
+      :line => 13,
+      :message => /^Unsafe\ reflection\ method\ `constantize`\ c/,
+      :confidence => 1,
+      :relative_path => "lib/run_stuff.rb",
+      :code => s(:call, s(:call, s(:const, :RUN_THINGS), :[], s(:call, s(:params), :[], s(:lit, :key))), :constantize),
+      :user_input => s(:call, s(:params), :[], s(:lit, :key))
+  end
+
   def test_safe_yaml_load_option
     assert_no_warning :type => :warning,
       :warning_code => 25,


### PR DESCRIPTION
Previously, it was only on method bodies. This probably won't be a huge change, since most code is inside methods.

As a result of this change, now all classes will have instance variable values propagated from their initializers, not just 'libraries'.

In Brakeman, a 'library' is any file/class that doesn't fall into a different category (like controllers, models, initializers, etc.)