### PR TITLE
3.2Expand Regex DoS check to include String#match and #match? coercion

### DIFF
--- a/test/apps/rails2/app/controllers/other_controller.rb
+++ b/test/apps/rails2/app/controllers/other_controller.rb
@@ -82,6 +82,14 @@ class OtherController < ApplicationController
     /#{Rack::Utils.escape_html(params[:regex])}/
   end
 
+  def test_regex_match
+    "haystack".match(params[:regex])
+  end
+
+  def test_regex_match?
+    "haystack".match?(params[:regex])
+  end
+
   def test_intern
     x = params[:x].intern
 

--- a/test/tests/markdown_output.rb
+++ b/test/tests/markdown_output.rb
@@ -10,6 +10,6 @@ class TestMarkdownOutput < Minitest::Test
   end
 
   def test_reported_warnings
-    assert_equal 175, @@report.lines.to_a.count, "Did you add vulnerabilities to the Rails 2 app? Update this test please!"
+    assert_equal 177, @@report.lines.to_a.count, "Did you add vulnerabilities to the Rails 2 app? Update this test please!"
   end
 end

--- a/test/tests/rails2.rb
+++ b/test/tests/rails2.rb
@@ -14,7 +14,7 @@ class Rails2Tests < Minitest::Test
       :controller => 1,
       :model => 4,
       :template => 47,
-      :generic => 60 }
+      :generic => 62 }
   end
 
   def report
@@ -1378,7 +1378,7 @@ class Rails2Tests < Minitest::Test
   def test_unsafe_symbol_creation_4
     assert_warning :type => :warning,
       :warning_type => "Denial of Service",
-      :line => 86,
+      :line => 94,
       :message => /^Symbol\ conversion\ from\ unsafe\ string\ in pa/,
       :confidence => 0,
       :file => /other_controller\.rb/,
@@ -1388,7 +1388,7 @@ class Rails2Tests < Minitest::Test
   def test_unsafe_symbol_creation_5
     assert_warning :type => :warning,
       :warning_type => "Denial of Service",
-      :line => 88,
+      :line => 96,
       :message => /^Symbol\ conversion\ from\ unsafe\ string\ in pa/,
       :confidence => 1,
       :file => /other_controller\.rb/,
@@ -1427,6 +1427,28 @@ class Rails2Tests < Minitest::Test
       :confidence => 2,
       :relative_path => "app/controllers/other_controller.rb",
       :user_input => s(:call, s(:params), :[], s(:lit, :regex))
+  end
+
+  def test_regex_match_dos
+    assert_warning :type => :warning,
+                   :warning_code => 76,
+                   :warning_type => "Denial of Service",
+                   :line => 86,
+                   :message => /^Parameter value used in string to regular expression coercion/,
+                   :confidence => 0,
+                   :relative_path => "app/controllers/other_controller.rb",
+                   :user_input => s(:call, s(:params), :[], s(:lit, :regex))
+  end
+
+  def test_regex_matchq_dos
+    assert_warning :type => :warning,
+                   :warning_code => 76,
+                   :warning_type => "Denial of Service",
+                   :line => 90,
+                   :message => /^Parameter value used in string to regular expression coercion/,
+                   :confidence => 0,
+                   :relative_path => "app/controllers/other_controller.rb",
+                   :user_input => s(:call, s(:params), :[], s(:lit, :regex))
   end
 
   def test_unsafe_symbol_creation_from_param
@@ -1518,7 +1540,7 @@ class Rails2WithOptionsTests < Minitest::Test
       :controller => 1,
       :model => 4,
       :template => 47,
-      :generic => 60 }
+      :generic => 62 }
   end
 
   def report

--- a/test/tests/tabs_output.rb
+++ b/test/tests/tabs_output.rb
@@ -10,6 +10,6 @@ class TestTabsOutput < Minitest::Test
   end
 
   def test_reported_warnings
-    assert_equal 112, @@report.lines.to_a.count, 'Did you add new vulnerabilities to the Rails 2 app?'
+    assert_equal 114, @@report.lines.to_a.count, 'Did you add new vulnerabilities to the Rails 2 app?'
   end
 end


### PR DESCRIPTION
Closes #1714.

I added additional behavior to the existing `check_regex_dos.rb` file. I thought it seemed like the correct location because 