### PR TITLE
Fix markdown message with pipe character

### DIFF
--- a/lib/brakeman/report/report_markdown.rb
+++ b/lib/brakeman/report/report_markdown.rb
@@ -104,7 +104,7 @@ class Brakeman::Report::Markdown < Brakeman::Report::Table
     end
 
     if warning.code
-      code = warning.format_code.gsub('`','``').gsub(/\A``|``\z/, '` `')
+      code = warning.format_code.gsub('`','``').gsub(/\A``|``\z/, '` `').gsub('|', '\|')
       message << ": `#{code}`"
     end
 


### PR DESCRIPTION
Warning message containing codes with pipe character `|` breaks markdown table