### PR TITLE
Fix infinite loop on mixin self-includes

### DIFF
--- a/lib/brakeman/tracker/collection.rb
+++ b/lib/brakeman/tracker/collection.rb
@@ -24,7 +24,7 @@ module Brakeman
     def ancestor? parent, seen={}
       seen[self.name] = true
 
-      if self.parent == parent or seen[self.parent]
+      if self.parent == parent or self.name == parent or seen[self.parent]
         true
       elsif parent_model = collection[self.parent]
         parent_model.ancestor? parent, seen
@@ -39,7 +39,7 @@ module Brakeman
     end
 
     def add_include class_name
-      @includes << class_name
+      @includes << class_name unless ancestor?(class_name)
     end
 
     def add_option name, exp

--- a/test/tests/tracker.rb
+++ b/test/tests/tracker.rb
@@ -74,6 +74,19 @@ class TrackerTests < Minitest::Test
     end
   end
 
+  def test_module_includes_in_same_class
+    ast = RubyParser.new.parse <<~RUBY
+      module Mixin
+        def self.builds_self
+          Class.new { include Mixin }
+        end
+      end
+    RUBY
+
+    Brakeman::LibraryProcessor.new(@tracker).process_library(ast, 'fake_file_name.rb')
+    assert_nil @tracker.find_method(:builds_self, :Mixin)
+  end
+
   private
 
   def parse_class


### PR DESCRIPTION
Adds ae37c48:

> Fixes a regression in 5.0.2 where a module that had code including itself in a class method would cause Brakeman::Tracker#find_method to infinite loop.

Hi! Thanks for the gem! While upgrading from 5.0.1 to 5.0.2 we had this regression when running brakeman in our CI. I narrowed it down to this unorthodox-but-technically-valid-ruby. We have a module in our codebase that includes itself when building a generic class. It caused brakeman to infinite loop on `Brakeman::Tracker#find_method`. I turned the smallest PoC I could into a test case.

Another way to solve this might be to prevent a class being added to its own `includes` collection, but this was the easier fix. Thanks, again! 