### PR TITLE
Added Common Weakness Enumeration (CWE) IDs to reported vulnerabilities

### DIFF
--- a/lib/brakeman/checks/check_basic_auth.rb
+++ b/lib/brakeman/checks/check_basic_auth.rb
@@ -31,7 +31,8 @@ class Brakeman::CheckBasicAuth < Brakeman::BaseCheck
               :message => "Basic authentication password stored in source code",
               :code => call,
               :confidence => :high,
-              :file => controller.file
+              :file => controller.file,
+              :cwe_id => [259]
           break
         end
       end
@@ -50,7 +51,8 @@ class Brakeman::CheckBasicAuth < Brakeman::BaseCheck
               :warning_type => "Basic Auth",
               :warning_code => :basic_auth_password,
               :message => "Basic authentication password stored in source code",
-              :confidence => :high
+              :confidence => :high,
+              :cwe_id => [259]
       end
     end
   end

--- a/lib/brakeman/checks/check_basic_auth_timing_attack.rb
+++ b/lib/brakeman/checks/check_basic_auth_timing_attack.rb
@@ -27,7 +27,8 @@ class Brakeman::CheckBasicAuthTimingAttack < Brakeman::BaseCheck
         :warning_code => :CVE_2015_7576,
         :message => msg("Basic authentication in ", msg_version(rails_version), " is vulnerable to timing attacks. Upgrade to ", msg_version(@upgrade)),
         :confidence => :high,
-        :link => "https://groups.google.com/d/msg/rubyonrails-security/ANv0HDHEC3k/mt7wNGxbFQAJ"
+        :link => "https://groups.google.com/d/msg/rubyonrails-security/ANv0HDHEC3k/mt7wNGxbFQAJ",
+        :cwe_id => [1254]
     end
   end
 end

--- a/lib/brakeman/checks/check_content_tag.rb
+++ b/lib/brakeman/checks/check_content_tag.rb
@@ -117,7 +117,8 @@ class Brakeman::CheckContentTag < Brakeman::CheckCrossSiteScripting
         :message => message,
         :user_input => input,
         :confidence => :high,
-        :link_path => "content_tag"
+        :link_path => "content_tag",
+        :cwe_id => [79]
 
     elsif not tracker.options[:ignore_model_output] and match = has_immediate_model?(arg)
       unless IGNORE_MODEL_METHODS.include? match.method
@@ -135,7 +136,8 @@ class Brakeman::CheckContentTag < Brakeman::CheckCrossSiteScripting
           :message => msg("Unescaped model attribute in ", msg_code("content_tag")),
           :user_input => match,
           :confidence => confidence,
-          :link_path => "content_tag"
+          :link_path => "content_tag",
+          :cwe_id => [79]
       end
 
     elsif @matched
@@ -151,7 +153,8 @@ class Brakeman::CheckContentTag < Brakeman::CheckCrossSiteScripting
         :message => message,
         :user_input => @matched,
         :confidence => :medium,
-        :link_path => "content_tag"
+        :link_path => "content_tag",
+        :cwe_id => [79]
     end
   end
 
@@ -195,7 +198,8 @@ class Brakeman::CheckContentTag < Brakeman::CheckCrossSiteScripting
         :message => msg(msg_version(rails_version), " ", msg_code("content_tag"), " does not escape double quotes in attribute values ", msg_cve("CVE-2016-6316"), ". Upgrade to ", msg_version(fix_version)),
         :confidence => confidence,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ"
+        :link_path => "https://groups.google.com/d/msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ",
+        :cwe_id => [79]
     end
   end
 

--- a/lib/brakeman/checks/check_cookie_serialization.rb
+++ b/lib/brakeman/checks/check_cookie_serialization.rb
@@ -15,7 +15,8 @@ class Brakeman::CheckCookieSerialization < Brakeman::BaseCheck
           :warning_code => :unsafe_cookie_serialization,
           :message => msg("Use of unsafe cookie serialization strategy ", msg_code(setting.value.inspect), " might lead to remote code execution"),
           :confidence => :medium,
-          :link_path => "unsafe_deserialization"
+          :link_path => "unsafe_deserialization",
+          :cwe_id => [565, 502]
       end
     end
   end

--- a/lib/brakeman/checks/check_create_with.rb
+++ b/lib/brakeman/checks/check_create_with.rb
@@ -39,7 +39,8 @@ class Brakeman::CheckCreateWith < Brakeman::BaseCheck
         :result => result,
         :message => @message,
         :confidence => confidence,
-        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/M4chq5Sb540/CC1Fh0Y_NWwJ"
+        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/M4chq5Sb540/CC1Fh0Y_NWwJ",
+        :cwe_id => [915]
     end
   end
 
@@ -69,6 +70,7 @@ class Brakeman::CheckCreateWith < Brakeman::BaseCheck
         :message => @message,
         :gem_info => gemfile_or_environment,
         :confidence => :medium,
-        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/M4chq5Sb540/CC1Fh0Y_NWwJ"
+        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/M4chq5Sb540/CC1Fh0Y_NWwJ",
+        :cwe_id => [915]
   end
 end

--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -82,7 +82,8 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
         :warning_code => :cross_site_scripting,
         :message => message,
         :code => input.match,
-        :confidence => :high
+        :confidence => :high,
+        :cwe_id => [79]
 
     elsif not tracker.options[:ignore_model_output] and match = has_immediate_model?(out)
       method = if call? match
@@ -116,7 +117,8 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
           :message => message,
           :code => match,
           :confidence => confidence,
-          :link_path => link_path
+          :link_path => link_path,
+          :cwe_id => [79]
       end
 
     else
@@ -200,7 +202,8 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
             :code => exp,
             :user_input => @matched,
             :confidence => confidence,
-            :link_path => link_path
+            :link_path => link_path,
+            :cwe_id => [79]
         end
       end
 

--- a/lib/brakeman/checks/check_csrf_token_forgery_cve.rb
+++ b/lib/brakeman/checks/check_csrf_token_forgery_cve.rb
@@ -21,7 +21,8 @@ class Brakeman::CheckCSRFTokenForgeryCVE < Brakeman::BaseCheck
         :message => msg(msg_version(rails_version), " has a vulnerability that may allow CSRF token forgery. Upgrade to ", msg_version(fix_version), " or patch"),
         :confidence => :medium,
         :gem_info => gemfile_or_environment,
-        :link => "https://groups.google.com/g/rubyonrails-security/c/NOjKiGeXUgw"
+        :link => "https://groups.google.com/g/rubyonrails-security/c/NOjKiGeXUgw",
+        :cwe_id => [352]
     end
   end
 end

--- a/lib/brakeman/checks/check_default_routes.rb
+++ b/lib/brakeman/checks/check_default_routes.rb
@@ -27,7 +27,8 @@ class Brakeman::CheckDefaultRoutes < Brakeman::BaseCheck
         :message => msg("All public methods in controllers are available as actions in ", msg_file("routes.rb")),
         :line => tracker.routes[:allow_all_actions].line,
         :confidence => :high,
-        :file => "#{tracker.app_path}/config/routes.rb"
+        :file => "#{tracker.app_path}/config/routes.rb",
+        :cwe_id => [22]
     end
   end
 
@@ -49,7 +50,8 @@ class Brakeman::CheckDefaultRoutes < Brakeman::BaseCheck
           :message => msg("Any public method in ", msg_code(name), " can be used as an action for ", msg_code(verb), " requests."),
           :line => actions[2],
           :confidence => :medium,
-          :file => "#{tracker.app_path}/config/routes.rb"
+          :file => "#{tracker.app_path}/config/routes.rb",
+          :cwe_id => [22]
       end
     end
   end
@@ -82,7 +84,8 @@ class Brakeman::CheckDefaultRoutes < Brakeman::BaseCheck
       :message => msg(msg_version(rails_version), " with globbing routes is vulnerable to directory traversal and remote code execution. Patch or upgrade to ", msg_version(upgrade)),
       :confidence => confidence,
       :file => "#{tracker.app_path}/config/routes.rb",
-      :link => "http://matasano.com/research/AnatomyOfRailsVuln-CVE-2014-0130.pdf"
+      :link => "http://matasano.com/research/AnatomyOfRailsVuln-CVE-2014-0130.pdf",
+      :cwe_id => [22]
   end
 
   def allow_all_actions?

