### PR TITLE
Add sql safe methods

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -215,6 +215,10 @@ To indicate certain methods return properly escaped output and should not be war
 
     brakeman --safe-methods benign_method_escapes_output,totally_safe_from_xss
 
+To indicate certain methods return properly escaped output and should not be warned about in SQL checks:
+
+    brakeman --sql-safe-methods benign_method_escapes_output,totally_safe_from_sql
+
 Brakeman warns about use of user input in URLs generated with `link_to`. Since Rails does not provide anyway of making these URLs really safe (e.g. limiting protocols to HTTP(S)), safe methods can be ignored with
 
     brakeman --url-safe-methods ensure_safe_protocol_or_something

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -65,7 +65,7 @@ module Brakeman
   #  * :report_routes - show found routes on controllers (default: false)
   #  * :run_checks - array of checks to run (run all if not specified)
   #  * :safe_methods - array of methods to consider safe
-  #  * :sql_safe_methods - array of sql sanatization methods to consider safe
+  #  * :sql_safe_methods - array of sql sanitization methods to consider safe
   #  * :skip_libs - do not process lib/ directory (default: false)
   #  * :skip_vendor - do not process vendor/ directory (default: true)
   #  * :skip_checks - checks not to run (run all if not specified)

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -65,6 +65,7 @@ module Brakeman
   #  * :report_routes - show found routes on controllers (default: false)
   #  * :run_checks - array of checks to run (run all if not specified)
   #  * :safe_methods - array of methods to consider safe
+  #  * :sql_safe_methods - array of sql sanatization methods to consider safe
   #  * :skip_libs - do not process lib/ directory (default: false)
   #  * :skip_vendor - do not process vendor/ directory (default: true)
   #  * :skip_checks - checks not to run (run all if not specified)
@@ -198,6 +199,7 @@ module Brakeman
       :relative_path => false,
       :report_progress => true,
       :safe_methods => Set.new,
+      :sql_safe_methods => Set.new,
       :skip_checks => Set.new,
       :skip_vendor => true,
     }

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -577,7 +577,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     :sanitize_sql_hash_for_assignment, :sanitize_sql_hash_for_conditions,
     :to_sql, :sanitize, :primary_key, :table_name_prefix, :table_name_suffix,
     :where_values_hash, :foreign_key, :uuid
-  ]
+  ].merge(tracker.options[:sql_safe_methods] || [])
 
   def safe_value? exp
     return true unless sexp? exp

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -577,7 +577,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     :sanitize_sql_hash_for_assignment, :sanitize_sql_hash_for_conditions,
     :to_sql, :sanitize, :primary_key, :table_name_prefix, :table_name_suffix,
     :where_values_hash, :foreign_key, :uuid
-  ].merge(tracker.options[:sql_safe_methods] || [])
+  ]
 
   def ignore_methods_in_sql
     @ignore_methods_in_sql ||= IGNORE_METHODS_IN_SQL.merge(tracker.options[:sql_safe_methods] || [])

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -580,6 +580,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
   ]
 
   def ignore_methods_in_sql
+    puts tracker.options[:sql_safe_methods]
     @ignore_methods_in_sql ||= IGNORE_METHODS_IN_SQL.merge(tracker.options[:sql_safe_methods] || [])
   end
 

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -579,6 +579,10 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     :where_values_hash, :foreign_key, :uuid
   ].merge(tracker.options[:sql_safe_methods] || [])
 
+  def ignore_methods_in_sql
+    @ignore_methods_in_sql ||= IGNORE_METHODS_IN_SQL.merge(tracker.options[:sql_safe_methods] || [])
+  end
+
   def safe_value? exp
     return true unless sexp? exp
 
@@ -607,7 +611,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
   def ignore_call? exp
     return unless call? exp
 
-    IGNORE_METHODS_IN_SQL.include? exp.method or
+    ignore_methods_in_sql.include? exp.method or
       quote_call? exp or
       arel? exp or
       exp.method.to_s.end_with? "_id" or

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -580,7 +580,6 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
   ]
 
   def ignore_methods_in_sql
-    puts tracker.options[:sql_safe_methods]
     @ignore_methods_in_sql ||= IGNORE_METHODS_IN_SQL.merge(tracker.options[:sql_safe_methods] || [])
   end
 

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -580,7 +580,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
   ]
 
   def ignore_methods_in_sql
-    @ignore_methods_in_sql ||= IGNORE_METHODS_IN_SQL.merge(tracker.options[:sql_safe_methods] || [])
+    @ignore_methods_in_sql ||= IGNORE_METHODS_IN_SQL + (tracker.options[:sql_safe_methods] || [])
   end
 
   def safe_value? exp

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -151,6 +151,11 @@ module Brakeman::Options
           options[:safe_methods].merge methods.map {|e| e.to_sym }
         end
 
