### PR TITLE
Add check for unsupported Rails/Ruby

### DIFF
--- a/lib/brakeman/checks/check_eol_rails.rb
+++ b/lib/brakeman/checks/check_eol_rails.rb
@@ -12,6 +12,8 @@ class Brakeman::CheckEOLRails < Brakeman::EOLCheck
   end
 
   RAILS_EOL_DATES = {
+    ['2.0.0', '2.3.99'] => Date.new(2013, 6, 25),
+    ['3.0.0', '3.2.99'] => Date.new(2016, 6, 30),
     ['4.0.0', '4.2.99'] => Date.new(2017, 4, 27),
     ['5.0.0', '5.0.99'] => Date.new(2018, 5, 9),
     ['5.1.0', '5.1.99'] => Date.new(2019, 8, 25),

--- a/lib/brakeman/checks/check_eol_rails.rb
+++ b/lib/brakeman/checks/check_eol_rails.rb
@@ -12,7 +12,7 @@ class Brakeman::CheckEOLRails < Brakeman::EOLCheck
   end
 
   RAILS_EOL_DATES = {
-    ['0.0.0', '4.2.99'] => Date.new(2017, 4, 27),
+    ['4.0.0', '4.2.99'] => Date.new(2017, 4, 27),
     ['5.0.0', '5.0.99'] => Date.new(2018, 5, 9),
     ['5.1.0', '5.1.99'] => Date.new(2019, 8, 25),
     ['5.2.0', '5.2.99'] => Date.new(2022, 6, 1),

--- a/lib/brakeman/checks/check_eol_rails.rb
+++ b/lib/brakeman/checks/check_eol_rails.rb
@@ -15,5 +15,7 @@ class Brakeman::CheckEOLRails < Brakeman::EOLCheck
     ['0.0.0', '4.2.99'] => Date.new(2017, 4, 27),
     ['5.0.0', '5.0.99'] => Date.new(2018, 5, 9),
     ['5.1.0', '5.1.99'] => Date.new(2019, 8, 25),
+    ['5.2.0', '5.2.99'] => Date.new(2022, 6, 1),
+    ['6.0.0', '6.0.99'] => Date.new(2023, 6, 1),
   }
 end

--- a/lib/brakeman/checks/check_eol_rails.rb
+++ b/lib/brakeman/checks/check_eol_rails.rb
@@ -1,0 +1,19 @@
+require_relative 'eol_check'
+
+class Brakeman::CheckEOLRails < Brakeman::EOLCheck
+  Brakeman::Checks.add self
+
+  @description = "Checks for unsupported versions of Rails"
+
+  def run_check
+    return unless tracker.config.rails_version
+
+    check_eol_version :rails, RAILS_EOL_DATES
+  end
+
+  RAILS_EOL_DATES = {
+    ['0.0.0', '4.2.99'] => Date.new(2017, 4, 27),
+    ['5.0.0', '5.0.99'] => Date.new(2018, 5, 9),
+    ['5.1.0', '5.1.99'] => Date.new(2019, 8, 25),
+  }
+end

--- a/lib/brakeman/checks/check_eol_ruby.rb
+++ b/lib/brakeman/checks/check_eol_ruby.rb
@@ -1,0 +1,26 @@
+require_relative 'eol_check'
+
+class Brakeman::CheckEOLRuby < Brakeman::EOLCheck
+  Brakeman::Checks.add self
+
+  @description = "Checks for unsupported versions of Ruby"
+
+  def run_check
+    return unless tracker.config.ruby_version
+
+    check_eol_version :ruby, RUBY_EOL_DATES
+  end
+
+  RUBY_EOL_DATES = {
+    ['0.0.0', '1.9.3'] => Date.new(2015, 2, 23),
+    ['2.0.0', '2.0.99'] => Date.new(2016, 2, 24),
+    ['2.1.0', '2.1.99'] => Date.new(2017, 3, 31),
+    ['2.2.0', '2.2.99'] => Date.new(2018, 3, 31),
+    ['2.3.0', '2.3.99'] => Date.new(2019, 3, 31),
+    ['2.4.0', '2.4.99'] => Date.new(2020, 3, 31),
+    ['2.5.0', '2.5.99'] => Date.new(2021, 3, 31),
+    ['2.6.0', '2.6.99'] => Date.new(2022, 3, 31),
+    ['2.7.0', '2.7.99'] => Date.new(2023, 3, 31),
+    ['3.0.0', '2.8.99'] => Date.new(2024, 3, 31),
+  }
+end

--- a/lib/brakeman/checks/check_symbol_dos.rb
+++ b/lib/brakeman/checks/check_symbol_dos.rb
@@ -9,7 +9,7 @@ class Brakeman::CheckSymbolDoS < Brakeman::BaseCheck
 
   def run_check
     return if rails_version and rails_version >= "5.0.0"
-    return if tracker.config.ruby_version >= "2.2"
+    return if tracker.config.ruby_version and tracker.config.ruby_version >= "2.2"
 
     tracker.find_call(:methods => UNSAFE_METHODS, :nested => true).each do |result|
       check_unsafe_symbol_creation(result)

--- a/lib/brakeman/checks/eol_check.rb
+++ b/lib/brakeman/checks/eol_check.rb
@@ -1,0 +1,47 @@
+require 'date'
+require 'brakeman/checks/base_check'
+
+# Not used directly - base check for EOLRails and EOLRuby
+class Brakeman::EOLCheck < Brakeman::BaseCheck
+  def check_eol_version library, eol_dates
+    version = case library
+              when :rails
+                tracker.config.rails_version
+              when :ruby
+                tracker.config.ruby_version
+              else
+                raise 'Implement using tracker.config.gem_version'
+              end
+
+    eol_dates.each do |(start_version, end_version), eol_date|
+      if version_between? start_version, end_version, version
+        case
+        when Date.today >= eol_date
+          warn_about_unsupported_version library, eol_date, version
+        when (Date.today + 30) >= eol_date
+          warn_about_soon_unsupported_version library, eol_date, version, :medium
+        when (Date.today + 60) >= eol_date
+          warn_about_soon_unsupported_version library, eol_date, version, :low
+        end
+
+        break
+      end
+    end
+  end
+
+  def warn_about_soon_unsupported_version library, eol_date, version, confidence
+    warn warning_type: 'Unmaintained Dependency',
+      warning_code: :"pending_eol_#{library}",
+      message: msg("Support for ", msg_version(version, library.capitalize), " ends on #{eol_date}"),
+      confidence: confidence,
+      gem_info: gemfile_or_environment
+  end
+
+  def warn_about_unsupported_version library, eol_date, version
+    warn warning_type: 'Unmaintained Dependency',
+      warning_code: :"eol_#{library}",
+      message: msg("Support for ", msg_version(version, library.capitalize), " ended on #{eol_date}"),
+      confidence: :high,
+      gem_info: gemfile_or_environment
+  end
+end

--- a/lib/brakeman/processors/gem_processor.rb
+++ b/lib/brakeman/processors/gem_processor.rb
@@ -6,6 +6,7 @@ class Brakeman::GemProcessor < Brakeman::BasicProcessor
   def initialize *args
     super
     @gem_name_version = /^\s*([-_+.A-Za-z0-9]+) \((\w(\.\w+)*)\)/
+    @ruby_version = /^\s+ruby (\d\.\d.\d+)/
   end
 
   def process_gems gem_files
@@ -95,6 +96,8 @@ class Brakeman::GemProcessor < Brakeman::BasicProcessor
   def set_gem_version_and_file line, file, line_num
     if line =~ @gem_name_version
       @tracker.config.add_gem $1, $2, file, line_num
+    elsif line =~ @ruby_version
+      @tracker.config.set_ruby_version $1
     end
   end
 end

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -137,7 +137,9 @@ class Brakeman::Scanner
     end
 
     if @app_tree.exists? ".ruby-version"
-      tracker.config.set_ruby_version @app_tree.file_path(".ruby-version").read
+      if version = @app_tree.file_path(".ruby-version").read[/(\d\.\d.\d+)/]
+        tracker.config.set_ruby_version version
+      end
     end
 
     tracker.config.load_rails_defaults

--- a/lib/brakeman/tracker/config.rb
+++ b/lib/brakeman/tracker/config.rb
@@ -14,7 +14,7 @@ module Brakeman
       @settings = {}
       @escape_html = nil
       @erubis = nil
-      @ruby_version = ""
+      @ruby_version = nil
       @rails_version = nil
     end
 

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -121,6 +121,8 @@ module Brakeman::WarningCodes
     :erb_template_injection => 117,
     :http_verb_confusion => 118,
     :unsafe_method_reflection => 119,
+    :eol_rails => 120,
+    :eol_ruby => 121,
 
     :custom_check => 9090,
   }