--- a/lib/brakeman/checks/check_deserialize.rb
+++ b/lib/brakeman/checks/check_deserialize.rb
@@ -87,7 +87,8 @@ class Brakeman::CheckDeserialize < Brakeman::BaseCheck
         :message => message,
         :user_input => input,
         :confidence => confidence,
-        :link_path => "unsafe_deserialization"
+        :link_path => "unsafe_deserialization",
+        :cwe_id => [502]
     end
   end
 

--- a/lib/brakeman/checks/check_detailed_exceptions.rb
+++ b/lib/brakeman/checks/check_detailed_exceptions.rb
@@ -19,7 +19,8 @@ class Brakeman::CheckDetailedExceptions < Brakeman::BaseCheck
            :warning_code => :local_request_config,
            :message => "Detailed exceptions are enabled in production",
            :confidence => :high,
-           :file => "config/environments/production.rb"
+           :file => "config/environments/production.rb",
+           :cwe_id => [200]
     end
   end
 
@@ -42,7 +43,8 @@ class Brakeman::CheckDetailedExceptions < Brakeman::BaseCheck
                :message => msg("Detailed exceptions may be enabled in ", msg_code("show_detailed_exceptions?")),
                :confidence => confidence,
                :code => src,
-               :file => definition[:file]
+               :file => definition[:file],
+               :cwe_id => [200]
         end
       end
     end

--- a/lib/brakeman/checks/check_digest_dos.rb
+++ b/lib/brakeman/checks/check_digest_dos.rb
@@ -29,7 +29,8 @@ class Brakeman::CheckDigestDoS < Brakeman::BaseCheck
       :message => message,
       :confidence => confidence,
       :link_path => "https://groups.google.com/d/topic/rubyonrails-security/vxJjrc15qYM/discussion",
-      :gem_info => gemfile_or_environment
+      :gem_info => gemfile_or_environment,
+      :cwe_id => [287]
   end
 
   def with_http_digest?

--- a/lib/brakeman/checks/check_divide_by_zero.rb
+++ b/lib/brakeman/checks/check_divide_by_zero.rb
@@ -36,7 +36,8 @@ class Brakeman::CheckDivideByZero < Brakeman::BaseCheck
         :warning_code => :divide_by_zero,
         :message => "Potential division by zero",
         :confidence => confidence,
-        :user_input => denominator
+        :user_input => denominator,
+        :cwe_id => [369]
     end
   end
 end

--- a/lib/brakeman/checks/check_dynamic_finders.rb
+++ b/lib/brakeman/checks/check_dynamic_finders.rb
@@ -27,7 +27,8 @@ class Brakeman::CheckDynamicFinders < Brakeman::BaseCheck
             :warning_code => :sql_injection_dynamic_finder,
             :message => "MySQL integer conversion may cause 0 to match any string",
             :confidence => :medium,
-            :user_input => arg
+            :user_input => arg,
+            :cwe_id => [89]
 
           break
         end

--- a/lib/brakeman/checks/check_escape_function.rb
+++ b/lib/brakeman/checks/check_escape_function.rb
@@ -15,7 +15,8 @@ class Brakeman::CheckEscapeFunction < Brakeman::BaseCheck
         :message => msg("Rails versions before 2.3.14 have a vulnerability in the ", msg_code("escape"), " method when used with Ruby 1.8 ", msg_cve("CVE-2011-2932")),
         :confidence => :high,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/Vr_7WSOrEZU/discussion"
+        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/Vr_7WSOrEZU/discussion",
+        :cwe_id => [79]
     end
   end
 end

--- a/lib/brakeman/checks/check_evaluation.rb
+++ b/lib/brakeman/checks/check_evaluation.rb
@@ -28,7 +28,8 @@ class Brakeman::CheckEvaluation < Brakeman::BaseCheck
         :warning_code => :code_eval,
         :message => "User input in eval",
         :user_input => input,
-        :confidence => :high
+        :confidence => :high,
+        :cwe_id => [913, 95]
     end
   end
 end

--- a/lib/brakeman/checks/check_execute.rb
+++ b/lib/brakeman/checks/check_execute.rb
@@ -117,7 +117,8 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
         :message => "Possible command injection",
         :code => call,
         :user_input => failure,
-        :confidence => confidence
+        :confidence => confidence,
+        :cwe_id => [77]
     end
   end
 
@@ -138,7 +139,8 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
           :warning_code => :command_injection,
           :message => msg("Possible command injection in ", msg_code("open")),
           :user_input => match,
-          :confidence => :high
+          :confidence => :high,
+          :cwe_id => [77]
       end
     end
   end
@@ -201,7 +203,8 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
       :message => "Possible command injection",
       :code => exp,
       :user_input => input,
-      :confidence => confidence
+      :confidence => confidence,
+      :cwe_id => [77]
   end
 
   # This method expects a :dstr or :evstr node

--- a/lib/brakeman/checks/check_file_access.rb
+++ b/lib/brakeman/checks/check_file_access.rb
@@ -60,7 +60,8 @@ class Brakeman::CheckFileAccess < Brakeman::BaseCheck
         :message => message,
         :confidence => confidence,
         :code => call,
-        :user_input => match
+        :user_input => match,
+        :cwe_id => [22]
     end
   end
 

--- a/lib/brakeman/checks/check_file_disclosure.rb
+++ b/lib/brakeman/checks/check_file_disclosure.rb
@@ -25,7 +25,8 @@ class Brakeman::CheckFileDisclosure < Brakeman::BaseCheck
         :message => msg(msg_version(rails_version), " has a file existence disclosure vulnerability. Upgrade to ", msg_version(fix_version), " or disable serving static assets"),
         :confidence => :high,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/23fiuwb1NBA/MQVM1-5GkPMJ"
+        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/23fiuwb1NBA/MQVM1-5GkPMJ",
+        :cwe_id => [22]
     end
   end
 

--- a/lib/brakeman/checks/check_filter_skipping.rb
+++ b/lib/brakeman/checks/check_filter_skipping.rb
@@ -15,7 +15,8 @@ class Brakeman::CheckFilterSkipping < Brakeman::BaseCheck
         :message => msg("Rails versions before 3.0.10 have a vulnerability which allows filters to be bypassed", msg_cve("CVE-2011-2929")),
         :confidence => :high,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/NCCsca7TEtY/discussion"
+        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/NCCsca7TEtY/discussion",
+        :cwe_id => [20]
     end
   end
 

--- a/lib/brakeman/checks/check_force_ssl.rb
+++ b/lib/brakeman/checks/check_force_ssl.rb
@@ -21,7 +21,8 @@ class Brakeman::CheckForceSSL < Brakeman::BaseCheck
         :message => msg("The application does not force use of HTTPS: ", msg_code("config.force_ssl"), " is not enabled"),
         :confidence => :high,
         :file => "config/environments/production.rb",
-        :line => line
+        :line => line,
+        :cwe_id => [311]
     end
   end
 end

--- a/lib/brakeman/checks/check_forgery_setting.rb
+++ b/lib/brakeman/checks/check_forgery_setting.rb
@@ -52,7 +52,8 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
     opts = {
       :controller => :ApplicationController,
       :warning_type => "Cross-Site Request Forgery",
-      :confidence => :high
+      :confidence => :high,
+      :cwe_id => [352]
     }.merge opts
 
     warn opts
@@ -76,6 +77,7 @@ class Brakeman::CheckForgerySetting < Brakeman::BaseCheck
       :message => msg("CSRF protection is flawed in unpatched versions of ", msg_version(rails_version), " ", msg_cve("CVE-2011-0447"), ". Upgrade to ", msg_version(new_version), " or apply patches as needed"),
       :gem_info => gemfile_or_environment,
       :file => nil,
-      :link_path => "https://groups.google.com/d/topic/rubyonrails-security/LZWjzCPgNmU/discussion"
+      :link_path => "https://groups.google.com/d/topic/rubyonrails-security/LZWjzCPgNmU/discussion",
+      :cwe_id => [352]
   end
 end

