### PR TITLE
Initial support for ActiveRecord enums (and other things, too)

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -208,6 +208,15 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       return Sexp.new(:false).line(exp.line)
     end
 
+    # For the simplest case of `Foo.thing`
+    if node_type? target, :const and first_arg.nil?
+      if tracker and (klass = tracker.find_class(class_name(target.value)))
+        if return_value = klass.get_simple_method_return_value(:class, method)
+          return return_value.deep_clone(exp.line)
+        end
+      end
+    end
+
     #See if it is possible to simplify some basic cases
     #of addition/concatenation.
     case method

--- a/lib/brakeman/processors/lib/call_conversion_helper.rb
+++ b/lib/brakeman/processors/lib/call_conversion_helper.rb
@@ -1,11 +1,5 @@
 module Brakeman
   module CallConversionHelper
-    def all_literals? exp, expected_type = :array
-      node_type? exp, expected_type and
-        exp.length > 1 and
-        exp.all? { |e| e.is_a? Symbol or node_type? e, :lit, :str }
-    end
-
     # Join two array literals into one.
     def join_arrays lhs, rhs, original_exp = nil
       if array? lhs and array? rhs

--- a/lib/brakeman/processors/model_processor.rb
+++ b/lib/brakeman/processors/model_processor.rb
@@ -98,19 +98,21 @@ class Brakeman::ModelProcessor < Brakeman::BaseProcessor
     enums = arg[2] # first value
     enums_name = pluralize(enum_name.to_s).to_sym
 
+    call_line = call.line
+
     if hash? enums
       enum_values = enums
     elsif array? enums
       # Build hash for enum values like Rails does
-      enum_values = s(:hash).line(call.line)
+      enum_values = s(:hash).line(call_line)
 
       enums.each_sexp.with_index do |v, index|
         enum_values << v
-        enum_values << s(:lit, index)
+        enum_values << s(:lit, index).line(call_line)
       end
     end
 
-    enum_method = s(:defs, s(:self), enum_name, s(:args), safe_literal(call.line))
+    enum_method = s(:defn, enum_name, s(:args), safe_literal(call_line))
     enums_method = s(:defs, s(:self), enums_name, s(:args), enum_values)
 
     @current_class.add_method :public, enum_name, enum_method, @current_file

--- a/lib/brakeman/tracker/collection.rb
+++ b/lib/brakeman/tracker/collection.rb
@@ -132,7 +132,8 @@ module Brakeman
           value = body.first
 
           if simple_literal? value or
-              (array? value and all_literals? value)
+              all_literals? value, :array or
+              all_literals? value, :hash
 
             add_simple_method meth_info, value
           end

--- a/lib/brakeman/tracker/collection.rb
+++ b/lib/brakeman/tracker/collection.rb
@@ -50,7 +50,7 @@ module Brakeman
 
     def add_method visibility, name, src, file_name
       meth_info = Brakeman::MethodInfo.new(name, src, self, file_name)
-      add_simple_method_maybe meth_info 
+      add_simple_method_maybe meth_info
 
       if src.node_type == :defs
         @class_methods[name] = meth_info
@@ -121,28 +121,15 @@ module Brakeman
 
     private
 
-    def add_simple_method_maybe meth_info 
-      src = meth_info.src
-
-      # Simple methods have one (simple) expression in the body and
-      # no arguments
-      if src.formal_args.length == 1 # no args
-        body = src.body
-        if body.length == 1 # single expression in body
-          value = body.first
-
-          if simple_literal? value or
-              all_literals? value, :array or
-              all_literals? value, :hash
-
-            add_simple_method meth_info, value
-          end
-        end
+    def add_simple_method_maybe meth_info
+      if meth_info.very_simple_method?
+        add_simple_method meth_info
       end
     end
 
-    def add_simple_method meth_info, value
-      name = meth_info.name 
+    def add_simple_method meth_info
+      name = meth_info.name
+      value = meth_info.return_value
 
       case meth_info.src.node_type
       when :defn

--- a/lib/brakeman/tracker/method_info.rb
+++ b/lib/brakeman/tracker/method_info.rb
@@ -25,5 +25,44 @@ module Brakeman
     def [] attr
       self.send(attr)
     end
+
+    def very_simple_method?
+      return @simple_method == :very unless @simple_method.nil?
+
+      # Very simple methods have one (simple) expression in the body and
+      # no arguments
+      if src.formal_args.length == 1 # no args
+        if src.method_length == 1 # Single expression in body
+          value = first_body # First expression in body
+
+          if simple_literal? value or
+              (array? value and all_literals? value) or
+              (hash? value and all_literals? value, :hash)
+
+            @return_value = value
+            @simple_method = :very
+          end
+        end
+      end
+
+      @simple_method ||= false
+    end
+
+    def return_value env = nil
+      if very_simple_method?
+        return @return_value
+      else
+        nil
+      end
+    end
+
+    def first_body
+      case @type
+      when :class
+        src[4]
+      when :instance
+        src[3]
+      end
+    end
   end
 end