--- a/test/apps/rails5.2/.ruby-version
+++ b/test/apps/rails5.2/.ruby-version
@@ -1,1 +1,1 @@
-2.3.1
+2.3.1@something_weird

--- a/test/tests/github_output.rb
+++ b/test/tests/github_output.rb
@@ -6,7 +6,7 @@ class TestGithubOutput < Minitest::Test
   end
 
   def test_report_format
-    assert_equal 40, @@report.lines.count, "Did you add vulnerabilities to the Rails 6 app? Update this test please!"
+    assert_equal 41, @@report.lines.count, "Did you add vulnerabilities to the Rails 6 app? Update this test please!"
     @@report.lines.each do |line|
       assert line.start_with?('::'), 'Every line must start with `::`'
       assert_equal 2, line.scan('::').count, 'Every line must have exactly 2 `::`'

--- a/test/tests/markdown_output.rb
+++ b/test/tests/markdown_output.rb
@@ -10,6 +10,6 @@ class TestMarkdownOutput < Minitest::Test
   end
 
   def test_reported_warnings
-    assert_equal 173, @@report.lines.to_a.count
+    assert_equal 175, @@report.lines.to_a.count, "Did you add vulnerabilities to the Rails 2 app? Update this test please!"
   end
 end

--- a/test/tests/only_files_option.rb
+++ b/test/tests/only_files_option.rb
@@ -10,7 +10,7 @@ class OnlyFilesOptionTests < Minitest::Test
       :controller => 8,
       :model => 0,
       :template => 1,