--- a/lib/brakeman/checks/check_header_dos.rb
+++ b/lib/brakeman/checks/check_header_dos.rb
@@ -20,7 +20,8 @@ class Brakeman::CheckHeaderDoS < Brakeman::BaseCheck
         :message => message,
         :confidence => :medium,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/msg/ruby-security-ann/A-ebV4WxzKg/KNPTbX8XAQUJ"
+        :link_path => "https://groups.google.com/d/msg/ruby-security-ann/A-ebV4WxzKg/KNPTbX8XAQUJ",
+        :cwe_id => [20]
     end
   end
 

--- a/lib/brakeman/checks/check_i18n_xss.rb
+++ b/lib/brakeman/checks/check_i18n_xss.rb
@@ -23,7 +23,8 @@ class Brakeman::CheckI18nXSS < Brakeman::BaseCheck
         :message => message,
         :confidence => :medium,
         :gem_info => gemfile_or_environment(:i18n),
-        :link_path => "https://groups.google.com/d/msg/ruby-security-ann/pLrh6DUw998/bLFEyIO4k_EJ"
+        :link_path => "https://groups.google.com/d/msg/ruby-security-ann/pLrh6DUw998/bLFEyIO4k_EJ",
+        :cwe_id => [79]
     end
   end
 

--- a/lib/brakeman/checks/check_jruby_xml.rb
+++ b/lib/brakeman/checks/check_jruby_xml.rb
@@ -31,6 +31,7 @@ class Brakeman::CheckJRubyXML < Brakeman::BaseCheck
       :message => msg(msg_version(rails_version), " with JRuby has a vulnerability in XML parser. Upgrade to ", msg_version(fix_version), " or patch"),
       :confidence => :high,
       :gem_info => gemfile_or_environment,
-      :link => "https://groups.google.com/d/msg/rubyonrails-security/KZwsQbYsOiI/5kUV7dSCJGwJ"
+      :link => "https://groups.google.com/d/msg/rubyonrails-security/KZwsQbYsOiI/5kUV7dSCJGwJ",
+      :cwe_id => [20]
   end
 end

--- a/lib/brakeman/checks/check_json_encoding.rb
+++ b/lib/brakeman/checks/check_json_encoding.rb
@@ -26,7 +26,8 @@ class Brakeman::CheckJSONEncoding < Brakeman::BaseCheck
         :message => message,
         :confidence => confidence,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/7VlB_pck3hU/3QZrGIaQW6cJ"
+        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/7VlB_pck3hU/3QZrGIaQW6cJ",
+        :cwe_id => [79]
     end
   end
 

--- a/lib/brakeman/checks/check_json_entity_escape.rb
+++ b/lib/brakeman/checks/check_json_entity_escape.rb
@@ -17,7 +17,8 @@ class Brakeman::CheckJSONEntityEscape < Brakeman::BaseCheck
         :message => msg("HTML entities in JSON are not escaped by default"),
         :confidence => :medium,
         :file => "config/environments/production.rb",
-        :line => 1
+        :line => 1,
+        :cwe_id => [79]
     end
   end
 
@@ -31,7 +32,8 @@ class Brakeman::CheckJSONEntityEscape < Brakeman::BaseCheck
           :warning_code => :json_html_escape_module,
           :message => msg("HTML entities in JSON are not escaped by default"),
           :confidence => :medium,
-          :file => "config/environments/production.rb"
+          :file => "config/environments/production.rb",
+          :cwe_id => [79]
       end
     end
   end

--- a/lib/brakeman/checks/check_json_parsing.rb
+++ b/lib/brakeman/checks/check_json_parsing.rb
@@ -33,7 +33,8 @@ class Brakeman::CheckJSONParsing < Brakeman::BaseCheck
         :message => message,
         :confidence => :high,
         :gem_info => gem_info,
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/1h2DR63ViGo/discussion"
+        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/1h2DR63ViGo/discussion",
+        :cwe_id => [74] # TODO: is this the best CWE for this?
     end
   end
 
@@ -98,7 +99,8 @@ class Brakeman::CheckJSONParsing < Brakeman::BaseCheck
       :message => message,
       :confidence => confidence,
       :gem_info => gemfile_or_environment(name),
-      :link => "https://groups.google.com/d/topic/rubyonrails-security/4_YvCpLzL58/discussion"
+      :link => "https://groups.google.com/d/topic/rubyonrails-security/4_YvCpLzL58/discussion",
+      :cwe_id => [74] # TODO: is this the best CWE for this?
   end
 
   def uses_json_parse?

--- a/lib/brakeman/checks/check_link_to.rb
+++ b/lib/brakeman/checks/check_link_to.rb
@@ -105,7 +105,8 @@ class Brakeman::CheckLinkTo < Brakeman::CheckCrossSiteScripting
       :message => message,
       :user_input => user_input,
       :confidence => confidence,
-      :link_path => "link_to"
+      :link_path => "link_to",
+      :cwe_id => [79]
 
     true
   end

--- a/lib/brakeman/checks/check_link_to_href.rb
+++ b/lib/brakeman/checks/check_link_to_href.rb
@@ -56,7 +56,8 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
           :message => message,
           :user_input => input,
           :confidence => :high,
-          :link_path => "link_to_href"
+          :link_path => "link_to_href",
+          :cwe_id => [79]
       end
     elsif not tracker.options[:ignore_model_output] and input = has_immediate_model?(url_arg)
       return if ignore_model_call? url_arg, input or duplicate? result
@@ -70,7 +71,8 @@ class Brakeman::CheckLinkToHref < Brakeman::CheckLinkTo
         :message => message,
         :user_input => input,
         :confidence => :weak,
-        :link_path => "link_to_href"
+        :link_path => "link_to_href",
+        :cwe_id => [79]
     end
   end
 

--- a/lib/brakeman/checks/check_mail_to.rb
+++ b/lib/brakeman/checks/check_mail_to.rb
@@ -25,7 +25,8 @@ class Brakeman::CheckMailTo < Brakeman::BaseCheck
         :message => message,
         :confidence => :high,
         :gem_info => gemfile_or_environment, # Probably ignored now
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/8CpI7egxX4E/discussion"
+        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/8CpI7egxX4E/discussion",
+        :cwe_id => [79]
     end
   end
 

--- a/lib/brakeman/checks/check_mass_assignment.rb
+++ b/lib/brakeman/checks/check_mass_assignment.rb
@@ -99,7 +99,8 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
         :message => "Unprotected mass assignment",
         :code => call,
         :user_input => input,
-        :confidence => confidence
+        :confidence => confidence,
+        :cwe_id => [915]
     end
 
     res
@@ -205,7 +206,8 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
       :warning_type => "Mass Assignment",
       :warning_code => :mass_assign_permit!,
       :message => msg('Specify exact keys allowed for mass assignment instead of using ', msg_code('permit!'), ' which allows any keys'),
-      :confidence => confidence
+      :confidence => confidence,
+      :cwe_id => [915]
   end
 
   def check_permit_all_parameters
@@ -217,7 +219,8 @@ class Brakeman::CheckMassAssignment < Brakeman::BaseCheck
           :warning_type => "Mass Assignment",
           :warning_code => :mass_assign_permit_all,
           :message => msg('Mass assignment is globally enabled. Disable and specify exact keys using ', msg_code('params.permit'), ' instead'),
-          :confidence => :high
+          :confidence => :high,
+          :cwe_id => [915]
       end
     end
   end

--- a/lib/brakeman/checks/check_mime_type_dos.rb
+++ b/lib/brakeman/checks/check_mime_type_dos.rb
@@ -26,7 +26,8 @@ class Brakeman::CheckMimeTypeDoS < Brakeman::BaseCheck
       :message => message,
       :confidence => :medium,
       :gem_info => gemfile_or_environment,
-      :link_path => "https://groups.google.com/d/msg/rubyonrails-security/9oLY_FCzvoc/w9oI9XxbFQAJ"
+      :link_path => "https://groups.google.com/d/msg/rubyonrails-security/9oLY_FCzvoc/w9oI9XxbFQAJ",
+      :cwe_id => [399]
   end
 
   def has_workaround?

