### PR TITLE
Adjust the copy of the interactive menu

### DIFF
--- a/lib/brakeman/report/ignore/interactive.rb
+++ b/lib/brakeman/report/ignore/interactive.rb
@@ -62,7 +62,7 @@ module Brakeman
           process_warnings
         end
 
-        m.choice "Hide previously ignored warnings" do
+        m.choice "Inspect new warnings" do
           @skip_ignored = true
           pre_show_help
           process_warnings


### PR DESCRIPTION
The first and second options are referring to *inspecting warnings* and to *hiding warnings* respectively.
This is a bit confusing when the actual thing the user wants to do is to have a look at new warnings, and eventually decide if they need to be ignored.
