### PR TITLE
Revise checking for request.env to only consider request headers

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -76,7 +76,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
         @has_user_input = Match.new(:params, exp)
       elsif cookies? target
         @has_user_input = Match.new(:cookies, exp)
-      elsif request_env? target
+      elsif request_headers? target
         @has_user_input = Match.new(:request, exp)
       elsif sexp? target and model_name? target[1] #TODO: Can this be target.target?
         @has_user_input = Match.new(:model, exp)
@@ -313,7 +313,7 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
         return Match.new(:params, exp)
       elsif cookies? exp
         return Match.new(:cookies, exp)
-      elsif request_env? exp
+      elsif request_headers? exp
         return Match.new(:request, exp)
       else
         has_immediate_user_input? exp.target

--- a/lib/brakeman/checks/check_redirect.rb
+++ b/lib/brakeman/checks/check_redirect.rb
@@ -98,8 +98,6 @@ class Brakeman::CheckRedirect < Brakeman::BaseCheck
     elsif call? opt
       if request_value? opt
         return Match.new(immediate, opt)
-      elsif request_value? opt.target
-        return Match.new(immediate, opt.target)
       elsif opt.method == :url_for and include_user_input? opt.first_arg
         return Match.new(immediate, opt)
         #Ignore helpers like some_model_url?

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -272,12 +272,13 @@ module Brakeman::Util
     if exp[1] == REQUEST_ENV
       if exp.method == :[]
         if string? exp.first_arg
+          # Only care about HTTP headers, which are prefixed by 'HTTP_'
           exp.first_arg.value.start_with?('HTTP_'.freeze)
         else
-          true
+          true # request.env[something]
         end
       else
-        true
+        false # request.env.something
       end
     else
       false

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -266,7 +266,22 @@ module Brakeman::Util
   end
 
   def request_env? exp
-    call? exp and (exp == REQUEST_ENV or exp[1] == REQUEST_ENV)
+    return unless sexp? exp
+    return true if exp == REQUEST_ENV
+
+    if exp[1] == REQUEST_ENV
+      if exp.method == :[]
+        if string? exp.first_arg
+          exp.first_arg.value.start_with?('HTTP_'.freeze)
+        else
+          true
+        end
+      else
+        true
+      end
+    else
+      false
+    end
   end
 
   #Check if exp is params, cookies, or request_env

--- a/lib/brakeman/util.rb
+++ b/lib/brakeman/util.rb
@@ -265,9 +265,9 @@ module Brakeman::Util
     false
   end
 
-  def request_env? exp
+  # Only return true when accessing request headers via request.env[...]
+  def request_headers? exp
     return unless sexp? exp
-    return true if exp == REQUEST_ENV
 
     if exp[1] == REQUEST_ENV
       if exp.method == :[]
@@ -284,11 +284,11 @@ module Brakeman::Util
     end
   end
 
-  #Check if exp is params, cookies, or request_env
+  #Check if exp is params, cookies, or request_headers
   def request_value? exp
     params? exp or
     cookies? exp or
-    request_env? exp
+    request_headers? exp
   end
 
   def constant? exp

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -83,7 +83,7 @@ class UtilTests < Minitest::Test
   end
 
   def util
-    Class.new.extend Brakeman::Util
+    @@util ||= Class.new.extend Brakeman::Util
   end
 
   def test_cookies?
@@ -92,6 +92,14 @@ class UtilTests < Minitest::Test
 
   def test_params?
     assert util.params?(@ruby_parser.new.parse 'params[:x][:y][:z]')
+  end
+
+  def test_request_headers?
+    assert util.request_headers?(@ruby_parser.new.parse 'request.env["HTTP_SOMETHING"]')
+    assert util.request_headers?(@ruby_parser.new.parse 'request.env[x]')
+    refute util.request_headers?(@ruby_parser.new.parse 'request.env["omniauth.something"]')
+    refute util.request_headers?(@ruby_parser.new.parse 'request.env')
+    refute util.request_headers?(@ruby_parser.new.parse 'request.env.x')
   end
 
   def test_template_path_to_name_with_views


### PR DESCRIPTION
Other parts of `request.env` are either not really request values and it's not obvious when that is/isn't the case.

So for now, rename `request_env?` to `request_headers?` and only match calls to `request.env['HTTP_...']`.