### PR TITLE
Fix Loofah version check

### DIFF
--- a/lib/brakeman/checks/check_sanitize_methods.rb
+++ b/lib/brakeman/checks/check_sanitize_methods.rb
@@ -90,7 +90,8 @@ class Brakeman::CheckSanitizeMethods < Brakeman::BaseCheck
   def loofah_vulnerable_cve_2018_8048?
     loofah_version = tracker.config.gem_version(:loofah)
 
-    loofah_version and loofah_version < "2.2.1"
+    # 2.2.1 is fix version
+    loofah_version and version_between?("0.0.0", "2.2.0", loofah_version)
   end
 
   def warn_sanitizer_cve cve, link, upgrade_version

--- a/test/tests/cves.rb
+++ b/test/tests/cves.rb
@@ -261,6 +261,24 @@ class CVETests < Minitest::Test
     assert_new 1 # CVE-2018-3760
   end
 
+  def test_CVE_2018_8048_exact_fix_version
+    before_rescan_of "Gemfile.lock", "rails5.2" do
+      replace "Gemfile.lock", "loofah (2.1.1)", "loofah (2.2.1)"
+    end
+
+    assert_version "2.2.1", :loofah
+    assert_fixed 1
+  end
+
+  def test_CVE_2018_8048_newer_version
+    before_rescan_of "Gemfile.lock", "rails5.2" do
+      replace "Gemfile.lock", "loofah (2.1.1)", "loofah (2.10.1)"
+    end
+
+    assert_version "2.10.1", :loofah
+    assert_fixed 1
+  end
+
   def test_CVE_2013_0276
     before_rescan_of "app/models/protected.rb", "rails2", :collapse_mass_assignment => true do
       replace "app/models/protected.rb", "attr_accessible nil", "attr_protected :admin"


### PR DESCRIPTION
Fixes #1603

In the interest of time, this supersedes #1604, #1605, #1606 since they didn't include tests and didn't use Brakeman's standard `version_between?` method.