### PR TITLE
Add option to disable parallel file parsing

### DIFF
--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -39,7 +39,7 @@ module Brakeman::Options
       OptionParser.new do |opts|
         opts.banner = "Usage: brakeman [options] rails/root/path"
 
-        opts.on "-n", "--no-threads", "Run checks sequentially" do
+        opts.on "-n", "--no-threads", "Run checks and file parsing sequentially" do
           options[:parallel_checks] = false
         end
 

--- a/lib/brakeman/rescanner.rb
+++ b/lib/brakeman/rescanner.rb
@@ -391,7 +391,7 @@ class Brakeman::Rescanner < Brakeman::Scanner
 
   def parse_ruby_files list
     paths = list.select(&:exists?)
-    file_parser = Brakeman::FileParser.new(tracker.app_tree, tracker.options[:parser_timeout])
+    file_parser = Brakeman::FileParser.new(tracker.app_tree, tracker.options[:parser_timeout], tracker.options[:parallel_checks])
     file_parser.parse_files paths
     tracker.add_errors(file_parser.errors)
     file_parser.file_list

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -71,7 +71,7 @@ class Brakeman::Scanner
   end
 
   def parse_files
-    fp = Brakeman::FileParser.new(tracker.app_tree, tracker.options[:parser_timeout])
+    fp = Brakeman::FileParser.new(tracker.app_tree, tracker.options[:parser_timeout], tracker.options[:parallel_checks])
 
     fp.parse_files tracker.app_tree.ruby_file_paths
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -34,7 +34,8 @@ module BrakemanTester
     #Run scan on app at the given path
     def run_scan path, name = nil, opts = {}
       opts.merge! :app_path => "#{TEST_PATH}/apps/#{path}",
-        :url_safe_methods => [:ensure_valid_proto!]
+        :url_safe_methods => [:ensure_valid_proto!],
+        :parallel_checks => false # Something broken with tests+parallel
 
       Brakeman.run(opts).report.to_hash
     end


### PR DESCRIPTION
Use existing `--no-threads` option to parse files sequentially.

Might be useful if there are issues with parallel parsing or someone wants to prioritize memory over speed.