### PR TITLE
fix loofah version check

### DIFF
--- a/lib/brakeman/checks/check_sanitize_methods.rb
+++ b/lib/brakeman/checks/check_sanitize_methods.rb
@@ -90,7 +90,7 @@ class Brakeman::CheckSanitizeMethods < Brakeman::BaseCheck
   def loofah_vulnerable_cve_2018_8048?
     loofah_version = tracker.config.gem_version(:loofah)
 
-    loofah_version and loofah_version < "2.2.1"
+    loofah_version and Gem::Version.new(loofah_version) < Gem::Version.new("2.2.1")
   end
 
   def warn_sanitizer_cve cve, link, upgrade_version


### PR DESCRIPTION
loofah is up to 2.10 which alphabetically is before 2.2
This changes the check to be a numerical comparison

Now it no longer has a false positive:

```
loofah gem 2.10.0 is vulnerable (CVE-2018-8048). Upgrade to 2.2.1
```

If you want me to go over the rest of the version checks, let me know.