### PR TITLE
Add check for CVE-2022-32209

### DIFF
--- a/lib/brakeman/checks/check_sanitize_config_cve.rb
+++ b/lib/brakeman/checks/check_sanitize_config_cve.rb
@@ -25,7 +25,7 @@ class Brakeman::CheckSanitizeConfigCve < Brakeman::BaseCheck
     return if result and not original? result
 
     message = msg(msg_version(@gem_version, 'rails-html-sanitizer'),
-                  " has an XSS vulnerability when ",
+                  " is vulnerable to cross-site scripting when ",
                   msg_code('select'),
                   " and ",
                   msg_code("style"),

--- a/lib/brakeman/checks/check_sanitize_config_cve.rb
+++ b/lib/brakeman/checks/check_sanitize_config_cve.rb
@@ -1,0 +1,120 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckSanitizeConfigCve < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = "Checks for vunerable uses of sanitize (CVE-2022-32209)"
+
+  def run_check
+    @specific_warning = false
+
+    @gem_version = tracker.config.gem_version :'rails-html-sanitizer'
+    if version_between? "0.0.0", "1.4.3", @gem_version
+      check_config
+      check_sanitize_calls
+      check_safe_list_allowed_tags
+
+      unless @specific_warning
+        # General warning about the vulnerable version
+        cve_warning
+      end
+    end
+  end
+
+  def cve_warning confidence: :weak, result: nil
+    return if result and not original? result
+
+    message = msg(msg_version(@gem_version, 'rails-html-sanitizer'),
+                  " has an XSS vulnerability when ",
+                  msg_code('select'),
+                  " and ",
+                  msg_code("style"),
+                  " tags are allowed ",
+                  msg_cve("CVE-2022-32209")
+                 )
+
+    unless result
+      message << ". Upgrade to 1.4.3 or newer"
+    end
+
+    warn :warning_type => "Cross-Site Scripting",
+      :warning_code => :CVE_2022_32209,
+      :message => message,
+      :confidence => confidence,
+      :gem_info => gemfile_or_environment(:'rails-html-sanitizer'),
+      :link_path => "https://groups.google.com/g/rubyonrails-security/c/ce9PhUANQ6s/m/S0fJfnkmBAAJ",
+      :cwe_id => [79],
+      :result => result
+  end
+
+  # Look for
+  #   config.action_view.sanitized_allowed_tags = ["select", "style"]
+  def check_config
+    sanitizer_config = tracker.config.rails.dig(:action_view, :sanitized_allowed_tags)
+
+    if sanitizer_config and include_both_tags? sanitizer_config
+      @specific_warning = true
+      cve_warning confidence: :high
+    end
+  end
+
+  # Look for
+  #   sanitize ..., tags: ["select", "style"]
+  # and
+  #   Rails::Html::SafeListSanitizer.new.sanitize(..., tags: ["select", "style"])
+  def check_sanitize_calls
+    tracker.find_call(method: :sanitize, target: nil).each do |result|
+      check_tags_option result
+    end
+
+    tracker.find_call(method: :sanitize, target: :'Rails::Html::SafeListSanitizer.new').each do |result|
+      check_tags_option result
+    end
+  end
+
+  # Look for
+  #   Rails::Html::SafeListSanitizer.allowed_tags = ["select", "style"]
+  def check_safe_list_allowed_tags
+    tracker.find_call(target: :'Rails::Html::SafeListSanitizer', method: :allowed_tags=).each do |result|
+      check_result result, result[:call].first_arg
+    end
+  end
+
+  private
+
+  def check_tags_option result
+    options = result[:call].last_arg
+
+    if options
+      check_result result, hash_access(options, :tags)
+    end
+  end
+
+  def check_result result, arg
+    if include_both_tags? arg
+      @specific_warning = true
+      cve_warning confidence: :high, result: result
+    end
+  end
+
+  def include_both_tags? exp
+    return unless sexp? exp
+
+    has_tag? exp, 'select' and
+      has_tag? exp, 'style'
+  end
+
+  def has_tag? exp, tag
+    tag_sym = tag.to_sym
+
+    exp.each_sexp do |e|
+      if string? e and e.value == tag
+        return true
+      elsif symbol? e and e.value == tag_sym
+        return true
+      end
+    end
+
+    false
+  end
+end

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -125,6 +125,7 @@ module Brakeman::WarningCodes
     :eol_ruby => 121,
     :pending_eol_rails => 122,
     :pending_eol_ruby => 123,
+    :CVE_2022_32209 => 124,
 
     :custom_check => 9090,
   }

