### PR TITLE
Convert splat array arguments to arguments

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -183,6 +183,12 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       return exp
     end
 
+    # If x(*[1,2,3]) change to x(1,2,3)
+    # if that's the only argument
+    if splat_array? exp.first_arg and exp.second_arg.nil?
+      exp.arglist = exp.first_arg[1].sexp_body
+    end
+
     target = exp.target
     method = exp.method
     first_arg = exp.first_arg
@@ -357,6 +363,11 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
 
   def temp_file_new line
     s(:call, TEMP_FILE_CLASS, :new).line(line)
+  end
+
+  def splat_array? exp
+    node_type? exp, :splat and
+      node_type? exp[1], :array
   end
 
   def process_iter exp

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -229,6 +229,14 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
+  def test_splat_array_args
+    assert_alias 'x(1, b, :c)', <<-RUBY
+      a = b
+      args = [1, a, :c]
+      x(*args)
+    RUBY
+  end
+
   def test_obvious_if
     assert_alias "'Yes!'", <<-RUBY
       condition = true


### PR DESCRIPTION
In the simplest case, where the splatted array is the only argument.

```ruby
foo(*[1, 2, 3])
```
becomes
```ruby
foo(1,2,3)
```