-      :generic => 16 }
+      :generic => 17 }
 
     if RUBY_PLATFORM == 'java'
       @expected[:generic] += 1
@@ -177,5 +177,19 @@ class OnlyFilesOptionTests < Minitest::Test
       :relative_path => "Gemfile.lock",
       :code => nil,
       :user_input => nil
+  end
+
+  def test_unmaintained_dependency_rails
+    assert_warning check_name: "EOLRails",
+      type: :warning,
+      warning_code: 120,
+      fingerprint: "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
+      warning_type: "Unmaintained Dependency",
+      line: 64,
+      message: /^Support\ for\ Rails\ 3\.2\.9\.rc2\ ended\ on\ 201/,
+      confidence: 0,
+      relative_path: "Gemfile.lock",
+      code: nil,
+      user_input: nil
   end
 end

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -1503,7 +1503,7 @@ class Rails2Tests < Minitest::Test
       fingerprint: "b43ad7ea48b7d5f0da242e205924653198f70c50f9cfda7211fcbc1f0abec65a",
       warning_type: "Unmaintained Dependency",
       line: nil,
-      message: /^Support\ for\ Rails\ 2\.3\.11\ ended\ on\ 2017\-0/,
+      message: /^Support\ for\ Rails\ 2\.3\.11\ ended\ on\ 2013\-0/,
       confidence: 0,
       relative_path: "config/environment.rb"
   end

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -14,7 +14,7 @@ class Rails2Tests < Minitest::Test
       :controller => 1,
       :model => 4,
       :template => 47,
-      :generic => 59 }
+      :generic => 60 }
   end
 
   def report
@@ -1495,6 +1495,18 @@ class Rails2Tests < Minitest::Test
       :relative_path => "app/controllers/emails_controller.rb",
       :user_input => s(:call, s(:params), :[], s(:lit, :email_id))
   end
+
+  def test_unmaintained_dependency_rails
+    assert_warning check_name: "EOLRails",
+      type: :warning,
+      warning_code: 120,
+      fingerprint: "b43ad7ea48b7d5f0da242e205924653198f70c50f9cfda7211fcbc1f0abec65a",
+      warning_type: "Unmaintained Dependency",
+      line: nil,
+      message: /^Support\ for\ Rails\ 2\.3\.11\ ended\ on\ 2017\-0/,
+      confidence: 0,
+      relative_path: "config/environment.rb"
+  end
 end
 
 class Rails2WithOptionsTests < Minitest::Test
