### PR TITLE
Skip values_at for non-hashes

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -314,7 +314,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
         exp = hash_values(target)
       end
     when :values_at
-      if hash? target
+      if node_type? target, :hash
         exp = hash_values_at target, exp.args
       end
     end

--- a/test/apps/rails6/app/controllers/accounts_controller.rb
+++ b/test/apps/rails6/app/controllers/accounts_controller.rb
@@ -26,4 +26,8 @@ class AccountsController < ApplicationController
   def eval_something
     eval(params[:x]).to_s
   end
+
+  def index
+    params.values_at(:test).join("|")
+  end
 end


### PR DESCRIPTION
Same as `Hash#values`.

Fixes #1609