+        opts.on "--sql-safe-methods meth1,meth2,etc", Array, "Do not warn of SQL if the input is wrapped in a safe method" do |methods|
+          options[:sql_safe_methods] ||= Set.new
+          options[:sql_safe_methods].merge methods.map {|e| e.to_sym }
+        end
+
         opts.on "--url-safe-methods method1,method2,etc", Array, "Do not warn of XSS if the link_to href parameter is wrapped in a safe method" do |methods|
           options[:url_safe_methods] ||= Set.new
           options[:url_safe_methods].merge methods.map {|e| e.to_sym }

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -53,4 +53,12 @@ class GroupsController < ApplicationController
       eval(params[:x]) # should not warn
     end
   end
+
+  def scope_with_custom_sanitization
+    ActiveRecord::Base.connection.execute "SELECT * FROM #{sanitize_s(user_input)}"
+  end
+
+  def sanitize_s(input)
+    input
+  end
 end

--- a/test/test.rb
+++ b/test/test.rb
@@ -34,7 +34,8 @@ module BrakemanTester
     #Run scan on app at the given path
     def run_scan path, name = nil, opts = {}
       opts.merge! :app_path => "#{TEST_PATH}/apps/#{path}",
-        :url_safe_methods => [:ensure_valid_proto!]
+        :url_safe_methods => [:ensure_valid_proto!],
+        :sql_safe_methods => [:ensure_valid_proto!]
 
       Brakeman.run(opts).report.to_hash
     end

--- a/test/test.rb
+++ b/test/test.rb
@@ -34,8 +34,7 @@ module BrakemanTester
     #Run scan on app at the given path
     def run_scan path, name = nil, opts = {}
       opts.merge! :app_path => "#{TEST_PATH}/apps/#{path}",
-        :url_safe_methods => [:ensure_valid_proto!],
-        :sql_safe_methods => [:ensure_valid_proto!]
+        :url_safe_methods => [:ensure_valid_proto!]
 
       Brakeman.run(opts).report.to_hash
     end

--- a/test/tests/github_output.rb
+++ b/test/tests/github_output.rb
@@ -6,7 +6,7 @@ class TestGithubOutput < Minitest::Test
   end
 
   def test_report_format
-    assert_equal 34, @@report.lines.count
+    assert_equal 35, @@report.lines.count
     @@report.lines.each do |line|
       assert line.start_with?('::'), 'Every line must start with `::`'
       assert_equal 2, line.scan('::').count, 'Every line must have exactly 2 `::`'

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -161,6 +161,11 @@ class BrakemanOptionsTest < Minitest::Test
     assert_equal Set[:test_method1, :test_method2], options[:safe_methods]
   end
 
+  def test__sql_safe_option
+    options = setup_options_from_input("--sql-safe-methods", "test_method2,test_method1,test_method2")
+    assert_equal Set[:test_method1, :test_method2], options[:sql_safe_methods]
+  end
+
   def test__url_safe_option
     options = setup_options_from_input("--url-safe-methods", "test_method2,test_method1,test_method2")
     assert_equal Set[:test_method1, :test_method2], options[:url_safe_methods]

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -121,6 +121,19 @@ class Rails6Tests < Minitest::Test
       :user_input => s(:call, s(:const, :User), :uuid)
   end
 
+  def test_sql_injection_safe_sql_methods_false_postitive
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "205c9aaba1e719acc4f7026c0f65f172d4ac8dd8d036d31a94d7d446c7c874e7",
+      :warning_type => "SQL Injection",
+      :line => 58,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 1,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:call, s(:colon2, s(:const, :ActiveRecord), :Base), :connection), :execute, s(:dstr, "SELECT * FROM ", s(:evstr, s(:call, nil, :sanitize_s, s(:call, nil, :user_input))))),
+      :user_input => s(:call, nil, :sanitize_s, s(:call, nil, :user_input))
+  end
+
   def test_sql_injection_date_integer_target_false_positive
     assert_no_warning :type => :warning,
       :warning_code => 0,

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -5,7 +5,7 @@ class Rails6Tests < Minitest::Test
   include BrakemanTester::CheckExpected
 
   def report
-    @@report ||= BrakemanTester.run_scan "rails6", "Rails 6", run_all_checks: true, sql_safe_methods: [:sanitize_s]
+    @@report ||= BrakemanTester.run_scan "rails6", "Rails 6", :run_all_checks => true, :sql_safe_methods => [:sanitize_s]
   end
 
   def expected

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -5,7 +5,7 @@ class Rails6Tests < Minitest::Test
   include BrakemanTester::CheckExpected
 
   def report
-    @@report ||= BrakemanTester.run_scan "rails6", "Rails 6", run_all_checks: true
+    @@report ||= BrakemanTester.run_scan "rails6", "Rails 6", run_all_checks: true, sql_safe_methods: [:sanitize_s]
   end
 
   def expected


### PR DESCRIPTION
**Description**

This PR adds a feature that allows the user to indicate that certain methods return properly escaped output and should not be warned about in SQL checks. 

**Summary**

- Adds :`sql_safe_methods` as a valid option to be used in the options hash argument when brakeman is called as a library or alternatively permits the use of `--sql-safe-methods` to be used from the command line. 
- Appends argument provided with `--sql-safe-methods`, or `sql_safe_methods` to `IGNORE_METHODS_IN_SQL` array in `CheckSQL` class.
- Adds description of feature to `OPTIONS.md `