### PR TITLE
Use correct capitalization for GitHub

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -163,7 +163,7 @@ Reports show relative paths by default. To use absolute paths instead:
 
 This does not affect HTML or tab-separated reports.
 
-To output Markdown with nice links to files on Github, use
+To output Markdown with nice links to files on GitHub, use
 
     brakeman --github-repo USER/REPO[/PATH][@REF]
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ There is a [plugin available](http://brakemanscanner.org/docs/jenkins/) for Jenk
 
 For even more continuous testing, try the [Guard plugin](https://github.com/guard/guard-brakeman).
 
-There are a couple [Github Actions](https://github.com/marketplace?type=actions&query=brakeman) available.
+There are a couple [GitHub Actions](https://github.com/marketplace?type=actions&query=brakeman) available.
 
 # Building
 

--- a/lib/brakeman/report/report_github.rb
+++ b/lib/brakeman/report/report_github.rb
@@ -1,4 +1,4 @@
-# Github Actions Formatter
+# GitHub Actions Formatter
 # Formats warnings as workflow commands to create annotations in GitHub UI
 class Brakeman::Report::Github < Brakeman::Report::Base
   def generate_report


### PR DESCRIPTION
👋 Hi there! This is a very tiny PR to change the capitalization of `Github` to `GitHub` in a few places, since that is the right way to write it. 😄 