### PR TITLE
Support Hash#values_at and Hash#values

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -301,6 +301,10 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       if node_type? target, :hash
         exp = hash_values(target)
       end
+    when :values_at
+      if hash? target
+        exp = hash_values_at target, exp.args
+      end
     end
 
     exp

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -296,6 +296,11 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       if call? target and target.method == :!
         exp = s(:or, s(:true).line(exp.line), s(:false).line(exp.line)).line(exp.line)
       end
+    when :values
+      # Hash literal
+      if node_type? target, :hash
+        exp = hash_values(target)
+      end
     end
 
     exp

--- a/lib/brakeman/processors/lib/call_conversion_helper.rb
+++ b/lib/brakeman/processors/lib/call_conversion_helper.rb
@@ -94,5 +94,13 @@ module Brakeman
         original_exp
       end
     end
+
+    def hash_values_at hash, keys
+      values = keys.map do |key|
+        process_hash_access hash, key
+      end
+
+      Sexp.new(:array).concat(values).line(hash.line)
+    end
   end
 end

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -142,6 +142,14 @@ module Brakeman::Util
     nil
   end
 
+  def hash_values hash
+    values = hash.each_sexp.each_slice(2).map do |_, value|
+      value
+    end
+
+    s(:array).concat(values)
+  end
+
   #These are never modified
   PARAMS_SEXP = Sexp.new(:params)
   SESSION_SEXP = Sexp.new(:session)

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -147,7 +147,7 @@ module Brakeman::Util
       value
     end
 
-    s(:array).concat(values)
+    Sexp.new(:array).concat(values).line(hash.line)
   end
 
   #These are never modified

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -249,6 +249,13 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
+  def test_hash_values
+    assert_alias '[1, 2, 3]', <<-RUBY
+      h = { a: 1, b: 2, c: 3 }
+      h.values
+    RUBY
+  end
+
   def test_hash_double_splat
     assert_alias "1", <<-RUBY
       a = { a: 1, b: "two", c: :three }

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -256,6 +256,20 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
+  def test_hash_values_at
+    assert_alias '[1, 2]', <<-RUBY
+      h = { a: 1, b: 2, c: 3 }
+      h.values_at(:a, :b)
+    RUBY
+  end
+
+  def test_hash_values_at_missing
+    assert_alias '[1, 2, :BRAKEMAN_SAFE_LITERAL]', <<-RUBY
+      h = { a: 1, b: 2, c: 3 }
+      h.values_at(:a, :b, :z)
+    RUBY
+  end
+
   def test_hash_double_splat
     assert_alias "1", <<-RUBY
       a = { a: 1, b: "two", c: :three }


### PR DESCRIPTION
Examples:

```ruby
h = { a: 1, b: 2, c: 3 }
values = h.values   #=> [1, 2]
v[1]                #=> 2
```

```ruby
h = { a: 1, b: 2, c: 3 }
values = h.values_at(:a, :c)  #=> [1, 3]
v[1]                          #=> 3
```

Also, if a hash table is all literal values, but the key is unknown (e.g. an argument), Brakeman will treat the value as a safe literal value.