### PR TITLE
Make order of `--interactive-ignore` actions in prompt consistent with help

### DIFF
--- a/lib/brakeman/report/ignore/interactive.rb
+++ b/lib/brakeman/report/ignore/interactive.rb
@@ -88,10 +88,10 @@ module Brakeman
 
         m.choice "i"
         m.choice "n"
-        m.choice "k"
+        m.choice "s"
         m.choice "u"
         m.choice "a"
-        m.choice "s"
+        m.choice "k"
         m.choice "q"
         m.choice "?" do
           show_help


### PR DESCRIPTION
Change the prompt from this:

```
Action: (i, n, k, u, a, s, q, ?) 
```

to this:

```
Action: (i, n, s, u, a, k, q, ?) 
```

This is to match the nearby help message:

```
Actions:
i - Add warning to ignore list
n - Add warning to ignore list and add note
s - Skip this warning (will remain ignored or shown)
u - Remove this warning from ignore list
a - Ignore this warning and all remaining warnings
k - Skip this warning and all remaining warnings
q - Quit, do not update ignored warnings
? - Display this help
```

In that help message, the actions are listed with ‘s’ (Skip this warning) before ‘k’ (Skip this warning and all remaining warnings) and with ‘k’ next to ‘a’ (Ignore this warning and all remaining warnings). That order makes more sense than the previous order of the action prompt.

## Testing this change

There are no existing automated tests of what Brakeman outputs during an interactive ignore session, and adding such automated tests seemed too difficult, especially in comparison with the simplicity of this fix. Thus, I tested this change manually.

An excerpt from the output of `bundle exec brakeman --interactive-ignore` on a codebase with one ignored warning, using this commit’s version of Brakeman:

```
Input file: |/app/config/brakeman.ignore|
1. Inspect all warnings
2. Inspect new warnings
3. Prune obsolete ignored warnings
4. Skip - use current ignore configuration
?  1
------------------------------
Actions:
i - Add warning to ignore list
n - Add warning to ignore list and add note
s - Skip this warning (will remain ignored or shown)
u - Remove this warning from ignore list
a - Ignore this warning and all remaining warnings
k - Skip this warning and all remaining warnings
q - Quit, do not update ignored warnings
? - Display this help
-------- 1/1 -----------------
Confidence: Weak
Category: Unmaintained Dependency
Message: Support for Rails 5.2.6 ends on 2022-06-01
File: Gemfile.lock
Line: 222
Note: (note censored)
Already ignored
Action: (i, n, s, u, a, k, q, ?) s
------------------------------
Ignoring 1 warnings
Showing 0 warnings
1. Save changes
2. Start over
3. Quit, do not save changes
?  3
```

The “Action:” prompt now matches the “Actions:” help text. Selecting one of the reordered actions, ‘s’, still works as expected.

When I ran `bundle exec brakeman --interactive-ignore` on the released version of Brakeman, the “Action:” prompt was this:

```
Action: (i, n, k, u, a, s, q, ?) 
```
