### PR TITLE
Handle `class << self`

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -529,8 +529,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
 
   #Process a method definition on self.
   def process_defs exp
-    env.scope do
-      set_env_defaults
+    meth_env do
       exp.body = process_all! exp.body
     end
     exp

--- a/lib/brakeman/processors/library_processor.rb
+++ b/lib/brakeman/processors/library_processor.rb
@@ -30,6 +30,12 @@ class Brakeman::LibraryProcessor < Brakeman::BaseProcessor
   end
 
   def process_defn exp
+    # TODO: Why is this different from ModuleHelper?
+
+    if @inside_sclass
+      exp = make_defs(exp)
+    end
+
     if exp.method_name == :initialize
       @alias_processor.process_safely exp.body_list
       @initializer_env = @alias_processor.only_ivars

--- a/test/apps/rails7/app/controllers/users_controller.rb
+++ b/test/apps/rails7/app/controllers/users_controller.rb
@@ -36,4 +36,9 @@ class UsersController < ApplicationController
   def redirect_back_or_to_with_fallback_disallow_host
     redirect_back_or_to params[:x], allow_other_host: false # no warning
   end
+
+  class << self
+    def just_here_for_test_coverage_thanks
+    end
+  end
 end

--- a/test/tests/tracker.rb
+++ b/test/tests/tracker.rb
@@ -68,6 +68,11 @@ class TrackerTests < Minitest::Test
     end
   end
 
+  def test_method_inside_sclass
+    parse_class
+    assert @tracker.find_method(:class_method, :Example, :class)
+  end
+
   def test_invalid_method_info_src
     assert_raises do
       Brakeman::MethodInfo.new(:blah, s(:not_a_defn), nil, nil)
@@ -108,6 +113,11 @@ class TrackerTests < Minitest::Test
       end
 
       def self.far
+      end
+
+      class << self
+        def class_method
+        end
       end
     end
     RUBY


### PR DESCRIPTION
If methods are defined inside a `class << self` block, add them as class methods.

Previously ignored warnings that were inside one of these methods will need to be re-ignored, as the fingerprint will change.