### PR TITLE
Patch to avoid issue with nil method call in alias_processor join_item

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -404,7 +404,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   end
 
   def join_item item, join_value
-    if item.is_a? String
+    if item.nil? || item.is_a?(String)
       "#{item}#{join_value}"
     elsif string? item or symbol? item or number? item
       s(:str, "#{item.value}#{join_value}").line(item.line)

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1329,6 +1329,12 @@ class AliasProcessorTests < Minitest::Test
     INPUT
   end
 
+  def test_join_item_works_with_nil_item
+    assert_nothing_raised do
+      Brakeman::AliasProcessor.new.join_item(nil, "something")
+    end
+  end
+
   def test_alias_processor_failure
     assert_raises do
       Brakeman::AliasProcessor.new.process s(:block, s(:attrasgn, s(:call, nil, :x), :"[]!", s(:lit, 1), s(:lit, 2)))


### PR DESCRIPTION
I continue to encounter the problem mentioned in https://github.com/presidentbeef/brakeman/issues/1635, even with latest 5.2.1 Brakeman.

This corrects it.