@@ -1506,7 +1518,7 @@ class Rails2WithOptionsTests < Minitest::Test
       :controller => 1,
       :model => 4,
       :template => 47,
-      :generic => 59 }
+      :generic => 60 }
   end
 
   def report

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -1457,7 +1457,7 @@ class Rails3Tests < Minitest::Test
       fingerprint: "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
       warning_type: "Unmaintained Dependency",
       line: 49,
-      message: /^Support\ for\ Rails\ 3\.0\.3\ ended\ on\ 2017\-04/,
+      message: /^Support\ for\ Rails\ 3\.0\.3\ ended\ on\ 2016\-06/,
       confidence: 0,
       relative_path: "Gemfile.lock",
       code: nil,

--- a/test/tests/rails3.rb
+++ b/test/tests/rails3.rb
@@ -14,7 +14,7 @@ class Rails3Tests < Minitest::Test
       :controller => 1,
       :model => 9,
       :template => 41,
-      :generic => 75
+      :generic => 76
     }
 
     if RUBY_PLATFORM == 'java'
@@ -1448,5 +1448,19 @@ class Rails3Tests < Minitest::Test
       :confidence => 0,
       :relative_path => "Gemfile.lock",
       :user_input => nil
+  end
+
+  def test_unmaintained_dependency_rails
+    assert_warning check_name: "EOLRails",
+      type: :warning,
+      warning_code: 120,
+      fingerprint: "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
+      warning_type: "Unmaintained Dependency",
+      line: 49,
+      message: /^Support\ for\ Rails\ 3\.0\.3\ ended\ on\ 2017\-04/,
+      confidence: 0,
+      relative_path: "Gemfile.lock",
+      code: nil,
+      user_input: nil
   end
 end

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -1395,7 +1395,7 @@ class Rails31Tests < Minitest::Test
       fingerprint: "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
       warning_type: "Unmaintained Dependency",
       line: 69,
-      message: /^Support\ for\ Rails\ 3\.1\.0\ ended\ on\ 2017\-04/,
+      message: /^Support\ for\ Rails\ 3\.1\.0\ ended\ on\ 2016\-06/,
       confidence: 0,
       relative_path: "Gemfile.lock",
       code: nil,

--- a/test/tests/rails31.rb
+++ b/test/tests/rails31.rb
@@ -13,7 +13,7 @@ class Rails31Tests < Minitest::Test
       :model => 3,
       :template => 23,
       :controller => 4,
-      :generic => 88 }
+      :generic => 89 }
   end
 
   def test_without_protection
@@ -1386,5 +1386,19 @@ class Rails31Tests < Minitest::Test
       :confidence => 1,
       :relative_path => "Gemfile.lock",
       :user_input => nil
+  end
+
+  def test_unmaintained_dependency_rails
+    assert_warning check_name: "EOLRails",
+      type: :warning,
+      warning_code: 120,
+      fingerprint: "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
+      warning_type: "Unmaintained Dependency",
+      line: 69,
+      message: /^Support\ for\ Rails\ 3\.1\.0\ ended\ on\ 2017\-04/,
+      confidence: 0,
+      relative_path: "Gemfile.lock",
+      code: nil,
+      user_input: nil
   end
 end

--- a/test/tests/rails32.rb
+++ b/test/tests/rails32.rb
@@ -14,7 +14,7 @@ class Rails32Tests < Minitest::Test
       :controller => 8,
       :model => 5,
       :template => 11,
-      :generic => 22 }
+      :generic => 23 }
 
     if RUBY_PLATFORM == 'java'
       @expected[:generic] += 1
@@ -470,5 +470,17 @@ class Rails32Tests < Minitest::Test
       :file => /multi_model\.rb/,
       :relative_path => "app/models/multi_model.rb",
       :format_code => /params\[:user_input2\]/
+  end
+
+  def test_unmaintained_dependency_rails
+    assert_warning check_name: "EOLRails",
+      type: :warning,
+      warning_code: 120,
+      fingerprint: "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
+      warning_type: "Unmaintained Dependency",
+      line: 64,
+      message: /^Support\ for\ Rails\ 3\.2\.9\.rc2\ ended\ on\ 201/,
+      confidence: 0,
+      relative_path: "Gemfile.lock"
   end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Minitest::Test
       :controller => 0,
       :model => 3,
       :template => 8,
