### PR TITLE
Add GitHub Action to publish docker image for new releases

### DIFF
--- a/.github/workflows/docker-hub-push.yml
+++ b/.github/workflows/docker-hub-push.yml
@@ -1,0 +1,31 @@
+name: docker-hub-push
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: |
+            presidentbeef/brakeman:latest
+            presidentbeef/brakeman:${{ github.ref_name }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add GitHub Action to update docker hub image
+
 # 5.3.1 - 2022-08-09
 
 * Fix version range for CVE-2022-32209


### PR DESCRIPTION
Resolve #1680

This will build both `amd64` and `arm64` image

Maintainers should add secrets for `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in GitHub repo settings

Not 100% that it's a working actions file, since it will only trigger on new tags creation, but it's based on some of my other repo with minor differences

Maintainers can test it by creating some temp tag (after this merged) like `test-tag-please-ignore` and check that docker images are built and pushed to docker hub (this will override `latest` image through, but it's already very outdated, so don't think there is any harm)