### PR TITLE
Ignore `I18N.locale` in SQL

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -513,4 +513,14 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
     string_building? exp.target or
     string_building? exp.first_arg
   end
+
+  I18N_CLASS = s(:const, :I18n)
+
+  def locale_call? exp
+    return unless call? exp
+
+    (exp.target == I18N_CLASS and
+     exp.method == :locale) or
+    locale_call? exp.target
+  end
 end

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -628,7 +628,8 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
       arel? exp or
       exp.method.to_s.end_with? "_id" or
       number_target? exp or
-      date_target? exp
+      date_target? exp or
+      locale_call? exp
   end
 
   QUOTE_METHODS = [:quote, :quote_column_name, :quoted_date, :quote_string, :quote_table_name]

--- a/test/apps/rails6/app/models/user.rb
+++ b/test/apps/rails6/app/models/user.rb
@@ -32,4 +32,8 @@ class User < ApplicationRecord
   end
 
   enum "stuff_#{stuff}": [:things]
+
+  def locale
+    User.where("lower(slug_#{I18n.locale.to_s.split("-").first}) = :country_id", country_id: params[:new_country_id]).first
+  end
 end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -267,6 +267,19 @@ class Rails6Tests < Minitest::Test
       :user_input => s(:call, s(:call, s(:const, :User), :states), :[], s(:str, "pending"))
   end
 
+  def test_sql_injection_locale
+    assert_no_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "843143d5a9dcfa097c66d80a6a72ba151c0332f1ea8c8bc852e418d4f0e2cb7b",
+      :warning_type => "SQL Injection",
+      :line => 37,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 1,
+      :relative_path => "app/models/user.rb",
+      :code => s(:call, s(:const, :User), :where, s(:dstr, "lower(slug_", s(:evstr, s(:call, s(:call, s(:call, s(:call, s(:const, :I18n), :locale), :to_s), :split, s(:str, "-")), :first)), s(:str, ") = :country_id")), s(:hash, s(:lit, :country_id), s(:call, s(:params), :[], s(:lit, :new_country_id)))),
+      :user_input => s(:call, s(:call, s(:call, s(:call, s(:const, :I18n), :locale), :to_s), :split, s(:str, "-")), :first)
+  end
+
   def test_dangerous_send_enum
     assert_no_warning :type => :warning,
       :warning_code => 23,


### PR DESCRIPTION
Fixes #1597