### PR TITLE
Support `fetch` from both arrays and hashes

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -227,6 +227,15 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       elsif hash? target
         exp = process_hash_access(target, first_arg, exp)
       end
+    when :fetch
+      if array? target
+        # Not dealing with default value
+        # so just pass in first argument, but process_array_access expects
+        # an array of arguments.
+        exp = process_array_access(target, [first_arg], exp)
+      elsif hash? target
+        exp = process_hash_access(target, first_arg, exp)
+      end
     when :merge!, :update
       if hash? target and hash? first_arg
          target = process_hash_merge! target, first_arg

--- a/lib/brakeman/processors/lib/call_conversion_helper.rb
+++ b/lib/brakeman/processors/lib/call_conversion_helper.rb
@@ -76,6 +76,8 @@ module Brakeman
 
         #Have to do this because first element is :array and we have to skip it
         array[1..-1][index] or original_exp
+      elsif all_literals? array
+        safe_literal(array.line)
       else
         original_exp
       end

--- a/test/apps/rails6/app/models/group.rb
+++ b/test/apps/rails6/app/models/group.rb
@@ -12,4 +12,10 @@ class Group < ApplicationRecord
     query = ActiveRecord::Base.sanitize_sql_like(query) # escaped variable
     Arel.sql("name ILIKE '%#{query}%'")
   end
+
+  def fetch_constant_hash_value(role_name)
+    roles = { admin: 1, moderator: 2 }.freeze
+    role = roles.fetch(role_name)
+    Arel.sql("role = '#{role}'")
+  end
 end

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -130,6 +130,14 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
+  def test_array_fetch_unknown_literal
+    assert_alias ':BRAKEMAN_SAFE_LITERAL', <<-RUBY
+    x = [1, 2, 3]
+    y = x.fetch(z)
+    y
+    RUBY
+  end
+
   def test_array_append
     assert_alias '[1, 2, 3]', <<-RUBY
       x = [1]
@@ -218,6 +226,13 @@ class AliasProcessorTests < Minitest::Test
     assert_alias '1', <<-RUBY
       x = { a: 0, b: 1, c: 3 }
       x.fetch(:b)
+    RUBY
+  end
+
+  def test_hash_fetch_unknown_literal
+    assert_alias ':BRAKEMAN_SAFE_LITERAL', <<-RUBY
+      x = { a: 0, b: 1, c: 3 }
+      x.fetch(:z)
     RUBY
   end
 

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -123,6 +123,12 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
+  def test_array_fetch
+    assert_alias '3', <<-RUBY
+    x = [1, 2, 3]
+    x.fetch(2)
+    RUBY
+  end
 
   def test_array_append
     assert_alias '[1, 2, 3]', <<-RUBY
@@ -205,6 +211,13 @@ class AliasProcessorTests < Minitest::Test
       x[:hello] = "hello world"
       x.merge! :goodbye => "You say goodbye, I say :hello"
       x[:goodbye]
+    RUBY
+  end
+
+  def test_hash_fetch
+    assert_alias '1', <<-RUBY
+      x = { a: 0, b: 1, c: 3 }
+      x.fetch(:b)
     RUBY
   end
 

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -134,7 +134,6 @@ class Rails6Tests < Minitest::Test
       :user_input => s(:call, s(:call, s(:lit, 30), :days), :ago)
   end
 
-
   def test_sql_injection_sanitize_sql_like
     assert_no_warning :type => :warning,
       :warning_code => 0,
@@ -146,6 +145,19 @@ class Rails6Tests < Minitest::Test
       :relative_path => "app/models/group.rb",
       :code => s(:call, s(:const, :Arel), :sql, s(:dstr, "name ILIKE '%", s(:evstr, s(:call, s(:colon2, s(:const, :ActiveRecord), :Base), :sanitize_sql_like, s(:lvar, :query))), s(:str, "%'"))),
       :user_input => s(:call, s(:colon2, s(:const, :ActiveRecord), :Base), :sanitize_sql_like, s(:lvar, :query))
+  end
+
+  def test_sql_injection_hash_fetch_all_literals
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "1b9a04c9fdc4b8c7f215387fb726dc542c2d35dde2f29b48a76248443524a5fa",
+      :warning_type => "SQL Injection",
+      :line => 14,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 1,
+      :relative_path => "app/models/group.rb",
+      :code => s(:call, s(:const, :Arel), :sql, s(:dstr, "role = '", s(:evstr, s(:call, s(:hash, s(:lit, :admin), s(:lit, 1), s(:lit, :moderator), s(:lit, 2)), :fetch, s(:lvar, :role_name))), s(:str, "'"))),
+      :user_input => s(:call, s(:hash, s(:lit, :admin), s(:lit, 1), s(:lit, :moderator), s(:lit, 2)), :fetch, s(:lvar, :role_name))
   end
 
   def test_cross_site_scripting_sanity


### PR DESCRIPTION
Attempt to fetch values from arrays/hashes based on key provided in `fetch`, if possible. But does _not_ use the default value.

If the array or hash has all literal values but the key is unknown (e.g. a variable we don't know the value of), returns a safe literal instead. This was already in place for `Hash#[]` but somehow not `Array#[]` 🤔 

Fixes one of the issues from #1571 