### PR TITLE
Don't exclude requested engine or lib paths if they reside in vendor

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -205,7 +205,7 @@ module Brakeman
       paths.reject do |path|
         relative_path = path.relative
 
-        if @skip_vendor and relative_path.include? 'vendor/'
+        if @skip_vendor and relative_path.include? 'vendor/' and !in_engine_paths?(path) and !in_add_libs_paths?(path)
           true
         else
           EXCLUDED_PATHS.any? do |excluded|
@@ -213,6 +213,14 @@ module Brakeman
           end
         end
       end
+    end
+
+    def in_engine_paths?(path)
+      @engine_paths.any? { |p| path.absolute.include?(p) }
+    end
+
+    def in_add_libs_paths?(path)
+      @additional_libs_path.any? { |p| path.absolute.include?(p) }
     end
 
     def match_path files, path


### PR DESCRIPTION
Fixes #1679

Currently, we find files that match various patterns such as the engine or
lib paths and exclude them if they reside in a vendor directory.

Instead, we should honor explicitly-allowed paths, even if we're excluding
vendor and they reside in a vendor directory.

Note, there are several globally EXCLUDED_PATHS such as:
/generators, test/, log/ that are still excluded even if they're in opt-in
engine/lib paths. This still seems reasonable and a test is included to
demonstrate this behavior is unchanged.