### PR TITLE
fix(sarifOutput): nil-safe render_message

### DIFF
--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -111,6 +111,8 @@ class Brakeman::Report::SARIF < Brakeman::Report::Base
   end
 
   def render_message message
+    return message if message.nil?
+
     # Ensure message ends with a period
     if message.end_with? "."
       message

--- a/test/tests/sarif_output.rb
+++ b/test/tests/sarif_output.rb
@@ -2,9 +2,21 @@ require_relative '../test'
 require 'json'
 
 class SARIFOutputTests < Minitest::Test
+
+  def tracker_3_2
+    @@tracker_3_2 ||= Brakeman.run("#{TEST_PATH}/apps/rails3.2") # has no brakeman.ignore
+  end
+
   def setup
-    @@sarif ||= JSON.parse(Brakeman.run(File.join(TEST_PATH, 'apps', 'rails3.2')).report.to_sarif) # has no brakeman.ignore
+    @@sarif ||= JSON.parse(tracker_3_2.report.to_sarif)
     @@sarif_with_ignore ||= JSON.parse(Brakeman.run(File.join(TEST_PATH, 'apps', 'rails4')).report.to_sarif) # has ignored warnings
+  end
+
+  def test_render_message
+    report = Brakeman::Report::SARIF.new tracker_3_2
+    assert_nil report.render_message(nil)
+    assert_equal 'Very serious sentence.', report.render_message('Very serious sentence')
+    assert_equal 'Nothing to see here.', report.render_message('Nothing to see here.')
   end
 
   def test_log_shape


### PR DESCRIPTION
Gracefully handle nil inputs to `render_message`. Fixes #1588.