### PR TITLE
Various test fixes for new ruby_parser changes.

### DIFF
--- a/lib/ruby_parser/bm_sexp.rb
+++ b/lib/ruby_parser/bm_sexp.rb
@@ -642,4 +642,14 @@ end
   RUBY
 end
 
+class String
+  ##
+  # This is a hack used by the lexer to sneak in line numbers at the
+  # identifier level. This should be MUCH smaller than making
+  # process_token return [value, lineno] and modifying EVERYTHING that
+  # reduces tIDENTIFIER.
+
+  attr_accessor :lineno
+end
+
 class WrongSexpError < RuntimeError; end

--- a/test/tests/file_parser.rb
+++ b/test/tests/file_parser.rb
@@ -34,11 +34,17 @@ class FileParserTests < Minitest::Test
 
     assert_equal 1, @tracker.errors.length
 
-    if RubyParser::Parser::VERSION.split(".").map(&:to_i).zip([3,14,0]).all? { |a, b| a >= b }
-      assert_match(/parse error on value false \(\$end\)/, @tracker.errors.first[:error])
-    else
-      assert_match(/parse error on value \"\$end\" \(\$end\)/, @tracker.errors.first[:error])
-    end
+    rp_version = Gem::Version.new(RubyParser::Parser::VERSION)
+    err_re = case
+             when rp_version >= Gem::Version.new("3.17.0")
+               /parse error on value "\$" \(\$end\)/
+             when rp_version >= Gem::Version.new("3.14.0")
+               /parse error on value false \(\$end\)/
+             else
+               /parse error on value \"\$end\" \(\$end\)/
+             end
+
+    assert_match(err_re, @tracker.errors.first[:error])
   end
 
   def test_read_files_reports_error

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -281,7 +281,7 @@ class Rails4Tests < Minitest::Test
       :warning_code => 0,
       :fingerprint => "700c504a68786c6a8d7a7125b5a722ede615e0f998f3c385d65bd12189220a99",
       :warning_type => "SQL Injection",
-      :line => 46,
+      :line => 47,
       :message => /^Possible\ SQL\ injection/,
       :confidence => 1,
       :relative_path => "app/controllers/friendly_controller.rb",

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -87,7 +87,7 @@ class Rails6Tests < Minitest::Test
       :warning_code => 0,
       :fingerprint => "e5f6e40868c9046e5c1433e4975e49b65967de1dcf3add7ba35248b897eeea1c",
       :warning_type => "SQL Injection",
-      :line => 19,
+      :line => 20,
       :message => /^Possible\ SQL\ injection/,
       :confidence => 1,
       :relative_path => "app/models/user.rb",


### PR DESCRIPTION
Mostly fixed by adding String#lineno=, which you should move away
from.

The rest were line numbers or error strings changing (also a tad
brittle to test since racc can change at any time).