--- a/lib/brakeman/checks/check_model_attr_accessible.rb
+++ b/lib/brakeman/checks/check_model_attr_accessible.rb
@@ -31,7 +31,8 @@ class Brakeman::CheckModelAttrAccessible < Brakeman::BaseCheck
               :warning_code => :dangerous_attr_accessible,
               :message => "Potentially dangerous attribute available for mass assignment",
               :confidence => confidence,
-              :code => Sexp.new(:lit, attribute)
+              :code => Sexp.new(:lit, attribute),
+              :cwe_id => [915]
             break # Prevent from matching single attr multiple times
           end
         end

--- a/lib/brakeman/checks/check_model_attributes.rb
+++ b/lib/brakeman/checks/check_model_attributes.rb
@@ -23,7 +23,8 @@ class Brakeman::CheckModelAttributes < Brakeman::BaseCheck
           :warning_type => "Attribute Restriction",
           :warning_code => :no_attr_accessible,
           :message => msg("Mass assignment is not restricted using ", msg_code("attr_accessible")),
-          :confidence => :high
+          :confidence => :high,
+          :cwe_id => [915] # TODO: Should this be mass assignment?
       elsif not tracker.options[:ignore_attr_protected]
         message, confidence, link = check_for_attr_protected_bypass
 
@@ -39,7 +40,8 @@ class Brakeman::CheckModelAttributes < Brakeman::BaseCheck
           :warning_type => "Attribute Restriction",
           :warning_code => warning_code,
           :message => message,
-          :confidence => confidence
+          :confidence => confidence,
+          :cwe_id => [915] # TODO: Should this be mass assignment?
       end
     end
   end

--- a/lib/brakeman/checks/check_model_serialize.rb
+++ b/lib/brakeman/checks/check_model_serialize.rb
@@ -61,7 +61,8 @@ class Brakeman::CheckModelSerialize < Brakeman::BaseCheck
         :confidence => confidence,
         :link => "https://groups.google.com/d/topic/rubyonrails-security/KtmwSbEpzrU/discussion",
         :file => model.file,
-        :line => model.top_line
+        :line => model.top_line,
+        :cwe_id => [502]
     end
   end
 end

--- a/lib/brakeman/checks/check_nested_attributes.rb
+++ b/lib/brakeman/checks/check_nested_attributes.rb
@@ -24,7 +24,8 @@ class Brakeman::CheckNestedAttributes < Brakeman::BaseCheck
         :message => message,
         :confidence => :high,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/-fkT0yja_gw/discussion"
+        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/-fkT0yja_gw/discussion",
+        :cwe_id => [20]
     end
   end
 

--- a/lib/brakeman/checks/check_nested_attributes_bypass.rb
+++ b/lib/brakeman/checks/check_nested_attributes_bypass.rb
@@ -39,7 +39,8 @@ class Brakeman::CheckNestedAttributesBypass < Brakeman::BaseCheck
       :file => model.file,
       :line => args.line,
       :confidence => :medium,
-      :link_path => "https://groups.google.com/d/msg/rubyonrails-security/cawsWcQ6c8g/tegZtYdbFQAJ"
+      :link_path => "https://groups.google.com/d/msg/rubyonrails-security/cawsWcQ6c8g/tegZtYdbFQAJ",
+      :cwe_id => [284]
   end
 
   def allow_destroy? arg

--- a/lib/brakeman/checks/check_number_to_currency.rb
+++ b/lib/brakeman/checks/check_number_to_currency.rb
@@ -36,7 +36,8 @@ class Brakeman::CheckNumberToCurrency < Brakeman::BaseCheck
       :message => message,
       :confidence => :medium,
       :gem_info => gemfile_or_environment,
-      :link_path => "https://groups.google.com/d/msg/ruby-security-ann/9WiRn2nhfq0/2K2KRB4LwCMJ"
+      :link_path => "https://groups.google.com/d/msg/ruby-security-ann/9WiRn2nhfq0/2K2KRB4LwCMJ",
+      :cwe_id => [79]
   end
 
   def check_number_helper_usage
@@ -69,6 +70,7 @@ class Brakeman::CheckNumberToCurrency < Brakeman::BaseCheck
       :message => msg("Format options in ", msg_code(result[:call].method), " are not safe in ", msg_version(rails_version)),
       :confidence => :high,
       :link_path => "https://groups.google.com/d/msg/ruby-security-ann/9WiRn2nhfq0/2K2KRB4LwCMJ",
-      :user_input => match
+      :user_input => match,
+      :cwe_id => [79]
   end
 end

--- a/lib/brakeman/checks/check_page_caching_cve.rb
+++ b/lib/brakeman/checks/check_page_caching_cve.rb
@@ -26,7 +26,8 @@ class Brakeman::CheckPageCachingCVE < Brakeman::BaseCheck
       :message => message,
       :confidence => confidence,
       :link_path => 'https://groups.google.com/d/msg/rubyonrails-security/CFRVkEytdP8/c5gmICECAgAJ',
-      :gem_info => gemfile_or_environment(gem_name)
+      :gem_info => gemfile_or_environment(gem_name),
+      :cwe_id => [22]
   end
 
   def uses_caches_page?

--- a/lib/brakeman/checks/check_permit_attributes.rb
+++ b/lib/brakeman/checks/check_permit_attributes.rb
@@ -38,6 +38,7 @@ class Brakeman::CheckPermitAttributes < Brakeman::BaseCheck
       :warning_code => :dangerous_permit_key,
       :message => "Potentially dangerous key allowed for mass assignment",
       :confidence => (confidence || SUSPICIOUS_KEYS[key.value]),
-      :user_input => key
+      :user_input => key,
+      :cwe_id => [915]
   end
 end

--- a/lib/brakeman/checks/check_quote_table_name.rb
+++ b/lib/brakeman/checks/check_quote_table_name.rb
@@ -28,7 +28,8 @@ class Brakeman::CheckQuoteTableName < Brakeman::BaseCheck
         :message => message,
         :confidence => confidence,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/ah5HN0S8OJs/discussion"
+        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/ah5HN0S8OJs/discussion",
+        :cwe_id => [89]
     end
   end
 

--- a/lib/brakeman/checks/check_redirect.rb
+++ b/lib/brakeman/checks/check_redirect.rb
@@ -55,7 +55,8 @@ class Brakeman::CheckRedirect < Brakeman::BaseCheck
         :message => "Possible unprotected redirect",
         :code => call,
         :user_input => res,
-        :confidence => confidence
+        :confidence => confidence,
+        :cwe_id => [601]
     end
   end
 

--- a/lib/brakeman/checks/check_regex_dos.rb
+++ b/lib/brakeman/checks/check_regex_dos.rb
@@ -51,7 +51,8 @@ class Brakeman::CheckRegexDoS < Brakeman::BaseCheck
           :warning_code => :regex_dos,
           :message => message,
           :confidence => confidence,
-          :user_input => match
+          :user_input => match,
+          :cwe_id => [20, 185]
       end
     end
   end

--- a/lib/brakeman/checks/check_render.rb
+++ b/lib/brakeman/checks/check_render.rb
@@ -57,7 +57,8 @@ class Brakeman::CheckRender < Brakeman::BaseCheck
         :warning_code => :dynamic_render_path,
         :message => message,
         :user_input => input,
-        :confidence => confidence
+        :confidence => confidence,
+        :cwe_id => [22]
     end
   end
 
@@ -78,7 +79,8 @@ class Brakeman::CheckRender < Brakeman::BaseCheck
           :warning_code => :dynamic_render_path_rce,
           :message => msg("Passing query parameters to ", msg_code("render"), " is vulnerable in ", msg_version(rails_version), " ", msg_cve("CVE-2016-0752")),
           :user_input => view,
-          :confidence => :high
+          :confidence => :high,
+          :cwe_id => [22]
       end
     end
   end

--- a/lib/brakeman/checks/check_render_dos.rb
+++ b/lib/brakeman/checks/check_render_dos.rb
@@ -32,6 +32,7 @@ class Brakeman::CheckRenderDoS < Brakeman::BaseCheck
       :message => message,
       :confidence => :high,
       :link_path => "https://groups.google.com/d/msg/rubyonrails-security/LMxO_3_eCuc/ozGBEhKaJbIJ",
-      :gem_info => gemfile_or_environment
+      :gem_info => gemfile_or_environment,
+      :cwe_id => [20]
   end
 end