--- a/test/apps/rails5.2/app/views/users/one.html.haml
+++ b/test/apps/rails5.2/app/views/users/one.html.haml
@@ -6,6 +6,8 @@
 %p#name
   %b Name:
   = @user.name
+  = sanitize @user.bio, tags: ['style', :select]
+  = Rails::Html::SafeListSanitizer.new.sanitize(@user.description, tags: ["select", "style"])
 
 :coffeescript
   $('h1').click ->

--- a/test/apps/rails5/config/application.rb
+++ b/test/apps/rails5/config/application.rb
@@ -11,5 +11,7 @@ module Rails5
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.action_view.sanitized_allowed_tags = ["select", "strong", "style", "b"]
   end
 end

--- a/test/apps/rails7/config/initializers/sanitizers.rb
+++ b/test/apps/rails7/config/initializers/sanitizers.rb
@@ -1,0 +1,1 @@
+Rails::Html::SafeListSanitizer.allowed_tags = ["select", "a", "style"]

--- a/test/tests/cves.rb
+++ b/test/tests/cves.rb
@@ -368,4 +368,27 @@ class CVETests < Minitest::Test
     assert_version "6.0.0"
     assert_warning type: :generic, :warning_code => 116
   end
+
+  def test_old_sanitize_cves
+    before_rescan_of "app/views/users/one.html.haml", "rails5.2" do
+      replace "app/views/users/one.html.haml", "sanitize", "not_sanitize"
+      replace "app/views/users/one.html.haml", "sanitize", "not_sanitize"
+    end
+
+    # Confidence is high when uses of `sanitize` are found.
+    # This tests that the confidence is lowered to medium
+    # when uses of `sanitize` are removed.
+    assert_warning warning_code: 107, confidence: 1
+    assert_warning warning_code: 106, confidence: 1
+  end
+
+  def test_CVE_2022_32209_rails6
+    before_rescan_of "Gemfile", "rails6" do
+      append "Gemfile", "\ngem 'rails-html-sanitizer', '1.4.2'"
+    end
+
+    assert_new 1
+    assert_version '1.4.2', :'rails-html-sanitizer'
+    assert_warning type: :generic, :warning_code => 124
+  end
 end

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -13,7 +13,7 @@ class Rails5Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 19,
-      :generic => 25
+      :generic => 26
     }
   end
 
@@ -701,6 +701,20 @@ class Rails5Tests < Minitest::Test
       :relative_path => "Gemfile",
       :code => nil,
       :user_input => nil
+  end
+
+  def test_cross_site_scripting_CVE_2022_32209_rails_config
+    assert_warning check_name: "SanitizeConfigCve",
+      type: :warning,
+      warning_code: 124,
+      fingerprint: "b9ac1b40c4e59a1e97e2beb039fdfa75c6fb97cf530161bd3c29939e83a513f4",
+      warning_type: "Cross-Site Scripting",
+      line: 133,
+      message: /^rails\-html\-sanitizer\ 1\.0\.2\ has\ an\ XSS\ vu/,
+      confidence: 0,
+      relative_path: "Gemfile.lock",
+      code: nil,
+      user_input: nil
   end
 
   def test_dangerous_eval_in_prior_class_method_with_same_name

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -710,7 +710,7 @@ class Rails5Tests < Minitest::Test
       fingerprint: "b9ac1b40c4e59a1e97e2beb039fdfa75c6fb97cf530161bd3c29939e83a513f4",
       warning_type: "Cross-Site Scripting",
       line: 133,
-      message: /^rails\-html\-sanitizer\ 1\.0\.2\ has\ an\ XSS\ vu/,
+      message: /^rails\-html\-sanitizer\ 1\.0\.2\ is\ vulnerable/,
       confidence: 0,
       relative_path: "Gemfile.lock",
       code: nil,

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -12,7 +12,7 @@ class Rails52Tests < Minitest::Test
     @@expected ||= {
       :controller => 0,
       :model => 0,
-      :template => 5,
+      :template => 7,
       :generic => 24
     }
   end
