### PR TITLE
Drop older Rubies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   default: &default
     docker:
-      - image: cimg/ruby:2.7
+      - image: cimg/ruby:3.0
     steps:
       - checkout
       - run: ruby --version && bundle check || bundle install
@@ -10,10 +10,10 @@ jobs:
           command: bundle exec rake
       - store_test_results:
           path: test-results
-  test-2-5:
+  test-3-1:
     <<: *default
     docker:
-      - image: cimg/ruby:2.5
+      - image: cimg/ruby:3.1
     steps:
       - checkout
       - attach_workspace:
@@ -36,18 +36,6 @@ jobs:
           paths:
             - codeclimate.json
             - cc-test-reporter
-  test-2-6:
-    <<: *default
-    docker:
-      - image: cimg/ruby:2.6
-  test-3-0:
-    <<: *default
-    docker:
-      - image: cimg/ruby:3.0
-  test-3-1:
-    <<: *default
-    docker:
-      - image: cimg/ruby:3.1
   test-3-2:
     <<: *default
     docker:
@@ -66,11 +54,8 @@ workflows:
   tests:
     jobs:
       - default
-      - test-2-5
-      - test-2-6
-      - test-3-0
       - test-3-1
       - test-3-2
       - upload-coverage:
           requires:
-            - test-2-5
+            - test-3-1

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Outside of Rails root (note that the output file is relative to path/to/rails/ap
 
 Brakeman should work with any version of Rails from 2.3.x to 7.x.
 
-Brakeman can analyze code written with Ruby 1.8 syntax and newer, but requires at least Ruby 2.5.0 to run.
+Brakeman can analyze code written with Ruby 2.0 syntax and newer, but requires at least Ruby 3.0.0 to run.
 
 # Basic Options
 

--- a/brakeman.gemspec
+++ b/brakeman.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files = ["bin/brakeman", "CHANGES.md", "FEATURES", "README.md"] + Dir["lib/**/*"]
   s.executables = ["brakeman"]
   s.license = "Brakeman Public Use License"
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 3.0.0'
 
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/presidentbeef/brakeman/issues",

--- a/build.rb
+++ b/build.rb
@@ -17,7 +17,4 @@ File.open "bundle/load.rb", "w" do |f|
   end
 end
 
-# Fix permissions
-system 'chmod 664 bundle/ruby/*/gems/ruby_parser-legacy-1.0.0/lib/ruby_parser/legacy/*'
-
 system "BM_PACKAGE=true gem build brakeman.gemspec"

--- a/gem_common.rb
+++ b/gem_common.rb
@@ -10,7 +10,6 @@ module Brakeman
     def self.base_dependencies spec
       spec.add_dependency "parallel", "~>1.20"
       spec.add_dependency "ruby_parser", "~>3.19"
-      spec.add_dependency "ruby_parser-legacy", "~>1.0"
       spec.add_dependency "sexp_processor", "~> 4.7"
       spec.add_dependency "ruby2ruby", "~>2.4.0"
       spec.add_dependency "safe_yaml", ">= 1.0"

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -1,6 +1,5 @@
 begin
   Brakeman.load_brakeman_dependency 'ruby_parser'
-  Brakeman.load_brakeman_dependency 'ruby_parser/legacy'
   require 'ruby_parser/bm_sexp.rb'
   require 'ruby_parser/bm_sexp_processor.rb'
   require 'brakeman/processor'

--- a/test/apps/rails2/lib/ruby18_syntax.rb
+++ b/test/apps/rails2/lib/ruby18_syntax.rb
@@ -1,4 +1,0 @@
-case blah
-when x:
- do_the_thing
-end 


### PR DESCRIPTION
- Raise required Ruby to 3.0.
- Drop parsing of Ruby 1.8 and 1.9