--- a/lib/brakeman/checks/check_render_inline.rb
+++ b/lib/brakeman/checks/check_render_inline.rb
@@ -28,14 +28,16 @@ class Brakeman::CheckRenderInline < Brakeman::CheckCrossSiteScripting
             :warning_code => :cross_site_scripting_inline,
             :message => msg("Unescaped ", msg_input(input), " rendered inline"),
             :user_input => input,
-            :confidence => :high
+            :confidence => :high,
+            :cwe_id => [79]
         elsif input = has_immediate_model?(render_value)
           warn :result => result,
             :warning_type => "Cross-Site Scripting",
             :warning_code => :cross_site_scripting_inline,
             :message => "Unescaped model attribute rendered inline",
             :user_input => input,
-            :confidence => :medium
+            :confidence => :medium,
+            :cwe_id => [79]
         end
       end
     end

--- a/lib/brakeman/checks/check_response_splitting.rb
+++ b/lib/brakeman/checks/check_response_splitting.rb
@@ -15,7 +15,8 @@ class Brakeman::CheckResponseSplitting < Brakeman::BaseCheck
         :message => msg("Rails versions before 2.3.14 have a vulnerability content type handling allowing injection of headers ", msg_cve("CVE-2011-3186")),
         :confidence => :medium,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/b_yTveAph2g/discussion"
+        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/b_yTveAph2g/discussion",
+        :cwe_id => [94]
     end
   end
 end

--- a/lib/brakeman/checks/check_reverse_tabnabbing.rb
+++ b/lib/brakeman/checks/check_reverse_tabnabbing.rb
@@ -53,6 +53,7 @@ class Brakeman::CheckReverseTabnabbing < Brakeman::BaseCheck
       :message => msg("When opening a link in a new tab without setting ", msg_code('rel: "noopener noreferrer"'),
                       ", the new tab can control the parent tab's location. For example, an attacker could redirect to a phishing page."),
       :confidence => confidence,
-      :user_input => rel
+      :user_input => rel,
+      :cwe_id => [1022]
   end
 end

--- a/lib/brakeman/checks/check_route_dos.rb
+++ b/lib/brakeman/checks/check_route_dos.rb
@@ -23,7 +23,8 @@ class Brakeman::CheckRouteDoS < Brakeman::BaseCheck
         :message => message,
         :confidence => :medium,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/dthJ5wL69JE/YzPnFelbFQAJ"
+        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/dthJ5wL69JE/YzPnFelbFQAJ",
+        :cwe_id => [399]
     end
   end
 

--- a/lib/brakeman/checks/check_safe_buffer_manipulation.rb
+++ b/lib/brakeman/checks/check_safe_buffer_manipulation.rb
@@ -26,6 +26,7 @@ class Brakeman::CheckSafeBufferManipulation < Brakeman::BaseCheck
       :warning_code => :safe_buffer_vuln, 
       :message => message,
       :confidence => :medium,
-      :gem_info => gemfile_or_environment
+      :gem_info => gemfile_or_environment,
+      :cwe_id => [79]
   end
 end

--- a/lib/brakeman/checks/check_sanitize_methods.rb
+++ b/lib/brakeman/checks/check_sanitize_methods.rb
@@ -51,7 +51,8 @@ class Brakeman::CheckSanitizeMethods < Brakeman::BaseCheck
         :warning_code => code,
         :message => message,
         :confidence => :high,
-        :link_path => link
+        :link_path => link,
+        :cwe_id => [79]
     end
   end
 
@@ -83,7 +84,8 @@ class Brakeman::CheckSanitizeMethods < Brakeman::BaseCheck
         :message => message,
         :gem_info => gemfile_or_environment(:loofah),
         :confidence => confidence,
-        :link_path => "https://github.com/flavorjones/loofah/issues/144"
+        :link_path => "https://github.com/flavorjones/loofah/issues/144",
+        :cwe_id => [79]
     end
   end
 
@@ -108,6 +110,7 @@ class Brakeman::CheckSanitizeMethods < Brakeman::BaseCheck
       :message => message,
       :gem_info => gemfile_or_environment(:'rails-html-sanitizer'),
       :confidence => confidence,
-      :link_path => link
+      :link_path => link,
+      :cwe_id => [79]
   end
 end

--- a/lib/brakeman/checks/check_secrets.rb
+++ b/lib/brakeman/checks/check_secrets.rb
@@ -27,7 +27,8 @@ class Brakeman::CheckSecrets < Brakeman::BaseCheck
             :message => msg("Hardcoded value for ", msg_code(name), " in source code"),
             :confidence => :medium,
             :file => constant.file,
-            :line => constant.line
+            :line => constant.line,
+            :cwe_id => [798]
         end
       end
     end

--- a/lib/brakeman/checks/check_select_tag.rb
+++ b/lib/brakeman/checks/check_select_tag.rb
@@ -52,7 +52,8 @@ class Brakeman::CheckSelectTag < Brakeman::BaseCheck
           :message => @message,
           :confidence => :high,
           :user_input => input,
-          :link_path => "https://groups.google.com/d/topic/rubyonrails-security/fV3QUToSMSw/discussion"
+          :link_path => "https://groups.google.com/d/topic/rubyonrails-security/fV3QUToSMSw/discussion",
+          :cwe_id => [79]
       end
     end
   end

--- a/lib/brakeman/checks/check_select_vulnerability.rb
+++ b/lib/brakeman/checks/check_select_vulnerability.rb
@@ -54,7 +54,8 @@ class Brakeman::CheckSelectVulnerability < Brakeman::BaseCheck
           :warning_code => :select_options_vuln,
           :result => result,
           :message => @message,
-          :confidence => confidence
+          :confidence => confidence,
+          :cwe_id => [79]
     end
   end
 end

--- a/lib/brakeman/checks/check_send.rb
+++ b/lib/brakeman/checks/check_send.rb
@@ -29,7 +29,8 @@ class Brakeman::CheckSend < Brakeman::BaseCheck
         :warning_code => :dangerous_send,
         :message => "User controlled method execution",
         :user_input => input,
-        :confidence => :high
+        :confidence => :high,
+        :cwe_id => [77]
     end
   end
 

--- a/lib/brakeman/checks/check_session_manipulation.rb
+++ b/lib/brakeman/checks/check_session_manipulation.rb
@@ -28,7 +28,8 @@ class Brakeman::CheckSessionManipulation < Brakeman::BaseCheck
         :warning_code => :session_key_manipulation,
         :message => msg(msg_input(input), " used as key in session hash"),
         :user_input => input,
-        :confidence => confidence
+        :confidence => confidence,
+        :cwe_id => [20] # TODO: what cwe should this be? it seems like it's looking for authz bypass
     end
   end
 end

--- a/lib/brakeman/checks/check_session_settings.rb
+++ b/lib/brakeman/checks/check_session_settings.rb
@@ -142,7 +142,8 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
       :message => "Session cookies should be set to HTTP only",
       :confidence => :high,
       :line => line,
-      :file => file
+      :file => file,
+      :cwe_id => [1004]
 
   end
 
@@ -152,7 +153,8 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
       :message => "Session secret should not be included in version control",
       :confidence => :high,
       :line => line,
-      :file => file
+      :file => file,
+      :cwe_id => [798]
   end
 
   def warn_about_secure_only line, file
@@ -161,7 +163,8 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
       :message => "Session cookie should be set to secure only",
       :confidence => :high,
       :line => line,
-      :file => file
+      :file => file,
+      :cwe_id => [614]
   end
 
   def ignored? file

--- a/lib/brakeman/checks/check_simple_format.rb
+++ b/lib/brakeman/checks/check_simple_format.rb
@@ -28,7 +28,8 @@ class Brakeman::CheckSimpleFormat < Brakeman::CheckCrossSiteScripting
       :message => message,
       :confidence => :medium,
       :gem_info => gemfile_or_environment,
-      :link_path => "https://groups.google.com/d/msg/ruby-security-ann/5ZI1-H5OoIM/ZNq4FoR2GnIJ"
+      :link_path => "https://groups.google.com/d/msg/ruby-security-ann/5ZI1-H5OoIM/ZNq4FoR2GnIJ",
+      :cwe_id => [79]
   end
 
   def check_simple_format_usage