@@ -588,28 +588,61 @@ class Rails52Tests < Minitest::Test
   end
 
   def test_cross_site_scripting_loofah_CVE_2018_8048
-    assert_warning :type => :warning,
-      :warning_code => 106,
-      :fingerprint => "c8adc1c0caf2c9251d1d8de588fb949070212d0eed5e1580aee88bab2287b772",
-      :warning_type => "Cross-Site Scripting",
-      :line => 90,
-      :message => /^loofah\ gem 2\.1\.1\ is\ vulnerable\ \(CVE\-2018\-804/,
-      :confidence => 1,
-      :relative_path => "Gemfile.lock",
-      :user_input => nil
+    assert_warning check_name: "SanitizeMethods",
+      type: :warning,
+      warning_code: 106,
+      fingerprint: "cdfb1541fdcc9cdcf0784ce5bd90013dc39316cb822eedea3f03b2521c06137f",
+      warning_type: "Cross-Site Scripting",
+      line: 90,
+      message: /^loofah\ gem\ 2\.1\.1\ is\ vulnerable\ \(CVE\-2018/,
+      confidence: 0,
+      relative_path: "Gemfile.lock",
+      code: nil,
+      user_input: nil
   end
 
   def test_cross_site_scripting_CVE_2018_3741
-    assert_warning :type => :warning,
-      :warning_code => 107,
-      :fingerprint => "e0636b950dd005468b5f9a0426ed50936e136f18477ca983cfc51b79e29f6463",
-      :warning_type => "Cross-Site Scripting",
-      :line => 125,
-      :message => /^rails\-html\-sanitizer\ 1\.0\.3\ is\ vulnerable/,
-      :confidence => 1,
-      :relative_path => "Gemfile.lock",
-      :user_input => nil
+    assert_warning check_name: "SanitizeMethods",
+      type: :warning,
+      warning_code: 107,
+      fingerprint: "3e35a6afcd1a8a14894cf26a7f00d4e895f0583bbc081d45e5bd28c4b541b7e6",
+      warning_type: "Cross-Site Scripting",
+      line: 125,
+      message: /^rails\-html\-sanitizer\ 1\.0\.3\ is\ vulnerable/,
+      confidence: 0,
+      relative_path: "Gemfile.lock",
+      code: nil,
+      user_input: nil
   end
+
+  def test_cross_site_scripting_CVE_2022_32209_sanitize_call
+    assert_warning check_name: "SanitizeConfigCve",
+      type: :template,
+      warning_code: 124,
+      fingerprint: "381dbd3ff41d8e8a36bc13ea1943fbf8f8d70774724c9f1be7b0581b88d1d3f5",
+      warning_type: "Cross-Site Scripting",
+      line: 9,
+      message: /^rails\-html\-sanitizer\ 1\.0\.3\ has\ an\ XSS\ vu/,
+      confidence: 0,
+      relative_path: "app/views/users/one.html.haml",
+      code: s(:call, nil, :sanitize, s(:call, s(:call, s(:const, :User), :find, s(:call, s(:params), :[], s(:lit, :id))), :bio), s(:hash, s(:lit, :tags), s(:array, s(:str, "style"), s(:lit, :select)))),
+      user_input: nil
+  end
+
+  def test_cross_site_scripting_CVE_2022_32209_sanitizer_new_call
+    assert_warning check_name: "SanitizeConfigCve",
+      type: :template,
+      warning_code: 124,
+      fingerprint: "9d6223653874a11b649ac92f5e9143ae4b3200fc171d42d193cc820ae850b8eb",
+      warning_type: "Cross-Site Scripting",
+      line: 10,
+      message: /^rails\-html\-sanitizer\ 1\.0\.3\ has\ an\ XSS\ vu/,
+      confidence: 0,
+      relative_path: "app/views/users/one.html.haml",
+      code: s(:call, s(:call, s(:colon2, s(:colon2, s(:const, :Rails), :Html), :SafeListSanitizer), :new), :sanitize, s(:call, s(:call, s(:const, :User), :find, s(:call, s(:params), :[], s(:lit, :id))), :description), s(:hash, s(:lit, :tags), s(:array, s(:str, "select"), s(:str, "style")))),
+      user_input: nil
+  end
+
 
   def test_command_injection_ignored_in_stdin
     assert_no_warning :type => :warning,

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -622,27 +622,12 @@ class Rails52Tests < Minitest::Test
       fingerprint: "381dbd3ff41d8e8a36bc13ea1943fbf8f8d70774724c9f1be7b0581b88d1d3f5",
       warning_type: "Cross-Site Scripting",
       line: 9,
-      message: /^rails\-html\-sanitizer\ 1\.0\.3\ has\ an\ XSS\ vu/,
+      message: /^rails\-html\-sanitizer\ 1\.0\.3\ is\ vulnerable/,
       confidence: 0,
       relative_path: "app/views/users/one.html.haml",
       code: s(:call, nil, :sanitize, s(:call, s(:call, s(:const, :User), :find, s(:call, s(:params), :[], s(:lit, :id))), :bio), s(:hash, s(:lit, :tags), s(:array, s(:str, "style"), s(:lit, :select)))),
       user_input: nil
   end
-
-  def test_cross_site_scripting_CVE_2022_32209_sanitizer_new_call
-    assert_warning check_name: "SanitizeConfigCve",
-      type: :template,
-      warning_code: 124,
-      fingerprint: "9d6223653874a11b649ac92f5e9143ae4b3200fc171d42d193cc820ae850b8eb",
-      warning_type: "Cross-Site Scripting",
-      line: 10,
-      message: /^rails\-html\-sanitizer\ 1\.0\.3\ has\ an\ XSS\ vu/,
-      confidence: 0,
-      relative_path: "app/views/users/one.html.haml",
-      code: s(:call, s(:call, s(:colon2, s(:colon2, s(:const, :Rails), :Html), :SafeListSanitizer), :new), :sanitize, s(:call, s(:call, s(:const, :User), :find, s(:call, s(:params), :[], s(:lit, :id))), :description), s(:hash, s(:lit, :tags), s(:array, s(:str, "select"), s(:str, "style")))),
-      user_input: nil
-  end
-
 
   def test_command_injection_ignored_in_stdin
     assert_no_warning :type => :warning,

--- a/test/tests/rails7.rb
+++ b/test/tests/rails7.rb
@@ -13,7 +13,7 @@ class Rails7Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 0,
-      :warning => 1
+      :warning => 2
     }
   end
 
@@ -28,5 +28,19 @@ class Rails7Tests < Minitest::Test
       :relative_path => "config/environments/production.rb",
       :code => nil,
       :user_input => nil
+  end
+
+  def test_cross_site_scripting_CVE_2022_32209_allowed_tags_initializer
+    assert_warning check_name: "SanitizeConfigCve",
+      type: :warning,
+      warning_code: 124,
+      fingerprint: "c2cc471a99036432e03d83e893fe748c2b1d5c40a39e776475faf088717af97d",
+      warning_type: "Cross-Site Scripting",
+      line: 1,
+      message: /^rails\-html\-sanitizer\ 1\.4\.2\ has\ an\ XSS\ vu/,
+      confidence: 0,
+      relative_path: "config/initializers/sanitizers.rb",
+      code: s(:attrasgn, s(:colon2, s(:colon2, s(:const, :Rails), :Html), :SafeListSanitizer), :allowed_tags=, s(:array, s(:str, "select"), s(:str, "a"), s(:str, "style"))),
+      user_input: nil
   end
 end

--- a/test/tests/rails7.rb
+++ b/test/tests/rails7.rb
@@ -37,7 +37,7 @@ class Rails7Tests < Minitest::Test
       fingerprint: "c2cc471a99036432e03d83e893fe748c2b1d5c40a39e776475faf088717af97d",
       warning_type: "Cross-Site Scripting",
       line: 1,
-      message: /^rails\-html\-sanitizer\ 1\.4\.2\ has\ an\ XSS\ vu/,
+      message: /^rails\-html\-sanitizer\ 1\.4\.2\ is\ vulnerable/,
       confidence: 0,
       relative_path: "config/initializers/sanitizers.rb",
       code: s(:attrasgn, s(:colon2, s(:colon2, s(:const, :Rails), :Html), :SafeListSanitizer), :allowed_tags=, s(:array, s(:str, "select"), s(:str, "a"), s(:str, "style"))),


### PR DESCRIPTION
In general, Brakeman does not keep up with CVEs for Rails or related gems.

However, in cases where Brakeman can point to specific vulnerable code and not just provide a general "you are using a vulnerable dependency" warning, I can make exceptions.