### PR TITLE
Support `presence`, `presence_in` and `in?`

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -328,6 +328,17 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
           exp = res
         end
       end
+    when :presence_in
+      arg = exp.first_arg
+
+      if node_type? arg, :array
+        # 1.presence_in [1,2,3]
+        if arg.include? target
+          exp = target
+        elsif all_literals? arg
+          exp = safe_literal(exp.line)
+        end
+      end
     end
 
     exp

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -300,11 +300,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
       if array? target and first_arg.nil? and sexp? target[1]
         exp = target[1]
       end
-    when :freeze
-      unless target.nil?
-        exp = target
-      end
-    when :dup
+    when :freeze, :dup, :presence
       unless target.nil?
         exp = target
       end

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -858,6 +858,17 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     (all_literals? exp.target or dir_glob? exp.target)
   end
 
+  # Check if exp is a call to Array#include? on an array literal
+  # that contains all literal values. For example:
+  #
+  #    x.in? [1, 2, "a"]
+  #
+  def in_array_all_literals? exp
+    call? exp and
+      exp.method == :in? and
+      all_literals? exp.first_arg
+  end
+
   # Check if exp is a call to Hash#include? on a hash literal
   # that contains all literal values. For example:
   #
@@ -911,28 +922,30 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
         scope do
           @branch_env = env.current
           branch_index = 2 + i # s(:if, condition, then_branch, else_branch)
-          if i == 0 and hash_or_array_include_all_literals? condition
+         exp[branch_index] = if i == 0 and hash_or_array_include_all_literals? condition
             # If the condition is ["a", "b"].include? x
-            # set x to "a" inside the true branch
+            # set x to safe_literal inside the true branch
             var = condition.first_arg
-            previous_value = env.current[var]
-            env.current[var] = safe_literal(var.line)
-            exp[branch_index] = process_if_branch branch
-            env.current[var] = previous_value
+            value = safe_literal(var.line)
+            process_branch_with_value(var, value, branch, i)
+          elsif i == 0 and in_array_all_literals? condition
+            # If the condition is x.in? ["a", "b"]
+            # set x to safe_literal inside the true branch
+            var = condition.target
+            value = safe_literal(var.line)
+            process_branch_with_value(var, value, branch, i)
           elsif i == 0 and equality_check? condition
             # For conditions like a == b,
             # set a to b inside the true branch
             var = condition.target
-            previous_value = env.current[var]
-            env.current[var] = condition.first_arg
-            exp[branch_index] = process_if_branch branch
-            env.current[var] = previous_value
+            value = condition.first_arg
+            process_branch_with_value(var, value, branch, i)
           elsif i == 1 and hash_or_array_include_all_literals? condition and early_return? branch
             var = condition.first_arg
             env.current[var] = safe_literal(var.line)
-            exp[branch_index] = process_if_branch branch
+            process_if_branch branch
           else
-            exp[branch_index] = process_if_branch branch
+            process_if_branch branch
           end
           branch_scopes << env.current
           @branch_env = nil
@@ -947,6 +960,14 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     end
 
     exp
+  end
+
+  def process_branch_with_value var, value, branch, branch_index
+    previous_value = env.current[var]
+    env.current[var] = value
+    result = process_if_branch branch
+    env.current[var] = previous_value
+    result
   end
 
   def early_return? exp

--- a/test/apps/rails7/app/controllers/users_controller.rb
+++ b/test/apps/rails7/app/controllers/users_controller.rb
@@ -2,4 +2,10 @@ class UsersController < ApplicationController
   def redirect_to_last!
     redirect_to User.last!
   end
+
+  def presence
+    # Don't warn... @field is either "foo" or nil
+    @field = params[:field].presence_in(%w[foo]) || raise(ActionController::BadRequest)
+    render "admin2/fields/#{@field}"
+  end
 end

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1043,12 +1043,12 @@ class AliasProcessorTests < Minitest::Test
 
     x
     INPUT
-    x = params[:x].presence
-    if ['a','b'].include? params[:x].presence
+    x = params[:x]
+    if ['a','b'].include? params[:x]
       User.BRAKEMAN_SAFE_LITERAL
     end
 
