### PR TITLE
Avoid false positive about Command Injection on Open3.capture

### DIFF
--- a/lib/brakeman/checks/check_execute.rb
+++ b/lib/brakeman/checks/check_execute.rb
@@ -87,6 +87,16 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
                   dangerous_interp?(first_arg) ||
                   dangerous_string_building?(first_arg)
       end
+    when :capture2, :capture2e, :capture3
+      # Open3 capture methods can take a :stdin_data argument which is used as the
+      # the input to the called command so it is not succeptable to command injection.
+      # As such if the last argument is a hash (and therefore execution options) it
+      # should be ignored
+
+      args.pop if hash?(args.last) && args.length > 2
+      failure = include_user_input?(args) ||
+                dangerous_interp?(args) ||
+                dangerous_string_building?(args)
     else
       failure = include_user_input?(args) ||
                 dangerous_interp?(args) ||

--- a/test/apps/rails5.2/lib/shell.rb
+++ b/test/apps/rails5.2/lib/shell.rb
@@ -128,4 +128,12 @@ class ShellStuff
       ls_io.read
     end
   end
+
+  def open3_capture_stdin_data
+    u = User.new
+    # None of these should warn
+    Open3.capture2("cat", stdin_data: "User.z = #{u.z}")
+    Open3.capture2e("cat", stdin_data: "User.z = #{u.z}")
+    Open3.capture3("cat", stdin_data: "User.z = #{u.z}")
+  end
 end

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -610,6 +610,35 @@ class Rails52Tests < Minitest::Test
       :relative_path => "Gemfile.lock",
       :user_input => nil
   end
+
+  def test_command_injection_ignored_in_stdin
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :fingerprint => "98e72a863c59b1a9dd0024ef645ede1677e87123ac57b7b2d54ca704aba8f8e1",
+      :warning_type => "Command Injection",
+      :line => 135,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 0,
+      :relative_path => "lib/shell.rb"
+
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :fingerprint => "a8ac4ba6f5c56040bb21bb8a2a69a003a1a37b17822209133accb92bbaf1a19b",
+      :warning_type => "Command Injection",
+      :line => 136,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 0,
+      :relative_path => "lib/shell.rb"
+
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :fingerprint => "775dbae94ae590e818d94bcef5d035b46cbc0f72c5c9cb568cfca20a746ed290",
+      :warning_type => "Command Injection",
+      :line => 137,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 0,
+      :relative_path => "lib/shell.rb"
+  end
 end
 
 class Rails52WithVendorTests < Minitest::Test


### PR DESCRIPTION
The last argument to `Open3.capture*` methods are execution options, one of which is a string to be used as the STDIN for the called process. It is useful to be able to use string interpolation on this argument and it is, in general, not succeptable to command injection.

Most of the other options are passed to [`Process.spawn`](https://ruby-doc.org/core-2.7.0/Process.html#method-c-spawn), and I don't believe any of those are succeptable either.

As such it is safe to ignore the last argument of the capture methods if it is a Hash.