-      :generic => 87
+      :generic => 88
     }
   end
 
@@ -1650,6 +1650,18 @@ class Rails4Tests < Minitest::Test
       :confidence => 0,
       :relative_path => "app/controllers/application_controller.rb",
       :user_input => nil
+  end
+
+  def test_unmaintained_dependency_rails
+    assert_warning check_name: "EOLRails",
+      type: :warning,
+      warning_code: 120,
+      fingerprint: "e9d00416c23870f08d30cfda6ad07e2138e0ce51ab6b684814eb69e789cfa631",
+      warning_type: "Unmaintained Dependency",
+      line: 4,
+      message: /^Support\ for\ Rails\ 4\.0\.0\ ended\ on\ 2017\-04/,
+      confidence: 0,
+      relative_path: "Gemfile"
   end
 
   def test_external_check

--- a/test/tests/rails4_with_engines.rb
+++ b/test/tests/rails4_with_engines.rb
@@ -9,7 +9,7 @@ class Rails4WithEnginesTests < Minitest::Test
       :controller => 2,
       :model => 5,
       :template => 12,
-      :generic => 14 }
+      :generic => 15 }
   end
 
   def report
@@ -381,5 +381,19 @@ class Rails4WithEnginesTests < Minitest::Test
       :confidence => 1,
       :relative_path => "gems.rb",
       :user_input => nil
+  end
+
+  def test_unmaintained_dependency_rails
+    assert_warning check_name: "EOLRails",
+      type: :warning,
+      warning_code: 120,
+      fingerprint: "918071d2713bdcc73e9cd9b5a1a3a59edf41d95fff50ab8c21f76f692fb5e0d7",
+      warning_type: "Unmaintained Dependency",
+      line: 4,
+      message: /^Support\ for\ Rails\ 4\.0\.0\ ended\ on\ 2017\-04/,
+      confidence: 0,
+      relative_path: "gems.rb",
+      code: nil,
+      user_input: nil
   end
 end

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -13,7 +13,7 @@ class Rails5Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 19,
-      :generic => 24
+      :generic => 25
     }
   end
 
@@ -941,5 +941,19 @@ class Rails5Tests < Minitest::Test
       :relative_path => "app/views/widget/haml_test.html.haml",
       :code => s(:call, s(:params), :[], s(:lit, :y)),
       :user_input => nil
+  end
+
+  def test_unmaintained_dependency_rails
+    assert_warning check_name: "EOLRails",
+      type: :warning,
+      warning_code: 120,
+      fingerprint: "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
+      warning_type: "Unmaintained Dependency",
+      line: 115,
+      message: /^Support\ for\ Rails\ 5\.0\.0\ ended\ on\ 2018\-05/,
+      confidence: 0,
+      relative_path: "Gemfile.lock",
+      code: nil,
+      user_input: nil
   end
 end

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -13,7 +13,7 @@ class Rails52Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 5,
-      :generic => 23
+      :generic => 24
     }
   end
 
@@ -638,6 +638,18 @@ class Rails52Tests < Minitest::Test
       :message => /^Possible\ command\ injection/,
       :confidence => 0,
       :relative_path => "lib/shell.rb"
+  end
+
+  def test_unmaintained_dependency_rails
+    assert_warning check_name: "EOLRuby",
+      type: :warning,
+      warning_code: 121,
+      fingerprint: "9a3951031616a07c8e02c86652f537e92c08685da97f5ec2b12d5d3602b55bb8",
+      warning_type: "Unmaintained Dependency",
+      line: 109,
+      message: /^Support\ for\ Ruby\ 2\.3\.1\ ended\ on\ 2019\-03\-/,
+      confidence: 0,
+      relative_path: "Gemfile.lock"
   end
 end
 

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,7 +13,7 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 34
+      :generic => 35
     }
   end
 
@@ -745,5 +745,17 @@ class Rails6Tests < Minitest::Test
       :relative_path => "app/controllers/accounts_controller.rb",
       :code => s(:call, nil, :eval, s(:call, s(:params), :[], s(:lit, :x))),
       :user_input => s(:call, s(:params), :[], s(:lit, :x))