--- a/lib/brakeman/tracker/method_info.rb
+++ b/lib/brakeman/tracker/method_info.rb
@@ -19,6 +19,8 @@ module Brakeman
               else
                 raise "Expected sexp type: #{src.node_type}"
               end
+
+      @simple_method = nil
     end
 
     # To support legacy code that expected a Hash

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -50,7 +50,11 @@ module Brakeman::Util
 
   # stupid simple, used to delegate to ActiveSupport
   def pluralize word
-    word + "s"
+    if word.end_with? 's'
+      word + 'es'
+    else
+      word + 's'
+    end
   end
 
   #Returns a class name as a Symbol.

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -293,7 +293,13 @@ module Brakeman::Util
     exp.is_a? Sexp and types.include? exp.node_type
   end
 
-  LITERALS = [:lit, :false, :str, :true, :array, :hash]
+  SIMPLE_LITERALS = [:lit, :false, :str, :true]
+
+  def simple_literal? exp
+    exp.is_a? Sexp and SIMPLE_LITERALS.include? exp.node_type
+  end
+
+  LITERALS = [*SIMPLE_LITERALS, :array, :hash]
 
   def literal? exp
     exp.is_a? Sexp and LITERALS.include? exp.node_type

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -309,6 +309,12 @@ module Brakeman::Util
     exp.is_a? Sexp and LITERALS.include? exp.node_type
   end
 
+  def all_literals? exp, expected_type = :array
+    node_type? exp, expected_type and
+      exp.length > 1 and
+      exp.all? { |e| e.is_a? Symbol or node_type? e, :lit, :str }
+  end
+
   DIR_CONST = s(:const, :Dir)
 
   # Dir.glob(...).whatever

--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -543,6 +543,20 @@ class Sexp
     self.body.unshift :rlist
   end
 
+  # Number of "statements" in a method.
+  # This is more effecient than `Sexp#body.length`
+  # because `Sexp#body` creates a new Sexp.
+  def method_length
+    expect :defn, :defs
+
+    case self.node_type
+    when :defn
+      self.length - 3
+    when :defs
+      self.length - 4
+    end
+  end
+
   def render_type
     expect :render
     self[1]

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -69,4 +69,15 @@ class GroupsController < ApplicationController
     User.order("name #{params[:direction]}") # Warn in 6.0, not in 6.1
     User.order(:name).reorder(params[:column]) # Warn in 6.0, not in 6.1
   end
+
+  # From https://github.com/presidentbeef/brakeman/issues/1492
+  def enum_include_check
+    status = "#{params[:status]}"
+    if Group.statuses.include? status
+      @status = status.to_sym
+      @countries = Group.send(@status) # Should not warn
+    else
+      redirect_to root_path, notice: 'Invalid status'
+    end
+  end
 end

--- a/test/apps/rails6/app/models/group.rb
+++ b/test/apps/rails6/app/models/group.rb
@@ -18,4 +18,12 @@ class Group < ApplicationRecord
     role = roles.fetch(role_name)
     Arel.sql("role = '#{role}'")
   end
+
+  def use_simple_method
+    self.where("thing = #{Group.simple_method}")
+  end
+
+  def self.simple_method
+    "Hello"
+  end
 end

--- a/test/apps/rails6/app/models/group.rb
+++ b/test/apps/rails6/app/models/group.rb
@@ -22,6 +22,7 @@ class Group < ApplicationRecord
   end
 
   def use_simple_method
+    # No warning
     self.where("thing = #{Group.simple_method}")
   end
 
@@ -30,6 +31,7 @@ class Group < ApplicationRecord
   end
 
   def use_enum
+    # No warning
     self.where("thing IN #{Group.statuses.values_at(*[:start, :stop]).join(',')}")
   end
 end

--- a/test/apps/rails6/app/models/group.rb
+++ b/test/apps/rails6/app/models/group.rb
@@ -1,4 +1,6 @@
 class Group < ApplicationRecord
+  enum status: { start: 0, stop: 2, in_process: 3 }
+
   def uuid_in_sql
     ActiveRecord::Base.connection.exec_query("select * where x = #{User.uuid}")
   end
@@ -25,5 +27,9 @@ class Group < ApplicationRecord
 
   def self.simple_method
     "Hello"
