### PR TITLE
Fix warning sorting with nil line numbers

### DIFF
--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -126,7 +126,7 @@ module Brakeman
 
         w[:note] = @notes[w[:fingerprint]] || ""
         w
-      end.sort_by { |w| [w[:fingerprint], w[:line]] }
+      end.sort_by { |w| [w[:fingerprint], w[:line] || 0] }
 
       output = {
         :ignored_warnings => warnings,

--- a/lib/brakeman/report/report_csv.rb
+++ b/lib/brakeman/report/report_csv.rb
@@ -17,7 +17,7 @@ class Brakeman::Report::CSV < Brakeman::Report::Base
     ]
 
     rows = tracker.filtered_warnings.sort_by do |w|
-      [w.confidence, w.warning_type, w.file, w.line, w.fingerprint]
+      [w.confidence, w.warning_type, w.file, w.line || 0, w.fingerprint]
     end.map do |warning|
       generate_row(headers, warning)
     end

--- a/lib/brakeman/report/report_text.rb
+++ b/lib/brakeman/report/report_text.rb
@@ -92,7 +92,7 @@ class Brakeman::Report::Text < Brakeman::Report::Base
       HighLine.color("No warnings found", :bold, :green)
     else
       warnings = tracker.filtered_warnings.sort_by do |w|
-        [w.confidence, w.warning_type, w.file, w.line, w.fingerprint]
+        [w.confidence, w.warning_type, w.file, w.line || 0, w.fingerprint]
       end.map do |w|
         output_warning w
       end


### PR DESCRIPTION
When sorting warnings, `nil` line numbers can sometimes cause an exception like

```
report_text.rb:94:in `sort_by': comparison of Array with Array failed (ArgumentError)
```

I'm kind of surprised this hasn't come up before, but I guess it's somewhat rare to have two warnings of the same type in the same file and also missing line numbers. And also the sorting algorithm needing to do that particular comparison.

In any case, for now just fixing this at time of `sort_by` instead of reporting a non-`nil` line number (which is essentially an API change).