### PR TITLE
feat: sarif output includes suppressed findings

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -527,12 +527,14 @@ module Brakeman
 
   # Returns an array of alert fingerprints for any ignored warnings without
   # notes found in the specified ignore file (if it exists).
-  def self.ignore_file_entries_with_empty_notes file
+  def self.ignore_file_entries_with_empty_notes file, options
     return [] unless file
 
     require 'brakeman/report/ignore/config'
 
-    config = IgnoreConfig.new(file, nil)
+    app_tree = Brakeman::AppTree.from_options(options)
+
+    config = IgnoreConfig.new(Brakeman::FilePath.from_app_tree(app_tree, file), nil)
     config.read_from_file
     config.already_ignored_entries_with_empty_notes.map { |i| i[:fingerprint] }
   end
@@ -543,9 +545,9 @@ module Brakeman
     app_tree = Brakeman::AppTree.from_options(options)
 
     if options[:ignore_file]
-      file = options[:ignore_file]
+      file = Brakeman::FilePath.from_app_tree(app_tree, options[:ignore_file])
     elsif app_tree.exists? "config/brakeman.ignore"
-      file = app_tree.expand_path("config/brakeman.ignore")
+      file = Brakeman::FilePath.from_app_tree(app_tree, "config/brakeman.ignore")
     elsif not options[:interactive_ignore]
       return
     end

--- a/lib/brakeman/commandline.rb
+++ b/lib/brakeman/commandline.rb
@@ -126,7 +126,7 @@ module Brakeman
 
         ensure_ignore_notes_failed = false
         if tracker.options[:ensure_ignore_notes]
-          fingerprints = Brakeman::ignore_file_entries_with_empty_notes tracker.ignored_filter&.file
+          fingerprints = Brakeman::ignore_file_entries_with_empty_notes tracker.ignored_filter&.file, options
 
           unless fingerprints.empty?
             ensure_ignore_notes_failed = true

--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -100,14 +100,14 @@ module Brakeman
 
     # Read configuration to file
     def read_from_file file = @file
-      if File.exist? file
+      if File.exist? file.absolute
         begin
           @already_ignored = JSON.parse(File.read(file), :symbolize_names => true)[:ignored_warnings]
         rescue => e
-          raise e, "\nError[#{e.class}] while reading brakeman ignore file: #{file}\n"
+          raise e, "\nError[#{e.class}] while reading brakeman ignore file: #{file.relative}\n"
         end
       else
-        Brakeman.notify "[Notice] Could not find ignore configuration in #{file}"
+        Brakeman.notify "[Notice] Could not find ignore configuration in #{file.relative}"
         @already_ignored = []
       end
 
@@ -134,7 +134,7 @@ module Brakeman
         :brakeman_version => Brakeman::Version
       }
 
-      File.open file, "w" do |f|
+      File.open file.absolute, "w" do |f|
         f.puts JSON.pretty_generate(output)
       end
     end

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -80,7 +80,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::Base
             :location => {
               :physicalLocation => {
                 :artifactLocation => {
-                  :uri => Brakeman::FilePath.from_app_tree(@app_tree, @ignore_filter.file).relative,
+                  :uri => @ignore_filter.file.relative,
                   :uriBaseId => '%SRCROOT%',
                 },
               },

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -387,13 +387,13 @@ class ConfigTests < Minitest::Test
   end
 
   def test_ignore_file_entries_with_empty_notes
-    assert Brakeman.ignore_file_entries_with_empty_notes(nil).empty?
+    assert Brakeman.ignore_file_entries_with_empty_notes(nil, {}).empty?
 
     ignore_file_missing_notes = Tempfile.new('brakeman.ignore')
     ignore_file_missing_notes.write IGNORE_WITH_MISSING_NOTES_JSON
     ignore_file_missing_notes.close
     assert_equal(
-      Brakeman.ignore_file_entries_with_empty_notes(ignore_file_missing_notes.path).to_set,
+      Brakeman.ignore_file_entries_with_empty_notes(ignore_file_missing_notes.path, {:app_path => "/tmp" }).to_set,
       [
         '006ac5fe3834bf2e73ee51b67eb111066f618be46e391d493c541ea2a906a82f',
       ].to_set
@@ -403,7 +403,7 @@ class ConfigTests < Minitest::Test
     ignore_file_with_notes = Tempfile.new('brakeman.ignore')
     ignore_file_with_notes.write IGNORE_WITH_NOTES_JSON
     ignore_file_with_notes.close
-    assert Brakeman.ignore_file_entries_with_empty_notes(ignore_file_with_notes.path).empty?
+    assert Brakeman.ignore_file_entries_with_empty_notes(ignore_file_with_notes.path, {:app_path => "/tmp" }).empty?
     ignore_file_with_notes.unlink
   end
 

--- a/test/tests/ignore.rb
+++ b/test/tests/ignore.rb
@@ -16,7 +16,8 @@ class IgnoreConfigTests < Minitest::Test
   end
 
   def make_config file = @config_file.path
-    c = Brakeman::IgnoreConfig.new file, report.warnings
+    app_tree = Brakeman::AppTree.from_options({:app_path => app_path})
+    c = Brakeman::IgnoreConfig.new Brakeman::FilePath.from_app_tree(app_tree, file), report.warnings
     c.read_from_file
     c.filter_ignored
     c
@@ -27,7 +28,11 @@ class IgnoreConfigTests < Minitest::Test
   end
 
   def report
-    @@report ||= Brakeman.run(File.join(TEST_PATH, "apps", "rails5.2"))
+    @@report ||= Brakeman.run(app_path)
+  end
+
+  def app_path
+    @@app_path ||= File.join(TEST_PATH, "apps", "rails5.2")
   end
 
   def test_sanity
@@ -181,7 +186,8 @@ class IgnoreConfigTests < Minitest::Test
     file.write "{[ This is bad json cuz I don't have a closing square bracket, bwahahaha...}"
     file.close
     begin
-      c = Brakeman::IgnoreConfig.new file.path, report.warnings
+      app_tree = Brakeman::AppTree.from_options({:app_path => app_path})
+      c = Brakeman::IgnoreConfig.new Brakeman::FilePath.from_app_tree(app_tree, file.path), report.warnings
       c.read_from_file
     rescue => e
       # The message should clearly show that there was a problem parsing the json

--- a/test/tests/sarif_output.rb
+++ b/test/tests/sarif_output.rb
@@ -102,7 +102,7 @@ class SARIFOutputTests < Minitest::Test
     assert_equal(
       1,
       @@sarif_with_ignore.dig('runs', 0, 'results').
-        map { |f| 1 if f['suppressions'] }.compact.sum
+        select { |f| f['suppressions'] }.count
     )
   end
 


### PR DESCRIPTION
Expand the SARIF report to include ignored warnings, properly annotated
with a [suppression](https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html#_Toc10127924).