### PR TITLE
Fix cve_2018_8048 false positive

### DIFF
--- a/lib/brakeman/checks/check_sanitize_methods.rb
+++ b/lib/brakeman/checks/check_sanitize_methods.rb
@@ -90,7 +90,7 @@ class Brakeman::CheckSanitizeMethods < Brakeman::BaseCheck
   def loofah_vulnerable_cve_2018_8048?
     loofah_version = tracker.config.gem_version(:loofah)
 
-    loofah_version and loofah_version < "2.2.1"
+    loofah_version and Gem::Version.new(loofah_version) < Gem::Version.new("2.2.1")
   end
 
   def warn_sanitizer_cve cve, link, upgrade_version


### PR DESCRIPTION
This PR fixes https://github.com/presidentbeef/brakeman/issues/1603#issue-912936927

String comparison of version strings sometimes makes false positive.
```
'2.10.0' < '2.2.1'
=> true
Gem::Version.new('2.10.0') < Gem::Version.new('2.2.1')
=> false
```