### PR TITLE
Scan directories that include 'public'

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -197,7 +197,6 @@ module Brakeman
       spec/
       test/
       tmp/
-      public/
       log/
     ]
 

--- a/test/tests/cves.rb
+++ b/test/tests/cves.rb
@@ -362,8 +362,10 @@ class CVETests < Minitest::Test
   end
 
   def test_CVE_2020_8166_rails6
-    before_rescan_of "Gemfile", "rails6" do
-      replace "Gemfile", "gem 'rails', '~> 6.0.0.beta2'", "gem 'rails', '~> 6.0.0'"
+    Date.stub :today, Date.parse('2022-04-06') do
+      before_rescan_of "Gemfile", "rails6" do
+        replace "Gemfile", "gem 'rails', '~> 6.0.0.beta2'", "gem 'rails', '~> 6.0.0'"
+      end
     end
 
     assert_new 1


### PR DESCRIPTION
This is ancient thinking to ignore the `/public/` directory, but there's no real need to do that now.

(Unrelated time-related test change)