### PR TITLE
Fix where full call is propagated unnecessarily

### DIFF
--- a/lib/brakeman/processors/lib/find_all_calls.rb
+++ b/lib/brakeman/processors/lib/find_all_calls.rb
@@ -233,6 +233,7 @@ class Brakeman::FindAllCalls < Brakeman::BasicProcessor
 
     unless @in_target
       @full_call = call_hash
+      call_hash[:full_call] = call_hash
     end
 
     # Process up the call chain

--- a/test/tests/call_index.rb
+++ b/test/tests/call_index.rb
@@ -143,6 +143,20 @@ class CallIndexTests < Minitest::Test
     assert_nil third[:parent]
   end
 
+  def test_full_call
+    xyz = @call_index.find_calls(target: :x, method: :z, chained: true).first
+    xy = @call_index.find_calls(target: :x, method: :y, nested: true).first
+    x = @call_index.find_calls(method: :x, nested: true).first
+    thing = @call_index.find_calls(method: :do_a_thing).first
+
+    # Full call for the call should be itself
+    assert_equal thing, thing[:full_call]
+    assert_equal xyz, xyz[:full_call]
+
+    assert_equal xyz, xy[:full_call]
+    assert_equal xyz, x[:full_call]
+  end
+
   def test_find_error
     assert_raises do
       @call_index.find_calls :target => nil, :methods => nil


### PR DESCRIPTION
The `:full_call` on a call site match is used exactly... once in Brakeman. It's been broken for a long time, though!

The idea of `:full_call` is that if you match part of a chain of calls (like `person.name` of `person.name.capitalize`), you can access the full call (`person.name.capitalize`).

The bug was that `:full_call` wasn't getting cleared out so the next, unrelated call would reference the previous call.