### PR TITLE
Fix `load_rails_defaults` overwriting settings in the Rails application

### DIFF
--- a/lib/brakeman/processors/lib/rails3_config_processor.rb
+++ b/lib/brakeman/processors/lib/rails3_config_processor.rb
@@ -86,7 +86,7 @@ class Brakeman::Rails3ConfigProcessor < Brakeman::BasicProcessor
       end
     elsif include_rails_config? exp
       options_path = get_rails_config exp
-      @tracker.config.set_rails_config(exp.first_arg, *options_path)
+      @tracker.config.set_rails_config(value: exp.first_arg, path: options_path, overwrite: true)
     end
 
     exp

--- a/lib/brakeman/tracker/config.rb
+++ b/lib/brakeman/tracker/config.rb
@@ -166,7 +166,7 @@ module Brakeman
     # then this will set
     #
     #   rails[:action_controller][:perform_caching] = value
-    def set_rails_config value, *path
+    def set_rails_config value:, path:, overwrite: false
       config = self.rails
 
       path[0..-2].each do |o|
@@ -182,7 +182,9 @@ module Brakeman
         config = option
       end
 
-      config[path.last] = value
+      if overwrite || config[path.last].nil?
+        config[path.last] = value
+      end
     end
 
     # Load defaults based on config.load_defaults value
@@ -195,38 +197,38 @@ module Brakeman
       false_value = Sexp.new(:false)
 
       if version >= 5.0
-        set_rails_config(true_value, :action_controller, :per_form_csrf_tokens)
-        set_rails_config(true_value, :action_controller, :forgery_protection_origin_check)
-        set_rails_config(true_value, :active_record, :belongs_to_required_by_default)
+        set_rails_config(value: true_value, path: [:action_controller, :per_form_csrf_tokens])
+        set_rails_config(value: true_value, path: [:action_controller, :forgery_protection_origin_check])
+        set_rails_config(value: true_value, path: [:active_record, :belongs_to_required_by_default])
         # Note: this may need to be changed, because ssl_options is a Hash
-        set_rails_config(true_value, :ssl_options, :hsts, :subdomains)
+        set_rails_config(value: true_value, path: [:ssl_options, :hsts, :subdomains])
       end
 
       if version >= 5.1
-        set_rails_config(false_value, :assets, :unknown_asset_fallback)
-        set_rails_config(true_value, :action_view, :form_with_generates_remote_forms)
+        set_rails_config(value: false_value, path: [:assets, :unknown_asset_fallback])
+        set_rails_config(value: true_value, path: [:action_view, :form_with_generates_remote_forms])
       end
 
       if version >= 5.2
-        set_rails_config(true_value, :active_record, :cache_versioning)
-        set_rails_config(true_value, :action_dispatch, :use_authenticated_cookie_encryption)
-        set_rails_config(true_value, :active_support, :use_authenticated_message_encryption)
-        set_rails_config(true_value, :active_support, :use_sha1_digests)
-        set_rails_config(true_value, :action_controller, :default_protect_from_forgery)
-        set_rails_config(true_value, :action_view, :form_with_generates_ids)
+        set_rails_config(value: true_value, path: [:active_record, :cache_versioning])
+        set_rails_config(value: true_value, path: [:action_dispatch, :use_authenticated_cookie_encryption])
+        set_rails_config(value: true_value, path: [:active_support, :use_authenticated_message_encryption])
+        set_rails_config(value: true_value, path: [:active_support, :use_sha1_digests])
+        set_rails_config(value: true_value, path: [:action_controller, :default_protect_from_forgery])
+        set_rails_config(value: true_value, path: [:action_view, :form_with_generates_ids])
       end
 
       if version >= 6.0