+  end
+
+  def test_unmaintained_dependency_ruby
+    assert_warning check_name: "EOLRuby",
+      type: :warning,
+      warning_code: 121,
+      fingerprint: "81776f151be34b9c42a5fc3bec249507a2acd9b64338e6f544a68559976bc5d5",
+      warning_type: "Unmaintained Dependency",
+      line: 7,
+      message: /^Support\ for\ Ruby\ 2\.5\.3\ ended\ on\ 2021\-03\-/,
+      confidence: 0,
+      relative_path: "Gemfile"
   end
 end

--- a/test/tests/rails_with_xss_plugin.rb
+++ b/test/tests/rails_with_xss_plugin.rb
@@ -480,7 +480,7 @@ class RailsWithXssPluginTests < Minitest::Test
       fingerprint: "e9d00416c23870f08d30cfda6ad07e2138e0ce51ab6b684814eb69e789cfa631",
       warning_type: "Unmaintained Dependency",
       line: 3,
-      message: /^Support\ for\ Rails\ 2\.3\.14\ ended\ on\ 2017\-0/,
+      message: /^Support\ for\ Rails\ 2\.3\.14\ ended\ on\ 2013\-0/,
       confidence: 0,
       relative_path: "Gemfile"
   end

--- a/test/tests/rails_with_xss_plugin.rb
+++ b/test/tests/rails_with_xss_plugin.rb
@@ -9,7 +9,7 @@ class RailsWithXssPluginTests < Minitest::Test
       :controller => 1,
       :model => 4,
       :template => 4,
-      :generic => 31 }
+      :generic => 32 }
   end
 
   def report
@@ -471,5 +471,17 @@ class RailsWithXssPluginTests < Minitest::Test
       :confidence => 1,
       :relative_path => "Gemfile",
       :user_input => nil
+  end
+
+  def test_unmaintained_dependency_rails
+    assert_warning check_name: "EOLRails",
+      type: :warning,
+      warning_code: 120,
+      fingerprint: "e9d00416c23870f08d30cfda6ad07e2138e0ce51ab6b684814eb69e789cfa631",
+      warning_type: "Unmaintained Dependency",
+      line: 3,
+      message: /^Support\ for\ Rails\ 2\.3\.14\ ended\ on\ 2017\-0/,
+      confidence: 0,
+      relative_path: "Gemfile"
   end
 end

--- a/test/tests/tabs_output.rb
+++ b/test/tests/tabs_output.rb
@@ -10,6 +10,6 @@ class TestTabsOutput < Minitest::Test
   end
 
   def test_reported_warnings
-    assert_equal 111, @@report.lines.to_a.count
+    assert_equal 112, @@report.lines.to_a.count, 'Did you add new vulnerabilities to the Rails 2 app?'
   end
 end

--- a/test/to_test.rb
+++ b/test/to_test.rb
@@ -50,16 +50,17 @@ class #{name}Tests < Test::Unit::TestCase
 
       <<-RUBY
   def test_#{w.warning_type.to_s.downcase.tr(" -", "__")}_#{counter}
-    assert_warning :type => #{w.warning_set.inspect},
-      :warning_code => #{w.warning_code},
-      :fingerprint => #{w.fingerprint.inspect},
-      :warning_type => #{w.warning_type.inspect},
-      :line => #{w.line.inspect},
-      :message => /^#{Regexp.escape w.message.to_s[0,40]}/,
-      :confidence => #{w.confidence},
-      :relative_path => #{w.file.relative.inspect},
-      :code => #{w.code.inspect},
-      :user_input => #{w.user_input.inspect}
+    assert_warning check_name: #{w.check_name.inspect},
+      type: #{w.warning_set.inspect},
+      warning_code: #{w.warning_code},
+      fingerprint: #{w.fingerprint.inspect},
+      warning_type: #{w.warning_type.inspect},
+      line: #{w.line.inspect},
+      message: /^#{Regexp.escape w.message.to_s[0,40]}/,
+      confidence: #{w.confidence},
+      relative_path: #{w.file.relative.inspect},
+      code: #{w.code.inspect},
+      user_input: #{w.user_input.inspect}
   end
       RUBY
     end.join("\n")


### PR DESCRIPTION
Adds new checks that will begin warning of end-of-line versions of Ruby and Rails.

* 60 days until EOL: low warning
* 30 days until EOL: medium warning
* EOL+: high warning