-    params[:x].presence
+    params[:x]
     OUTPUT
   end
 
@@ -1366,6 +1366,13 @@ class AliasProcessorTests < Minitest::Test
   def test_ignore_dup
     assert_alias "blah", <<-INPUT
     x = blah.dup
+    x
+    INPUT
+  end
+
+  def test_ignore_presence
+    assert_alias "blah", <<-INPUT
+    x = blah.presence
     x
     INPUT
   end

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1010,6 +1010,48 @@ class AliasProcessorTests < Minitest::Test
     INPUT
   end
 
+  def test_branch_in_array
+    assert_alias 'x', <<-INPUT
+    if x.in? [1,2,3]
+      stuff
+    end
+
+    x
+    INPUT
+
+    assert_output <<-INPUT, <<-OUTPUT
+    if x.in? [1,2,3]
+      y = x + 2
+      p y
+    end
+
+    x
+    INPUT
+    if x.in? [1,2,3]
+      y = :BRAKEMAN_SAFE_LITERAL
+      p :BRAKEMAN_SAFE_LITERAL
+    end
+
+    x
+    OUTPUT
+
+    assert_output <<-INPUT, <<-OUTPUT
+    x = params[:x]
+    if x.in? ['a','b']
+      User.send x
+    end
+
+    x
+    INPUT
+    x = params[:x]
+    if params[:x].in? ['a','b']
+      User.BRAKEMAN_SAFE_LITERAL
+    end
+
+    params[:x]
+    OUTPUT
+  end
+
   def test_branch_array_include
     assert_alias 'x', <<-INPUT
     if [1,2,3].include? x

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1010,6 +1010,20 @@ class AliasProcessorTests < Minitest::Test
     INPUT
   end
 
+  def test_presence_in_all_literals
+    assert_alias "'1'", <<-INPUT
+    x = '1'.presence_in ['1', '2', '3']
+    x
+    INPUT
+  end
+
+  def test_presence_in_unknown
+    assert_alias ':BRAKEMAN_SAFE_LITERAL', <<-INPUT
+    x = y.presence_in ['1', '2', '3']
+    x
+    INPUT
+  end
+
   def test_branch_in_array
     assert_alias 'x', <<-INPUT
     if x.in? [1,2,3]

--- a/test/tests/rails7.rb
+++ b/test/tests/rails7.rb
@@ -268,6 +268,20 @@ class Rails7Tests < Minitest::Test
       user_input: nil
   end
 
+  def test_presence_in_with_render_path_false_positive
+    assert_no_warning check_name: "Render",
+      type: :warning,
+      warning_code: 15,
+      fingerprint: "32762c066cbafafce28947fb91f24cd547c52f184084fb4dc05ac9ff81def638",
+      warning_type: "Dynamic Render Path",
+      line: 9,
+      message: /^Render\ path\ contains\ parameter\ value/,
+      confidence: 1,
+      relative_path: "app/controllers/users_controller.rb",
+      code: s(:render, :action, s(:dstr, "admin2/fields/", s(:evstr, s(:or, s(:call, s(:call, s(:params), :[], s(:lit, :field)), :presence_in, s(:array, s(:str, "foo"))), s(:call, nil, :raise, s(:colon2, s(:const, :ActionController), :BadRequest))))), s(:hash)),
+      user_input: s(:call, s(:call, s(:params), :[], s(:lit, :field)), :presence_in, s(:array, s(:str, "foo")))
+  end
+
   def test_cross_site_scripting_CVE_2022_32209_allowed_tags_initializer
     assert_warning check_name: "SanitizeConfigCve",
       type: :warning,


### PR DESCRIPTION
A bit lazy combining these but...

This will treat `presence` like it isn't... even... present... :see_no_evil: 

For `presence_in`:
* If the argument is an array and the target is in the array, change it to the target (e.g. `1.presence_in([1])`)
* If the argument is an array of literals, return a `safe_literal`

`in?` will be treated like `include?` (but with target/argument swapped) for `if` conditions.