### PR TITLE
use Warning#relative_path for location path when reporting in codeclimate format

### DIFF
--- a/lib/brakeman/report/report_codeclimate.rb
+++ b/lib/brakeman/report/report_codeclimate.rb
@@ -73,7 +73,7 @@ class Brakeman::Report::CodeClimate < Brakeman::Report::Base
     if tracker.options[:path_prefix]
       (Pathname.new(tracker.options[:path_prefix]) + Pathname.new(warning.file.relative)).to_s
     else
-      warning.file
+      warning.relative_path
     end
   end
 end

--- a/test/tests/report_generation.rb
+++ b/test/tests/report_generation.rb
@@ -37,6 +37,7 @@ class TestReportGeneration < Minitest::Test
     report = @@report.to_codeclimate
 
     assert report.is_a? String
+    refute report.include? Dir.pwd # Ensure output does not include absolute paths
   end
 
   def test_csv_sanity


### PR DESCRIPTION
* Since Warning#file could return a reference to the absolute path, and codeclimate does not support reporting issues in that format, we want to always ensure that the location of any issue is being reported with a relative location.