### PR TITLE
fix(InteractiveIgnorer): use FilePath

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -556,7 +556,7 @@ module Brakeman
 
     if options[:interactive_ignore]
       require 'brakeman/report/ignore/interactive'
-      config = InteractiveIgnorer.new(file, tracker.warnings).start
+      config = InteractiveIgnorer.new(app_tree, file, tracker.warnings).start
     else
       notify "[Notice] Using '#{file}' to filter warnings"
       config = IgnoreConfig.new(file, tracker.warnings)

--- a/lib/brakeman/file_path.rb
+++ b/lib/brakeman/file_path.rb
@@ -50,6 +50,10 @@ module Brakeman
       File.exist? self.absolute
     end
 
+    def empty?
+      self.relative.to_s.empty?
+    end
+
     # Compare FilePaths. Raises an ArgumentError unless both objects are FilePaths.
     def <=> rhs
       raise ArgumentError unless rhs.is_a? Brakeman::FilePath

--- a/test/tests/file_path.rb
+++ b/test/tests/file_path.rb
@@ -43,6 +43,17 @@ class FilePathTests < Minitest::Test
     assert_equal "/tmp/blah/thing.rb", "#{fp}"
   end
 
+  def test_file_path_empty?
+    at = Brakeman::AppTree.new("/tmp/blah")
+    fp1 = Brakeman::FilePath.from_app_tree at, "/tmp/blah/thing.rb"
+    fp2 = Brakeman::FilePath.from_app_tree at, "/tmp/blah/thing/"
+    fp3 = Brakeman::FilePath.from_app_tree at, ""
+
+    refute fp1.empty?
+    refute fp2.empty?
+    assert fp3.empty?
+  end
+
   def test_file_path_equality
     at = Brakeman::AppTree.new("/tmp/blah")
     fp1 = Brakeman::FilePath.from_app_tree at, "/tmp/blah/thing.rb"


### PR DESCRIPTION
Fixes #1622.

The refactor of ignore files to use FilePath in #1620 did not include
the InteractiveIgnorer. Complete the refactor.

The original PR included the refactor to FilePath in order to update
ignorefile pathing to match other pathing within Brakeman, which in turn
permitted the SARIF report to use the pre-loaded relative path in its
output.

As noted in #1622, this had the unintended side effect of making the
path of `-i` configurations relative to the app root (if an absolute
path was not provided), rather than relative to where the command was
run. This _differs_ from the behavior of the `-c` flag, may be
undesired, and is not addressed in this PR.