### PR TITLE
Add PG::Connection.escape_string as authorized sanitization function

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -591,7 +591,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     :sanitize_sql_for_assignment, :sanitize_sql_for_conditions, :sanitize_sql_hash,
     :sanitize_sql_hash_for_assignment, :sanitize_sql_hash_for_conditions,
     :to_sql, :sanitize, :primary_key, :table_name_prefix, :table_name_suffix,
-    :where_values_hash, :foreign_key, :uuid, :escape_string
+    :where_values_hash, :foreign_key, :uuid, :escape, :escape_string
   ]
 
   def ignore_methods_in_sql

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -591,7 +591,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     :sanitize_sql_for_assignment, :sanitize_sql_for_conditions, :sanitize_sql_hash,
     :sanitize_sql_hash_for_assignment, :sanitize_sql_hash_for_conditions,
     :to_sql, :sanitize, :primary_key, :table_name_prefix, :table_name_suffix,
-    :where_values_hash, :foreign_key, :uuid
+    :where_values_hash, :foreign_key, :uuid, :escape_string
   ]
 
   def ignore_methods_in_sql


### PR DESCRIPTION
Hello,

In the same way as [ActiveRecord::Base.sanitize_sql()](https://api.rubyonrails.org/v7.0.6/classes/ActiveRecord/Sanitization/ClassMethods.html#method-i-sanitize_sql), I suggest adding [PG::Connection.escape_string()](https://deveiate.org/code/pg/PG/Connection.html#method-c-escape_string-doc) as an authorized function to sanitize sql statments.

Using this will never be as good as using prepared statements, but this addition, if deemed relevant, would limit false positives.

Thanks!
Nb: [escape](https://deveiate.org/code/pg/PG/Connection.html#method-i-escape) is an alias for [escape_string](https://deveiate.org/code/pg/PG/Connection.html#method-i-escape_string).