### PR TITLE
Update Docs for ruby version references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Please follow the typical GitHub flow:
 These are some code conventions to follow so your code fits into the rest of Brakeman.
 
 * Must use typical Ruby 2 space indentation
-* Must work with Ruby 2.3.0
+* Must work with Ruby 2.4.0
 * Prefer to wrap lines near 80 characters but it's not a hard rule
 
 ### Preparing Tests

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Outside of Rails root (note that the output file is relative to path/to/rails/ap
 
 # Compatibility
 
-Brakeman should work with any version of Rails from 2.3.x to 6.x.
+Brakeman should work with any version of Rails from 2.4.x to 6.x.
 
-Brakeman can analyze code written with Ruby 1.8 syntax and newer, but requires at least Ruby 2.3.0 to run.
+Brakeman can analyze code written with Ruby 1.8 syntax and newer, but requires at least Ruby 2.4.0 to run.
 
 # Basic Options
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Outside of Rails root (note that the output file is relative to path/to/rails/ap
 
 # Compatibility
 
-Brakeman should work with any version of Rails from 2.4.x to 6.x.
+Brakeman should work with any version of Rails from 2.3.x to 6.x.
 
 Brakeman can analyze code written with Ruby 1.8 syntax and newer, but requires at least Ruby 2.4.0 to run.
 


### PR DESCRIPTION
Minimum version has been updated to 2.4.0 here: https://github.com/presidentbeef/brakeman/pull/1515.