### PR TITLE
Detect `::Rails.application.configure` too

### DIFF
--- a/lib/brakeman/processors/lib/rails4_config_processor.rb
+++ b/lib/brakeman/processors/lib/rails4_config_processor.rb
@@ -2,10 +2,11 @@ require 'brakeman/processors/lib/rails3_config_processor'
 
 class Brakeman::Rails4ConfigProcessor < Brakeman::Rails3ConfigProcessor
   APPLICATION_CONFIG = s(:call, s(:call, s(:const, :Rails), :application), :configure)
+  ALT_APPLICATION_CONFIG = s(:call, s(:call, s(:colon3, :Rails), :application), :configure)
 
   # Look for Rails.application.configure do ... end
   def process_iter exp
-    if exp.block_call == APPLICATION_CONFIG
+    if exp.block_call == APPLICATION_CONFIG or exp.block_call == ALT_APPLICATION_CONFIG
       @inside_config = true
       process exp.block if sexp? exp.block
       @inside_config = false

--- a/test/apps/rails6/config/environments/production.rb
+++ b/test/apps/rails6/config/environments/production.rb
@@ -1,4 +1,4 @@
-Rails.application.configure do
+::Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.


### PR DESCRIPTION
Not just `Rails.application.configure`.

Probably should normalize constants, at least when they are at the top-level. But that might be too disruptive.

Fixes #1584