### PR TITLE
Support loading `slim/smart`

### DIFF
--- a/test/apps/rails5.2/Gemfile
+++ b/test/apps/rails5.2/Gemfile
@@ -60,3 +60,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "slim", "~> 3.0.1", require: ["slim", "slim/smart"]

--- a/test/apps/rails5.2/app/views/users/smart.html.slim
+++ b/test/apps/rails5.2/app/views/users/smart.html.slim
@@ -1,0 +1,11 @@
+p
+  Your credit card
+  strong will not
+  > be charged now.
+
+This is a text
+  which spans
+  several lines.
+
+footer
+  Copyright &copy; #{params[:x]} not xss?


### PR DESCRIPTION
in the very specific case where `slim/smart` is mentioned in the Gemfile.

If others need this functionality, it can be expanded. It's just awkward to find where apps `require` things with the way Brakeman works, if you need to know early in the analysis. So, this is a hack.

Fixes #1570