### PR TITLE
Don't fail if $HOME/$USER are not defined

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -157,10 +157,17 @@ module Brakeman
     end
   end
 
-  CONFIG_FILES = [
-    File.expand_path("~/.brakeman/config.yml"),
-    File.expand_path("/etc/brakeman/config.yml")
-  ]
+  CONFIG_FILES = begin
+                   [
+                     File.expand_path("~/.brakeman/config.yml"),
+                     File.expand_path("/etc/brakeman/config.yml")
+                   ]
+                 rescue ArgumentError
+                   # In case $HOME or $USER aren't defined for use of `~`
+                   [
+                     File.expand_path("/etc/brakeman/config.yml")
+                   ]
+                 end
 
   def self.config_file custom_location, app_path
     app_config = File.expand_path(File.join(app_path, "config", "brakeman.yml"))


### PR DESCRIPTION
It can happen... e.g. in AWS Lambda :sweat_smile: 

I kind of want to just drop these entirely... does anyone use global Brakeman configs??