### PR TITLE
Fix class method lookup in parent classes

### DIFF
--- a/lib/brakeman/tracker.rb
+++ b/lib/brakeman/tracker.rb
@@ -245,7 +245,7 @@ class Brakeman::Tracker
       end
 
       # Not in any included modules, check the parent
-      @method_cache[cache_key] = find_method(method_name, klass.parent)
+      @method_cache[cache_key] = find_method(method_name, klass.parent, method_type)
     end
   end
 

--- a/test/tests/tracker.rb
+++ b/test/tests/tracker.rb
@@ -73,6 +73,11 @@ class TrackerTests < Minitest::Test
     assert @tracker.find_method(:class_method, :Example, :class)
   end
 
+  def test_class_method_in_parent
+    parse_class
+    assert @tracker.find_method(:parent_class_method, :Example, :class)
+  end
+
   def test_invalid_method_info_src
     assert_raises do
       Brakeman::MethodInfo.new(:blah, s(:not_a_defn), nil, nil)
@@ -103,6 +108,9 @@ class TrackerTests < Minitest::Test
 
     class Parent
       def zoop
+      end
+
+      def self.parent_class_method
       end
     end
 


### PR DESCRIPTION
`method_type` parameter was not being propagating when searching parent classes.