### PR TITLE
Avoid warning about unescaped attribute names in content_tag for Rails 6.1.6+

### DIFF
--- a/lib/brakeman/checks/check_content_tag.rb
+++ b/lib/brakeman/checks/check_content_tag.rb
@@ -73,11 +73,14 @@ class Brakeman::CheckContentTag < Brakeman::CheckCrossSiteScripting
       check_argument result, content
     end
 
-    #Attribute keys are never escaped, so check them for user input
-    if not @matched and hash? attributes and not request_value? attributes
-      hash_iterate(attributes) do |k, _v|
-        check_argument result, k
-        return if @matched
+    # This changed in Rails 6.1.6
+    if version_between? '0.0.0', '6.1.5' 
+      #Attribute keys are never escaped, so check them for user input
+      if not @matched and hash? attributes and not request_value? attributes
+        hash_iterate(attributes) do |k, _v|
+          check_argument result, k
+          return if @matched
+        end
       end
     end
 

--- a/test/tests/rails7.rb
+++ b/test/tests/rails7.rb
@@ -313,6 +313,19 @@ class Rails7Tests < Minitest::Test
       user_input: nil
   end
 
+  def test_cross_site_scripting_content_tag
+    assert_no_warning check_name: "ContentTag",
+      type: :template,
+      warning_code: 53,
+      warning_type: "Cross-Site Scripting",
+      line: 2,
+      message: /^Unescaped\ parameter\ value\ in\ `content_ta/,
+      confidence: 0,
+      relative_path: "app/views/users/index.html.erb",
+      code: s(:call, nil, :content_tag, s(:lit, :b), s(:call, nil, :cool_content), s(:hash, s(:call, s(:call, nil, :params), :[], s(:lit, :stuff)), s(:call, s(:call, nil, :params), :[], s(:lit, :things)))),
+      user_input: s(:call, s(:call, nil, :params), :[], s(:lit, :stuff))
+  end
+
   def test_redirect_1
     assert_warning check_name: "Redirect",
       type: :warning,


### PR DESCRIPTION
Fixes #1778