+  end
+
+  def use_enum
+    self.where("thing IN #{Group.statuses.values_at(*[:start, :stop]).join(',')}")
   end
 end

--- a/test/apps/rails6/app/models/group.rb
+++ b/test/apps/rails6/app/models/group.rb
@@ -1,6 +1,4 @@
 class Group < ApplicationRecord
-  enum status: { start: 0, stop: 2, in_process: 3 }
-
   def uuid_in_sql
     ActiveRecord::Base.connection.exec_query("select * where x = #{User.uuid}")
   end
@@ -29,6 +27,8 @@ class Group < ApplicationRecord
   def self.simple_method
     "Hello"
   end
+
+  enum status: { start: 0, stop: 2, in_process: 3 }
 
   def use_enum
     # No warning

--- a/test/apps/rails6/app/models/user.rb
+++ b/test/apps/rails6/app/models/user.rb
@@ -24,4 +24,10 @@ class User < ApplicationRecord
   def recent_stuff
     where("date > #{Date.today - 1}")
   end
+
+  enum state: ["pending", "active", "archived"]
+
+  def check_enum
+    where("state = #{User.states["pending"]}")
+  end
 end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -186,7 +186,6 @@ class Rails6Tests < Minitest::Test
       :user_input => s(:call, s(:call, s(:const, :Date), :today), :-, s(:lit, 1))
   end
 
-<<<<<<< HEAD
   def test_sql_injection_rewhere
     assert_warning :type => :warning,
       :warning_code => 0,
@@ -266,6 +265,19 @@ class Rails6Tests < Minitest::Test
       :relative_path => "app/models/user.rb",
       :code => s(:call, nil, :where, s(:dstr, "state = ", s(:evstr, s(:call, s(:call, s(:const, :User), :states), :[], s(:str, "pending"))))),
       :user_input => s(:call, s(:call, s(:const, :User), :states), :[], s(:str, "pending"))
+  end
+
+  def test_dangerous_send_enum
+    assert_no_warning :type => :warning,
+      :warning_code => 23,
+      :fingerprint => "483fa36e41f5791e86f345a19b517a61859886d685ce40ef852871bb7a935f2d",
+      :warning_type => "Dangerous Send",
+      :line => 78,
+      :message => /^User\ controlled\ method\ execution/,
+      :confidence => 0,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:call, s(:const, :Group), :send, s(:call, s(:dstr, "", s(:evstr, s(:call, s(:params), :[], s(:lit, :status)))), :to_sym)),
+      :user_input => s(:call, s(:params), :[], s(:lit, :status))
   end
 
   def test_cross_site_scripting_sanity

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -186,6 +186,7 @@ class Rails6Tests < Minitest::Test
       :user_input => s(:call, s(:call, s(:const, :Date), :today), :-, s(:lit, 1))
   end
 
+<<<<<<< HEAD
   def test_sql_injection_rewhere
     assert_warning :type => :warning,
       :warning_code => 0,
@@ -252,6 +253,19 @@ class Rails6Tests < Minitest::Test
       :relative_path => "app/controllers/groups_controller.rb",
       :code => s(:call, s(:call, s(:const, :User), :order, s(:lit, :name)), :reorder, s(:call, s(:params), :[], s(:lit, :column))),
       :user_input => s(:call, s(:params), :[], s(:lit, :column))
+  end
+
+  def test_sql_injection_enum
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "b2071137eba7ef6ecbcc1c6381a428e5c576a5fadf73dc04b2e155c41043e1d2",
+      :warning_type => "SQL Injection",
+      :line => 31,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 0,
+      :relative_path => "app/models/user.rb",
+      :code => s(:call, nil, :where, s(:dstr, "state = ", s(:evstr, s(:call, s(:call, s(:const, :User), :states), :[], s(:str, "pending"))))),
+      :user_input => s(:call, s(:call, s(:const, :User), :states), :[], s(:str, "pending"))
   end
 
   def test_cross_site_scripting_sanity


### PR DESCRIPTION
Tired of splitting this into separate PRs, so here we go!

For _very_ simple, obvious _class_ methods, Brakeman will now pull out the return value:

```ruby
class A
  def self.cool_beans
    "nice beans!"
  end
end

A.cool_beans # => "nice beans!"
```

This PR also builds on that to support use of [ActiveRecord `enum`](https://api.rubyonrails.org/classes/ActiveRecord/Enum.html), which essentially just defining a number of methods that return constant values or booleans.

```ruby
class B < ActiveRecord::Base
  enum status: [:waiting, :running, :done]
end

B.statuses # => { waiting: 0, running: 1, done: 2 }
```

Additionally:
* `pluralize` is slightly better now (`status` -> `statuses` instead of `statuss`)
* Support for `Hash#include?`