@@ -58,6 +59,7 @@ class Brakeman::CheckSimpleFormat < Brakeman::CheckCrossSiteScripting
       :message => msg("Values passed to ", msg_code("simple_format"), " are not safe in ", msg_version(rails_version)),
       :confidence => :high,
       :link_path => "https://groups.google.com/d/msg/ruby-security-ann/5ZI1-H5OoIM/ZNq4FoR2GnIJ",
-      :user_input => match
+      :user_input => match,
+      :cwe_id => [79]
   end
 end

--- a/lib/brakeman/checks/check_single_quotes.rb
+++ b/lib/brakeman/checks/check_single_quotes.rb
@@ -38,7 +38,8 @@ class Brakeman::CheckSingleQuotes < Brakeman::BaseCheck
       :message => message,
       :confidence => :medium,
       :gem_info => gemfile_or_environment,
-      :link_path => "https://groups.google.com/d/topic/rubyonrails-security/kKGNeMrnmiY/discussion"
+      :link_path => "https://groups.google.com/d/topic/rubyonrails-security/kKGNeMrnmiY/discussion",
+      :cwe_id => [79]
   end
 
   #Process initializers to see if they use workaround

--- a/lib/brakeman/checks/check_skip_before_filter.rb
+++ b/lib/brakeman/checks/check_skip_before_filter.rb
@@ -29,7 +29,8 @@ class Brakeman::CheckSkipBeforeFilter < Brakeman::BaseCheck
         :message => msg("List specific actions (", msg_code(":only => [..]"), ") when skipping CSRF check"),
         :code => filter,
         :confidence => :medium,
-        :file => controller.file
+        :file => controller.file,
+        :cwe_id => [352]
 
     when :login_required, :authenticate_user!, :require_user
       warn :controller => controller.name,
@@ -39,7 +40,8 @@ class Brakeman::CheckSkipBeforeFilter < Brakeman::BaseCheck
         :code => filter,
         :confidence => :medium,
         :link_path => "authentication_whitelist",
-        :file => controller.file
+        :file => controller.file,
+        :cwe_id => [287]
     end
   end
 

--- a/lib/brakeman/checks/check_sprockets_path_traversal.rb
+++ b/lib/brakeman/checks/check_sprockets_path_traversal.rb
@@ -30,7 +30,8 @@ class Brakeman::CheckSprocketsPathTraversal < Brakeman::BaseCheck
       :message => message,
       :confidence => confidence,
       :gem_info => gemfile_or_environment(:sprockets),
-      :link_path => "https://groups.google.com/d/msg/rubyonrails-security/ft_J--l55fM/7roDfQ50BwAJ"
+      :link_path => "https://groups.google.com/d/msg/rubyonrails-security/ft_J--l55fM/7roDfQ50BwAJ",
+      :cwe_id => [22, 200]
   end
 
   def has_workaround?

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -247,7 +247,8 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
         :warning_code => :sql_injection,
         :message => "Possible SQL injection",
         :user_input => user_input,
-        :confidence => confidence
+        :confidence => confidence,
+        :cwe_id => [89]
     end
 
     if check_for_limit_or_offset_vulnerability call.last_arg
@@ -261,7 +262,8 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
         :warning_type => "SQL Injection",
         :warning_code => :sql_injection_limit_offset,
         :message => msg("Upgrade to Rails >= 2.1.2 to escape ", msg_code(":limit"), " and ", msg_code("offset"), ". Possible SQL injection"),
-        :confidence => confidence
+        :confidence => confidence,
+        :cwe_id => [89]
     end
   end
 

--- a/lib/brakeman/checks/check_sql_cves.rb
+++ b/lib/brakeman/checks/check_sql_cves.rb
@@ -81,7 +81,8 @@ class Brakeman::CheckSQLCVEs < Brakeman::BaseCheck
       :message => msg(msg_version(rails_version), " contains a SQL injection vulnerability ", msg_cve(cve), ". Upgrade to ", msg_version(upgrade_version)),
       :confidence => :high,
       :gem_info => gemfile_or_environment,
-      :link_path => link
+      :link_path => link,
+      :cwe_id => [89]
   end
 
   def upgrade_version? versions
@@ -101,6 +102,7 @@ class Brakeman::CheckSQLCVEs < Brakeman::BaseCheck
       :message => msg(msg_version(rails_version), " contains a SQL injection vulnerability ", msg_cve("CVE-2014-0080"), " with PostgreSQL. Upgrade to ", msg_version("4.0.3")),
       :confidence => :high,
       :gem_info => gemfile_or_environment(:pg),
-      :link_path => "https://groups.google.com/d/msg/rubyonrails-security/Wu96YkTUR6s/pPLBMZrlwvYJ"
+      :link_path => "https://groups.google.com/d/msg/rubyonrails-security/Wu96YkTUR6s/pPLBMZrlwvYJ",
+      :cwe_id => [89]
   end
 end

--- a/lib/brakeman/checks/check_ssl_verify.rb
+++ b/lib/brakeman/checks/check_ssl_verify.rb
@@ -43,6 +43,7 @@ class Brakeman::CheckSSLVerify < Brakeman::BaseCheck
       :warning_type => "SSL Verification Bypass",
       :warning_code => :ssl_verification_bypass,
       :message => "SSL certificate verification was bypassed",
-      :confidence => :high
+      :confidence => :high,
+      :cwe_id => [295]
   end
 end

--- a/lib/brakeman/checks/check_strip_tags.rb
+++ b/lib/brakeman/checks/check_strip_tags.rb
@@ -35,7 +35,8 @@ class Brakeman::CheckStripTags < Brakeman::BaseCheck
         :message => message,
         :gem_info => gemfile_or_environment,
         :confidence => :high,
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/K5EwdJt06hI/discussion"
+        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/K5EwdJt06hI/discussion",
+        :cwe_id => [79]
     end
   end
 
@@ -60,7 +61,8 @@ class Brakeman::CheckStripTags < Brakeman::BaseCheck
       :message => message,
       :confidence => :high,
       :gem_info => gemfile_or_environment,
-      :link_path => "https://groups.google.com/d/topic/rubyonrails-security/FgVEtBajcTY/discussion"
+      :link_path => "https://groups.google.com/d/topic/rubyonrails-security/FgVEtBajcTY/discussion",
+      :cwe_id => [79]
   end
 
   def cve_2015_7579
@@ -78,7 +80,8 @@ class Brakeman::CheckStripTags < Brakeman::BaseCheck
         :message => message,
         :confidence => confidence,
         :gem_info => gemfile_or_environment(:"rails-html-sanitizer"),
-        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/OU9ugTZcbjc/PjEP46pbFQAJ"
+        :link_path => "https://groups.google.com/d/msg/rubyonrails-security/OU9ugTZcbjc/PjEP46pbFQAJ",
+        :cwe_id => [79]
 
     end
   end

--- a/lib/brakeman/checks/check_symbol_dos.rb
+++ b/lib/brakeman/checks/check_symbol_dos.rb
@@ -45,7 +45,8 @@ class Brakeman::CheckSymbolDoS < Brakeman::BaseCheck
         :warning_code => :unsafe_symbol_creation,
         :message => message,
         :user_input => input,
-        :confidence => confidence
+        :confidence => confidence,
+        :cwe_id => [20]
     end
   end
 

--- a/lib/brakeman/checks/check_symbol_dos_cve.rb
+++ b/lib/brakeman/checks/check_symbol_dos_cve.rb
@@ -23,7 +23,8 @@ class Brakeman::CheckSymbolDoSCVE < Brakeman::BaseCheck
         :message => msg(msg_version(rails_version), " has a denial of service vulnerability in ActiveRecord. Upgrade to ", msg_version(fix_version), " or patch"),
         :confidence => :medium,
         :gem_info => gemfile_or_environment,
-        :link => "https://groups.google.com/d/msg/rubyonrails-security/jgJ4cjjS8FE/BGbHRxnDRTIJ"
+        :link => "https://groups.google.com/d/msg/rubyonrails-security/jgJ4cjjS8FE/BGbHRxnDRTIJ",
+        :cwe_id => [20]
     end
   end
 end

