### PR TITLE
Fixed detection of UnscopedFind if optional: true is defined in the model and is not self-reference related

### DIFF
--- a/lib/brakeman/checks/check_unscoped_find.rb
+++ b/lib/brakeman/checks/check_unscoped_find.rb
@@ -17,7 +17,7 @@ class Brakeman::CheckUnscopedFind < Brakeman::BaseCheck
       end
     end
 
-    calls = tracker.find_call :method => [:find, :find_by_id, :find_by_id!, :find_by, :find_by!],
+    calls = tracker.find_call :method => [:find, :find_by_id, :find_by_id!],
                               :targets => associated_model_names
 
     calls.each do |call|

--- a/test/apps/rails7/app/controllers/groups_controller.rb
+++ b/test/apps/rails7/app/controllers/groups_controller.rb
@@ -1,0 +1,6 @@
+class GroupsController < ApplicationController
+  def show
+    @group = Group.find(params[:id])
+    @user = User.find(params[:id])
+  end
+end

--- a/test/apps/rails7/app/models/group.rb
+++ b/test/apps/rails7/app/models/group.rb
@@ -1,0 +1,3 @@
+class Group < ApplicationRecord
+  belongs_to :user, optional: true
+end

--- a/test/apps/rails7/app/models/user.rb
+++ b/test/apps/rails7/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+  belongs_to :matched_user, class_name: 'User', optional: true
 end

--- a/test/tests/rails7.rb
+++ b/test/tests/rails7.rb
@@ -16,7 +16,7 @@ class Rails7Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 0,
-      :warning => 23
+      :warning => 24
     }
   end
 
@@ -395,5 +395,33 @@ class Rails7Tests < Minitest::Test
       relative_path: "app/controllers/users_controller.rb",
       code: s(:call, nil, :redirect_back_or_to, s(:call, s(:params), :[], s(:lit, :x))),
       user_input: s(:call, s(:params), :[], s(:lit, :x))
+  end
+
+  def test_unscoped_find
+    assert_warning check_name: "UnscopedFind",
+      type: :warning,
+      warning_code: 82,
+      fingerprint: "e84705527089566771bd3ae5b04f9c82529a0f388a4864eb4a91f7ad468541da",
+      warning_type: "Unscoped Find",
+      line: 3,
+      message: /^Unscoped\ call\ to\ `Group\#find`/,
+      confidence: 2,
+      relative_path: "app/controllers/groups_controller.rb",
+      code: s(:call, s(:const, :Group), :find, s(:call, s(:params), :[], s(:lit, :id))),
+      user_input: s(:call, s(:params), :[], s(:lit, :id))
+  end
+
+  def test_unscoped_find_2
+    assert_no_warning check_name: "UnscopedFind",
+      type: :warning,
+      warning_code: 82,
+      fingerprint: "f2ba23dcceff3cefef2d9fd08a0fe9f87b5936226ec883a73e3a93629e172387",
+      warning_type: "Unscoped Find",
+      line: 4,
+      message: /^Unscoped\ call\ to\ `User\#find`/,
+      confidence: 2,
+      relative_path: "app/controllers/groups_controller.rb",
+      code: s(:call, s(:const, :User), :find, s(:call, s(:params), :[], s(:lit, :id))),
+      user_input: s(:call, s(:params), :[], s(:lit, :id))
   end
 end


### PR DESCRIPTION
ref https://github.com/presidentbeef/brakeman/issues/1139
ref https://github.com/presidentbeef/brakeman/pull/1153

The change in https://github.com/presidentbeef/brakeman/pull/1153 avoids checking UnscopedFind for model classes with optional: true settings, but I think UnscopedFind warning should be issued for the following cases.

The current code only checks if optional: true is defined in the model class, so the check for the Group model is skipped.

```rb
class Group < ApplicationRecord
  belongs_to :user, optional: true
end
```

```rb
class GroupsController < ApplicationController
  def show
    @group = Group.find(params[:id])
  end
end
```

This PR solves this problem by also checking self-reference associations.
We have also added implementation and testing for the issues mentioned in https://github.com/presidentbeef/brakeman/issues/1139 so that they are not affected.

