### PR TITLE
Check loofah versions using Gem::Version instead of String#>

### DIFF
--- a/lib/brakeman/checks/check_sanitize_methods.rb
+++ b/lib/brakeman/checks/check_sanitize_methods.rb
@@ -1,4 +1,5 @@
 require 'brakeman/checks/base_check'
+require 'rubygems/version'
 
 #sanitize and sanitize_css are vulnerable:
 #CVE-2013-1855 and CVE-2013-1857
@@ -90,7 +91,7 @@ class Brakeman::CheckSanitizeMethods < Brakeman::BaseCheck
   def loofah_vulnerable_cve_2018_8048?
     loofah_version = tracker.config.gem_version(:loofah)
 
-    loofah_version and loofah_version < "2.2.1"
+    loofah_version and Gem::Version.new(loofah_version) < Gem::Version.new("2.2.1")
   end
 
   def warn_sanitizer_cve cve, link, upgrade_version


### PR DESCRIPTION
With loofah v2.10 ([just released](https://rubygems.org/gems/loofah/versions/2.10.0)) fails interpreting it as an earlier version than 2.2.

This should be ported to all version checks, but I thought this hotfix was still granted to avoid headaches and red CIs to other people facing the same issue.