--- a/lib/brakeman/checks/check_template_injection.rb
+++ b/lib/brakeman/checks/check_template_injection.rb
@@ -26,7 +26,8 @@ class Brakeman::CheckTemplateInjection < Brakeman::BaseCheck
         :warning_code => :erb_template_injection,
         :message => msg(msg_input(input), " used directly in ", msg_code("ERB"), " template, which might enable remote code execution"),
         :user_input => input,
-        :confidence => :high
+        :confidence => :high,
+        :cwe_id => [1336]
     end
   end
 end

--- a/lib/brakeman/checks/check_translate_bug.rb
+++ b/lib/brakeman/checks/check_translate_bug.rb
@@ -33,7 +33,8 @@ class Brakeman::CheckTranslateBug < Brakeman::BaseCheck
         :message => message,
         :confidence => confidence,
         :gem_info => gemfile_or_environment,
-        :link_path => "http://groups.google.com/group/rubyonrails-security/browse_thread/thread/2b61d70fb73c7cc5"
+        :link_path => "http://groups.google.com/group/rubyonrails-security/browse_thread/thread/2b61d70fb73c7cc5",
+        :cwe_id => [79]
     end
   end
 

--- a/lib/brakeman/checks/check_unsafe_reflection.rb
+++ b/lib/brakeman/checks/check_unsafe_reflection.rb
@@ -49,7 +49,8 @@ class Brakeman::CheckUnsafeReflection < Brakeman::BaseCheck
         :warning_code => :unsafe_constantize,
         :message => message,
         :user_input => input,
-        :confidence => confidence
+        :confidence => confidence,
+        :cwe_id => [470]
     end
   end
 end

--- a/lib/brakeman/checks/check_unsafe_reflection_methods.rb
+++ b/lib/brakeman/checks/check_unsafe_reflection_methods.rb
@@ -63,6 +63,7 @@ class Brakeman::CheckUnsafeReflectionMethods < Brakeman::BaseCheck
       :warning_code => :unsafe_method_reflection,
       :message => message,
       :user_input => input,
-      :confidence => confidence
+      :confidence => confidence,
+      :cwe_id => [470]
   end
 end

--- a/lib/brakeman/checks/check_unscoped_find.rb
+++ b/lib/brakeman/checks/check_unscoped_find.rb
@@ -40,7 +40,8 @@ class Brakeman::CheckUnscopedFind < Brakeman::BaseCheck
       :message      => msg("Unscoped call to ", msg_code("#{result[:target]}##{result[:method]}")),
       :code         => result[:call],
       :confidence   => :weak,
-      :user_input   => input
+      :user_input   => input,
+      :cwe_id => [285]
   end
 
   def optional_belongs_to? exp

--- a/lib/brakeman/checks/check_validation_regex.rb
+++ b/lib/brakeman/checks/check_validation_regex.rb
@@ -91,7 +91,8 @@ class Brakeman::CheckValidationRegex < Brakeman::BaseCheck
       :warning_code => :validation_regex,
       :message => msg("Insufficient validation for ", msg_code(get_name validator), " using ", msg_code(regex.inspect), ". Use ", msg_code("\\A"), " and ", msg_code("\\z"), " as anchors"),
       :line => value.line,
-      :confidence => :high
+      :confidence => :high,
+      :cwe_id => [777]
     end
   end
 

--- a/lib/brakeman/checks/check_verb_confusion.rb
+++ b/lib/brakeman/checks/check_verb_confusion.rb
@@ -70,6 +70,7 @@ class Brakeman::CheckVerbConfusion < Brakeman::BaseCheck
       :message => message,
       :code => code,
       :user_input => result[:call],
-      :confidence => confidence
+      :confidence => confidence,
+      :cwe_id => [352]
   end
 end

--- a/lib/brakeman/checks/check_weak_hash.rb
+++ b/lib/brakeman/checks/check_weak_hash.rb
@@ -53,7 +53,8 @@ class Brakeman::CheckWeakHash < Brakeman::BaseCheck
       :warning_code => :weak_hash_digest,
       :message => message,
       :confidence => confidence,
-      :user_input => input
+      :user_input => input,
+      :cwe_id => [328]
   end
 
   def process_hmac_result result
@@ -74,7 +75,8 @@ class Brakeman::CheckWeakHash < Brakeman::BaseCheck
       :warning_type => "Weak Hash",
       :warning_code => :weak_hash_hmac,
       :message => message,
-      :confidence => :medium
+      :confidence => :medium,
+      :cwe_id => [328]
   end
 
   def process_openssl_result result
@@ -90,7 +92,8 @@ class Brakeman::CheckWeakHash < Brakeman::BaseCheck
           :warning_type => "Weak Hash",
           :warning_code => :weak_hash_digest,
           :message => msg("Weak hashing algorithm used: ", msg_lit(alg)),
-          :confidence => :medium
+          :confidence => :medium,
+          :cwe_id => [328]
       end
     end
   end

--- a/lib/brakeman/checks/check_without_protection.rb
+++ b/lib/brakeman/checks/check_without_protection.rb
@@ -55,7 +55,8 @@ class Brakeman::CheckWithoutProtection < Brakeman::BaseCheck
             :message => "Unprotected mass assignment",
             :code => call, 
             :user_input => input,
-            :confidence => confidence
+            :confidence => confidence,
+            :cwe_id => [915]
 
         end
       end

--- a/lib/brakeman/checks/check_xml_dos.rb
+++ b/lib/brakeman/checks/check_xml_dos.rb
@@ -30,7 +30,8 @@ class Brakeman::CheckXMLDoS < Brakeman::BaseCheck
       :message => message,
       :confidence => :medium,
       :gem_info => gemfile_or_environment,
-      :link_path => "https://groups.google.com/d/msg/rubyonrails-security/bahr2JLnxvk/x4EocXnHPp8J"
+      :link_path => "https://groups.google.com/d/msg/rubyonrails-security/bahr2JLnxvk/x4EocXnHPp8J",
+      :cwe_id => [125]
   end
 
   def has_workaround?

--- a/lib/brakeman/checks/check_yaml_parsing.rb
+++ b/lib/brakeman/checks/check_yaml_parsing.rb
@@ -29,7 +29,8 @@ class Brakeman::CheckYAMLParsing < Brakeman::BaseCheck
         :message => message,
         :confidence => :high,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/61bkgvnSGTQ/discussion"
+        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/61bkgvnSGTQ/discussion",
+        :cwe_id => [20]
     end
 
     #Warn if app accepts YAML
@@ -41,7 +42,8 @@ class Brakeman::CheckYAMLParsing < Brakeman::BaseCheck
         :message => message,
         :confidence => :high,
         :gem_info => gemfile_or_environment,
-        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/61bkgvnSGTQ/discussion"
+        :link_path => "https://groups.google.com/d/topic/rubyonrails-security/61bkgvnSGTQ/discussion",
+        :cwe_id => [20]
     end
   end
 

--- a/lib/brakeman/checks/eol_check.rb
+++ b/lib/brakeman/checks/eol_check.rb
@@ -34,7 +34,8 @@ class Brakeman::EOLCheck < Brakeman::BaseCheck
       warning_code: :"pending_eol_#{library}",
       message: msg("Support for ", msg_version(version, library.capitalize), " ends on #{eol_date}"),
       confidence: confidence,
-      gem_info: gemfile_or_environment
+      gem_info: gemfile_or_environment,
+      :cwe_id => [1104]
   end
 
   def warn_about_unsupported_version library, eol_date, version
@@ -42,6 +43,7 @@ class Brakeman::EOLCheck < Brakeman::BaseCheck
       warning_code: :"eol_#{library}",
       message: msg("Support for ", msg_version(version, library.capitalize), " ended on #{eol_date}"),
       confidence: :high,
-      gem_info: gemfile_or_environment
+      gem_info: gemfile_or_environment,
+      :cwe_id => [1104]
   end
 end

--- a/lib/brakeman/report/report_table.rb
+++ b/lib/brakeman/report/report_table.rb
@@ -98,7 +98,7 @@ class Brakeman::Report::Table < Brakeman::Report::Base
     render_warnings generic_warnings,
                     :warning,
                     'security_warnings',