-        set_rails_config(Sexp.new(:lit, :zeitwerk), :autoloader)
-        set_rails_config(false_value, :action_view, :default_enforce_utf8)
-        set_rails_config(true_value, :action_dispatch, :use_cookies_with_metadata)
-        set_rails_config(false_value, :action_dispatch, :return_only_media_type_on_content_type)
-        set_rails_config(Sexp.new(:str, 'ActionMailer::MailDeliveryJob'), :action_mailer, :delivery_job)
-        set_rails_config(true_value, :active_job, :return_false_on_aborted_enqueue)
-        set_rails_config(Sexp.new(:lit, :active_storage_analysis), :active_storage, :queues, :analysis)
-        set_rails_config(Sexp.new(:lit, :active_storage_purge), :active_storage, :queues, :purge)
-        set_rails_config(true_value, :active_storage, :replace_on_assign_to_many)
-        set_rails_config(true_value, :active_record, :collection_cache_versioning)
+        set_rails_config(value: Sexp.new(:lit, :zeitwerk), path: [:autoloader])
+        set_rails_config(value: false_value, path: [:action_view, :default_enforce_utf8])
+        set_rails_config(value: true_value, path: [:action_dispatch, :use_cookies_with_metadata])
+        set_rails_config(value: false_value, path: [:action_dispatch, :return_only_media_type_on_content_type])
+        set_rails_config(value: Sexp.new(:str, 'ActionMailer::MailDeliveryJob'), path: [:action_mailer, :delivery_job])
+        set_rails_config(value: true_value, path: [:active_job, :return_false_on_aborted_enqueue])
+        set_rails_config(value: Sexp.new(:lit, :active_storage_analysis), path: [:active_storage, :queues, :analysis])
+        set_rails_config(value: Sexp.new(:lit, :active_storage_purge), path: [:active_storage, :queues, :purge])
+        set_rails_config(value: true_value, path: [:active_storage, :replace_on_assign_to_many])
+        set_rails_config(value: true_value, path: [:active_record, :collection_cache_versioning])
       end
     end
   end

--- a/test/apps/rails5.2/config/application.rb
+++ b/test/apps/rails5.2/config/application.rb
@@ -14,5 +14,8 @@ module Rails52
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    # https://guides.rubyonrails.org/v7.0/configuring.html#config-action-controller-per-form-csrf-tokens
+    # config.action_controller.per_form_csrf_tokens = true
   end
 end

--- a/test/apps/rails5.2/config/environments/production.rb
+++ b/test/apps/rails5.2/config/environments/production.rb
@@ -91,4 +91,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # https://guides.rubyonrails.org/v7.0/configuring.html#config-action-controller-default-protect-from-forgery
+  # config.action_controller.default_protect_from_forgery = true
 end

--- a/test/tests/config.rb
+++ b/test/tests/config.rb
@@ -1,6 +1,9 @@
 require_relative '../test'
+require 'brakeman/rescanner'
 
 class RailsConfiguration < Minitest::Test
+  include BrakemanTester::RescanTestHelper
+
   def test_rails5_2_configuration_load_defaults
     tracker = Brakeman.run(File.join(TEST_PATH, "apps", "rails5.2"))
 
@@ -18,8 +21,26 @@ class RailsConfiguration < Minitest::Test
 
     # Rails 5.2 settings should be included
     assert_equal Sexp.new(:true), tracker.config.rails[:active_record][:belongs_to_required_by_default]
+    assert_equal Sexp.new(:true), tracker.config.rails[:action_controller][:default_protect_from_forgery]
 
     # Rails 6.0 settings should not be included
     assert_nil tracker.config.rails[:action_dispatch][:use_cookies_with_metadata]
+  end
+
+  def test_rails5_2_configuration_load_defaults_with_config
+    before_rescan_of ["config/application.rb", "config/environments/production.rb"], "rails5.2" do
+      replace "config/application.rb", "# config.action_controller.per_form_csrf_tokens = true", "config.action_controller.per_form_csrf_tokens = false"
+      replace "config/environments/production.rb", "# config.action_controller.default_protect_from_forgery = true", "config.action_controller.default_protect_from_forgery = false"
+    end
+
+    tracker = @rescanner.tracker
+
+    refute tracker.config.rails.empty?
+
+    # Local Rails 5.0 overwrite should be used
+    assert_equal Sexp.new(:false), tracker.config.rails[:action_controller][:per_form_csrf_tokens]
+
+    # Local Rails 5.2 overwrite should be used
+    assert_equal Sexp.new(:false), tracker.config.rails[:action_controller][:default_protect_from_forgery]
   end
 end


### PR DESCRIPTION
While doing some work to implement some additional checks for #1545, I discovered that while Brakeman loads the Rails configuration as expected, if any defaults are set, these are actually overwritten and so Brakeman won't report issues where those defaults are different inside the application.

This appears to be at odds to how Rails works with defaults, where they are (usually) overwritten by the environment configuration.