### PR TITLE
Handle multiple values in case/when ...

### DIFF
--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1214,6 +1214,38 @@ class AliasProcessorTests < Minitest::Test
     OUTPUT
   end
 
+  def test_case_list
+    assert_output <<-INPUT, <<-OUTPUT
+      case y
+      when :a, :b, :c
+        something(y)
+      end
+    INPUT
+      case y
+      when :a, :b, :c
+        something(:BRAKEMAN_SAFE_LITERAL)
+      end
+    OUTPUT
+  end
+
+  def test_case_splat
+    assert_output <<-INPUT, <<-OUTPUT
+      x = [1, 2, 3]
+
+      case y
+      when *x
+        something(y)
+      end
+    INPUT
+      x = [1, 2, 3]
+
+      case y
+      when *[1, 2, 3]
+        something(:BRAKEMAN_SAFE_LITERAL)
+      end
+    OUTPUT
+  end
+
   def test_less_copying_of_arrays_and_hashes
     assert_output <<-'INPUT', <<-'OUTPUT'
       x = {}


### PR DESCRIPTION
Do not warn about these cases:

```ruby
case x
when 1, 2, 3
  maybe_dangerous(x)
end
```

and

```ruby
y = [1, 2, 3]

case x
when *y
  maybe_dangerous(x)
end
```

(In the future, it might make sense to assign a union of the values (e.g. `x = 1 || 2 || 3`), but not doing that now because it has performance implications and not sure it matters for security issues.)

Fixes #1730 