### PR TITLE
Updates to Array#join handling

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -220,7 +220,13 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
         exp = math_op(:+, target, first_arg, exp)
       end
     when :-, :*, :/
-      exp = math_op(method, target, first_arg, exp)
+      if method == :* and array? target
+        if target.length > 2 and string? first_arg
+          exp = process_array_join(target, first_arg)
+        end
+      else
+        exp = math_op(method, target, first_arg, exp)
+      end
     when :[]
       if array? target
         exp = process_array_access(target, exp.args, exp)

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -350,7 +350,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     result.unshift combined_first
 
     # Have to fix up strings that follow interpolation
-    result.reduce(s(:dstr).line(array.line)) do |memo, e|
+    string = result.reduce(s(:dstr).line(array.line)) do |memo, e|
       if string? e and node_type? memo.last, :evstr
         e.value = "#{join_value}#{e.value}"
       elsif join_value and node_type? memo.last, :evstr and node_type? e, :evstr
@@ -359,6 +359,14 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
 
       memo << e
     end
+
+    # Convert (:dstr, "hello world")
+    # to (:str, "hello world")
+    if string.length == 2 and string.last.is_a? String
+      string[0] = :str
+    end
+
+    string
   end
 
   def join_item item, join_value

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -318,6 +318,11 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
 
   # Painful conversion of Array#join into string interpolation
   def process_array_join array, join_str
+    # Empty array
+    if array.length == 1
+      return s(:str, '').line(array.line)
+    end
+
     result = s().line(array.line)
 
     join_value = if string? join_str

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -221,7 +221,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       end
     when :-, :*, :/
       if method == :* and array? target
-        if target.length > 2 and string? first_arg
+        if string? first_arg
           exp = process_array_join(target, first_arg)
         end
       else
@@ -294,7 +294,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
         exp = target
       end
     when :join
-      if array? target and target.length > 2 and (string? first_arg or first_arg.nil?)
+      if array? target and (string? first_arg or first_arg.nil?)
         exp = process_array_join(target, first_arg)
       end
     when :!
@@ -326,8 +326,10 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
                    nil
                  end
 
-    array[1..-2].each do |e|
-      result << join_item(e, join_value)
+    if array.length > 2
+      array[1..-2].each do |e|
+        result << join_item(e, join_value)
+      end
     end
 
     result << join_item(array.last, nil)

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1221,6 +1221,13 @@ class AliasProcessorTests < Minitest::Test
     assert_equal 1, processed_sexp[2][3].line
   end
 
+  def test_array_join_single_value
+    assert_alias "'hello'", <<-INPUT
+      x = ["hello"].join(' ')
+      x
+    INPUT
+  end
+
   def test_ignore_freeze
     assert_alias "blah", <<-INPUT
     x = blah.freeze

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1228,6 +1228,13 @@ class AliasProcessorTests < Minitest::Test
     INPUT
   end
 
+  def test_array_join_empty_array
+    assert_alias "''", <<-INPUT
+      x = [].join(' ')
+      x
+    INPUT
+  end
+
   def test_ignore_freeze
     assert_alias "blah", <<-INPUT
     x = blah.freeze

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1200,6 +1200,15 @@ class AliasProcessorTests < Minitest::Test
     INPUT
   end
 
+  def test_array_star_join
+    assert_alias '"a b 1"', <<-'INPUT'
+      a = :a
+      b = 'b'
+      c = 1
+      [a, b, c] * ' '
+    INPUT
+  end
+
   def test_array_join_line_numbers
     # Test that line numbers are set for all parts of a joined string
     original_sexp = RubyParser.new.parse "z = [x, 1].join(' ')"


### PR DESCRIPTION
* Treat `Array#*` like `Array#join`
* `Array#join` with single (simple) element array returns that element
* `[].join(..)` returns `''` empty string
* If everything ends up as a plain string, return `:str` instead of `:dstr` node type