-                    ["Confidence", "Class", "Method", "Warning Type", "Message"],
+                    ["Confidence", "Class", "Method", "Warning Type", "CWE ID", "Message"],
                     'Class'
   end
 
@@ -107,7 +107,7 @@ class Brakeman::Report::Table < Brakeman::Report::Base
     render_warnings template_warnings,
                     :template,
                     'view_warnings',
-                    ['Confidence', 'Template', 'Warning Type', 'Message'],
+                    ['Confidence', 'Template', 'Warning Type', "CWE ID", 'Message'],
                     'Template'
 
   end
@@ -117,7 +117,7 @@ class Brakeman::Report::Table < Brakeman::Report::Base
     render_warnings model_warnings,
                     :model,
                     'model_warnings',
-                    ['Confidence', 'Model', 'Warning Type', 'Message'],
+                    ['Confidence', 'Model', 'Warning Type', "CWE ID", 'Message'],
                     'Model'
   end
 
@@ -126,7 +126,7 @@ class Brakeman::Report::Table < Brakeman::Report::Base
     render_warnings controller_warnings,
                     :controller,
                     'controller_warnings',
-                    ['Confidence', 'Controller', 'Warning Type', 'Message'],
+                    ['Confidence', 'Controller', 'Warning Type', "CWE ID", 'Message'],
                     'Controller'
   end
 
@@ -134,7 +134,7 @@ class Brakeman::Report::Table < Brakeman::Report::Base
     render_warnings ignored_warnings,
                     :ignored,
                     'ignored_warnings',
-                    ['Confidence', 'Warning Type', 'File', 'Message'],
+                    ['Confidence', 'Warning Type', "CWE ID", 'File', 'Message'],
                     'Warning Type'
   end
 

--- a/lib/brakeman/report/templates/controller_warnings.html.erb
+++ b/lib/brakeman/report/templates/controller_warnings.html.erb
@@ -5,6 +5,7 @@
       <th>Confidence</th>
       <th>Controller</th>
       <th>Warning Type</th>
+      <th>CWE ID</th>
       <th>Message</th>
     </tr>
   </thead>
@@ -14,6 +15,7 @@
       <td><%= warning['Confidence']%></td>
       <td><%= warning['Controller']%></td>
       <td><%= warning['Warning Type']%></td>
+      <td><%= warning['CWE ID']%></td>
       <td><%= warning['Message']%></td>
     </tr>
   <% end %>

--- a/lib/brakeman/report/templates/ignored_warnings.html.erb
+++ b/lib/brakeman/report/templates/ignored_warnings.html.erb
@@ -6,6 +6,7 @@
         <th>Confidence</th>
         <th>File</th>
         <th>Warning Type</th>
+        <th>CWE ID</th>
         <th>Message</th>
         <th>Note</th>
       </tr>
@@ -16,6 +17,7 @@
         <td><%= warning['Confidence']%></td>
         <td><%= warning['File']%></td>
         <td><%= warning['Warning Type']%></td>
+        <td><%= warning['CWE ID']%></td>
         <td><%= warning['Message']%></td>
         <td><%= warning['Note']%></td>
       </tr>

--- a/lib/brakeman/report/templates/model_warnings.html.erb
+++ b/lib/brakeman/report/templates/model_warnings.html.erb
@@ -5,6 +5,7 @@
       <th>Confidence</th>
       <th>Model</th>
       <th>Warning Type</th>
+      <th>CWE ID</th>
       <th>Message</th>
     </tr>
   </thead>
@@ -14,6 +15,7 @@
       <td><%= warning['Confidence']%></td>
       <td><%= warning['Model']%></td>
       <td><%= warning['Warning Type']%></td>
+      <td><%= warning['CWE ID']%></td>
       <td><%= warning['Message']%></td>
     </tr>
   <% end %>

--- a/lib/brakeman/report/templates/security_warnings.html.erb
+++ b/lib/brakeman/report/templates/security_warnings.html.erb
@@ -6,6 +6,7 @@
       <th>Class</th>
       <th>Method</th>
       <th>Warning Type</th>
+      <th>CWE ID</th>
       <th>Message</th>
     </tr>
   </thead>
@@ -16,6 +17,7 @@
       <td><%= warning['Class']%></td>
       <td><%= warning['Method']%></td>
       <td><%= warning['Warning Type']%></td>
+      <td><%= warning['CWE ID']%></td>
       <td><%= warning['Message']%></td>
     </tr>
   <% end %>

--- a/lib/brakeman/report/templates/view_warnings.html.erb
+++ b/lib/brakeman/report/templates/view_warnings.html.erb
@@ -5,6 +5,7 @@
       <th>Confidence</th>
       <th>Template</th>
       <th>Warning Type</th>
+      <th>CWE ID</th>
       <th>Message</th>
     </tr>
   </thead>
@@ -27,6 +28,7 @@
         <% end %>
       </td>
       <td><%= warning['Warning Type']%></td>
+      <td><%= warning['CWE ID']%></td>
       <td><%= warning['Message']%></td>
     </tr>
   <% end %>

--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -5,7 +5,7 @@ require 'brakeman/messages'
 
 #The Warning class stores information about warnings
 class Brakeman::Warning
-  attr_reader :called_from, :check, :class, :confidence, :controller,
+  attr_reader :called_from, :check, :class, :confidence, :controller, :cwe_id,
     :line, :method, :model, :template, :user_input, :user_input_type,
     :warning_code, :warning_set, :warning_type
 
@@ -31,6 +31,7 @@ class Brakeman::Warning
     :class => :@class,
     :code => :@code,
     :controller => :@controller,
+    :cwe_id => :@cwe_id,
     :file => :@file,
     :gem_info => :@gem_info,
     :line => :@line,
@@ -219,6 +220,7 @@ class Brakeman::Warning
   def to_row type = :warning
     @row = { "Confidence" => TEXT_CONFIDENCE[self.confidence],
       "Warning Type" => self.warning_type.to_s,
+      "CWE ID" => self.cwe_id,
       "Message" => self.message }
 
     case type

--- a/test/apps/rails4/external_checks/check_external_check_test.rb
+++ b/test/apps/rails4/external_checks/check_external_check_test.rb
@@ -14,7 +14,8 @@ class Brakeman::CheckExternalCheckTest < Brakeman::BaseCheck
           warning_code: :custom_check,
           message: "Called something shady!",
           confidence: :high,
-          user_input: user_input
+          user_input: user_input,
+          :cwe_id => [-1]
       end
     end
   end

--- a/test/test.rb
+++ b/test/test.rb
@@ -121,6 +121,18 @@ module BrakemanTester::CheckExpected
       end
     end
   end
+
+  def test_every_warning_has_cwe_id
+    [:generic_warnings, :template_warnings, :controller_warnings, :model_warnings].each do |type|
+      report[type].each do |w|
+        refute_nil w.cwe_id, lambda { "Warning did not have a CWE ID: #{w.message}" }
+        assert_kind_of Array, w.cwe_id, lambda { 'Warnings must have a CWE that is an Array'}
+        w.cwe_id.each do |cwe|
+          assert_kind_of Integer, cwe, lambda { 'Warnings must have a CWE IDs that are Integers'}
+        end
+      end
+    end
+  end
 end
 
 module BrakemanTester::RescanTestHelper


### PR DESCRIPTION
 - Closes #1636 
 - The methodology used to assign CWEs to a vulnerability is as follows:
    If the vulnerability has a CVE, and that CVE has CWEs associated with it,
    then those CWEs are used.
    If a vulnerability has a CVE, but does not have CWEs associated with it,
    then I chose the best applicable CWE(s) according to my understanding of the vulnerability and the CWE.
    If the vulnerability does not have a CVE,
    then I chose the best applicable CWE(s) according to my understanding of the vulnerability and the CWE.
 - Given that the NVD site indicates that in some rare cases a vulnerability can have multiple CWEs, and
    that some of the reported vulnerabilities with a CVE do in fact have multiple CWEs, an array was used as the
    data structure so as to allow reporting multiple CWEs.
 - Added a test helper to ensure that warnings contain a CWE with consistent format

 TODOs:
 - Ideally the CWEs include links to the respective CWE on cwe.mitre.org, however, I am unclear of where exactly this should 
   happen.
 - Add tests for report formats.