### PR TITLE
Add ruby 3.2 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
   test-3-0:
     <<: *default
     docker:
-      - image: circleci/ruby:3.0
+      - image: cimg/ruby:3.0
   test-3-1:
     <<: *default
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,6 @@ jobs:
     <<: *default
     docker:
       - image: cimg/ruby:3.2
-  test-latest:
-    <<: *default
-    docker:
-      - image: circleci/ruby:latest
   upload-coverage:
     <<: *default
     working_directory: ~/repo
@@ -75,7 +71,6 @@ workflows:
       - test-3-0
       - test-3-1
       - test-3-2
-      - test-latest
       - upload-coverage:
           requires:
             - test-2-5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,10 @@ jobs:
     <<: *default
     docker:
       - image: cimg/ruby:3.1
+  test-3-2:
+    <<: *default
+    docker:
+      - image: cimg/ruby:3.2
   test-latest:
     <<: *default
     docker:
@@ -70,6 +74,7 @@ workflows:
       - test-2-6
       - test-3-0
       - test-3-1
+      - test-3-2
       - test-latest
       - upload-coverage:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: cimg/ruby:2.7
     steps:
       - checkout
-      - run: bundle check || bundle install
+      - run: ruby --version && bundle check || bundle install
       - run:
           command: bundle exec rake
       - store_test_results:

--- a/test/tests/rails7.rb
+++ b/test/tests/rails7.rb
@@ -5,7 +5,10 @@ class Rails7Tests < Minitest::Test
   include BrakemanTester::CheckExpected
 
   def report
-    @@report ||= BrakemanTester.run_scan "rails7", "Rails 7", :run_all_checks => true
+    @@report ||=
+      Date.stub :today, Date.parse('2023-02-10') do
+        BrakemanTester.run_scan "rails7", "Rails 7", :run_all_checks => true
+      end
   end
 
   def expected
@@ -13,8 +16,14 @@ class Rails7Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 0,
-      :warning => 22
+      :warning => 23
     }
+  end
+
+  def test_ruby_2_7_eol
+    assert_warning check_name: "EOLRuby",
+      message: "Support for Ruby 2.7.0 ends on 2023-03-31 near line 140",
+      fingerprint: "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df"
   end
 
   def test_missing_encryption_1


### PR DESCRIPTION
Something fails on when I use ruby 3.2 in production. I think this should work but it is allways good to test have it in ci too.
