### PR TITLE
Improve test suite speed

### DIFF
--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -371,7 +371,7 @@ class Brakeman::Tracker
       end
     end
 
-    @models.delete model_name
+    @models.delete(model_name)
   end
 
   #Clear information related to model

--- a/test/test.rb
+++ b/test/test.rb
@@ -139,6 +139,7 @@ module BrakemanTester::RescanTestHelper
   attr_reader :original, :rescan, :rescanner
 
   @@temp_dirs = {}
+  @@scans = {}
 
   Minitest.after_run do
     @@temp_dirs.each do |_, dir|
@@ -171,7 +172,12 @@ module BrakemanTester::RescanTestHelper
     end
 
     options = {:app_path => dir, :debug => false}.merge(options)
-    @original = Brakeman.run options
+
+    if @@scans[[app, options]]
+      @original = @@scans[[app, options]]
+    else
+      @@scans[[app, options]] = @original = Brakeman.run(options)
+    end
 
     begin
       yield dir if block_given?

--- a/test/test.rb
+++ b/test/test.rb
@@ -74,26 +74,20 @@ module BrakemanTester::FindWarning
     end
   end
 
-  def find opts = {}, &block
+  def find opts = {}
     warnings = report[warning_table(opts[:type])]
 
     opts.delete :type
 
-    result = if block
-      warnings.select block
-    else
-      warnings.select do |w|
-        opts.all? do |k,v|
-          if k == :relative_path
-            v === w.file.relative
-          else
-            v === w.send(k)
-          end
+    warnings.select do |w|
+      opts.all? do |k,v|
+        if k == :relative_path
+          v === w.file.relative
+        else
+          v === w.send(k)
         end
       end
     end
-
-    result
   end
 end
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -164,11 +164,8 @@ module BrakemanTester::RescanTestHelper
 
       yield dir if block_given?
 
-      File.open(File.join(dir, '.brakeman.dump'), "w") do |f|
-        f.print(Marshal.dump(@original))
-      end
-
-      t = Marshal.load(File.read(File.join(dir, '.brakeman.dump')))
+      # Not reqally sure why we do this..?
+      t = Marshal.load(Marshal.dump(@original))
 
       @rescanner = Brakeman::Rescanner.new(t.options, t.processor, changed)
       @rescan = @rescanner.recheck

--- a/test/tests/parser_timeout.rb
+++ b/test/tests/parser_timeout.rb
@@ -5,7 +5,7 @@ class ParserTimeoutTests < Minitest::Test
   include BrakemanTester::RescanTestHelper
 
   def test_timeout
-    before_rescan_of "lib/large_file.rb", "rails5.2", { parser_timeout: 1 } do
+    before_rescan_of "lib/large_file.rb", "rails5.2", { parser_timeout: 0.5 } do
       random_ruby = Array.new(10000) { "def x_#{rand(1000)}\nputs '#{"**" * 1000}'\nend" }.join("\n")
       write_file "lib/large_file.rb", random_ruby
     end
@@ -13,6 +13,6 @@ class ParserTimeoutTests < Minitest::Test
     assert_equal 1, @rescanner.tracker.errors.length
 
     timeout_error = @rescanner.tracker.errors.first
-    assert_match(/Parsing .* took too long \(> 1 seconds\)/, timeout_error[:error])
+    assert_match(/Parsing .* took too long \(> 0.5 seconds\)/, timeout_error[:error])
   end
 end

--- a/test/tests/rescanner.rb
+++ b/test/tests/rescanner.rb
@@ -152,6 +152,9 @@ class RescannerTests < Minitest::Test
     model = "app/models/user.rb"
 
     before_rescan_of model do
+      # So actually there is another definition of User in
+      # app/models/user/command_dependency.rb
+      # so this does not completely delete the model
       remove model
     end
 
@@ -165,7 +168,7 @@ class RescannerTests < Minitest::Test
     model = "app/models/user.rb"
     dependency = "app/models/user/command_dependency.rb"
 
-    before_rescan_of model do
+    before_rescan_of [model, dependency] do
       remove model
       remove dependency
     end


### PR DESCRIPTION
* In rescan tests, only copy apps once and cache for the rest
* In rescan tests, don't Marshal `tracker` to disk... maybe don't Marshal it at all? (Can't remember why this is done.)
* Lower parser timeout test timeout
* Cache initial scans for rescan tests
* Remove unused block parameter from `BrakemanTester::FindWarning#find`

Together these provide about ~30% reduction in time to run the test suite.