### PR TITLE
Add obsolete entries to comparison report

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -493,10 +493,14 @@ module Brakeman
     end
 
     tracker = run(options)
+    new_report = JSON.parse(tracker.report.to_json, symbolize_names: true)
 
-    new_results = JSON.parse(tracker.report.to_json, :symbolize_names => true)[:warnings]
+    new_results = new_report[:warnings]
+    obsolete_ignored = tracker.unused_fingerprints
 
-    Brakeman::Differ.new(new_results, previous_results).diff
+    Brakeman::Differ.new(new_results, previous_results).diff.tap do |diff|
+      diff[:obsolete] = obsolete_ignored
+    end
   end
 
   def self.load_brakeman_dependency name, allow_fail = false

--- a/test/test.rb
+++ b/test/test.rb
@@ -176,7 +176,7 @@ module BrakemanTester::RescanTestHelper
     begin
       yield dir if block_given?
 
-      # Not reqally sure why we do this..?
+      # Not really sure why we do this..?
       t = Marshal.load(Marshal.dump(@original))
 
       @rescanner = Brakeman::Rescanner.new(t.options, t.processor, changed)


### PR DESCRIPTION
Include "obsolete"  (warnings in the ignore configuration that are no longer present) fingerprints in report when using `--compare`.

```json
{
  "new": [

  ],
  "fixed": [

  ],
  "obsolete": [

  ]
}
```

This isn't particularly smart - it just reports the obsolete fingerprints just like the text report would for a new scan. It doesn't differentiate between already-obsolete and newly-obsolete.
In other words, if there were ignored warnings that were already missing in the original report, they will still be reported as obsolete in the new report.

Fixes #1758 

Also update the test for comparison report to be more modern.