### PR TITLE
merge cookie and param check

### DIFF
--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -238,30 +238,22 @@ module Brakeman::Util
 
   #Check if _exp_ is a params hash
   def params? exp
-    if exp.is_a? Sexp
-      return true if exp.node_type == :params or ALL_PARAMETERS.include? exp
-
-      if call? exp
-        if params? exp[1]
-          return true
-        elsif exp[2] == :[]
-          return params? exp[1]
-        end
-      end
-    end
-
-    false
+    recurse_check?(exp) { |child| child.node_type == :params or ALL_PARAMETERS.include? child }
   end
 
   def cookies? exp
+    recurse_check?(exp) { |child| child.node_type == :cookies or ALL_COOKIES.include? child }
+  end
+
+  def recurse_check? exp, &check
     if exp.is_a? Sexp
-      return true if exp.node_type == :cookies or ALL_COOKIES.include? exp
+      return true if yield(exp)
 
       if call? exp
-        if cookies? exp[1]
+        if recurse_check? exp[1], &check
           return true
         elsif exp[2] == :[]
-          return cookies? exp[1]
+          return recurse_check? exp[1], &check
         end
       end
     end


### PR DESCRIPTION
Hello,

Both cookie and param methods are recursive tests.
This extracts the recursion mechanism into a separate method.

Goal is to remove code climate warning:

https://codeclimate.com/github/presidentbeef/brakeman/lib/brakeman/util.rb/source#issue-25dd99aa71b8bc2260fef8f7a714191a

> Similar blocks of code found in 2 locations. Consider refactoring

As for testing, it looks like most of the `if` blocks are tested except for the last one, `if exp[2] == :[]`
Please double check that I didn't mess that one up.
