### PR TITLE
Check Unscoped AR queries with find_by/find_by!

### DIFF
--- a/lib/brakeman/checks/check_unscoped_find.rb
+++ b/lib/brakeman/checks/check_unscoped_find.rb
@@ -24,12 +24,9 @@ class Brakeman::CheckUnscopedFind < Brakeman::BaseCheck
       process_result call
     end
 
-    tracker.find_call(:method => :find_by, :targets => associated_model_names).each do |result|
+    tracker.find_call(:method => [:find_by, :find_by!], :targets => associated_model_names).each do |result|
       arg = result[:call].first_arg
-
-      if hash? arg and hash_access(arg, :id)
-        process_result result
-      end
+      process_result(result) if hash?(arg)
     end
   end
 

--- a/test/apps/rails4/app/controllers/users_controller.rb
+++ b/test/apps/rails4/app/controllers/users_controller.rb
@@ -136,5 +136,6 @@ class UsersController < ApplicationController
     Email.find_by id: params[:email][:id]
     Email.find_by! id: params[:email][:id]
     Email.find_by public_id: params[:email][:public_id]
+    Email.find_by! public_id: params[:email][:public_id]
   end
 end

--- a/test/apps/rails4/app/controllers/users_controller.rb
+++ b/test/apps/rails4/app/controllers/users_controller.rb
@@ -134,5 +134,7 @@ class UsersController < ApplicationController
 
   def email_find_by
     Email.find_by id: params[:email][:id]
+    Email.find_by! id: params[:email][:id]
+    Email.find_by public_id: params[:email][:public_id]
   end
 end

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Minitest::Test
       :controller => 0,
       :model => 3,
       :template => 8,
-      :generic => 89
+      :generic => 91
     }
   end
 
@@ -1592,7 +1592,7 @@ class Rails4Tests < Minitest::Test
       :user_input => s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :id))
   end
 
-  def test_unscoped_find_by
+  def test_unscoped_find_by_with_id
     assert_warning check_name: "UnscopedFind",
       type: :warning,
       warning_code: 82,
@@ -1604,6 +1604,34 @@ class Rails4Tests < Minitest::Test
       relative_path: "app/controllers/users_controller.rb",
       code: s(:call, s(:const, :Email), :find_by, s(:hash, s(:lit, :id), s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :id)))),
       user_input: s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :id))
+  end
+
+  def test_unscoped_find_by_with_id!
+    assert_warning check_name: "UnscopedFind",
+      type: :warning,
+      warning_code: 82,
+      fingerprint: "da4c77ce860d5567bfaf5e915b734e54712a276dfbee36694757754a49ed4e0c",
+      warning_type: "Unscoped Find",
+      line: 137,
+      message: /^Unscoped\ call\ to\ `Email\#find_by!`/,
+      confidence: 2,
+      relative_path: "app/controllers/users_controller.rb",
+      code: s(:call, s(:const, :Email), :find_by!, s(:hash, s(:lit, :id), s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :id)))),
+      user_input: s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :id))
+  end
+
+  def test_unscoped_find_by_with_other_attributes_not_id
+    assert_warning check_name: "UnscopedFind",
+      type: :warning,
+      warning_code: 82,
+      fingerprint: "575ee0a7f8bcb874b01cbfe99191dd6fd3404df8951159fa00d037ac55d3f55d",
+      warning_type: "Unscoped Find",
+      line: 138,
+      message: /^Unscoped\ call\ to\ `Email\#find_by`/,
+      confidence: 2,
+      relative_path: "app/controllers/users_controller.rb",
+      code: s(:call, s(:const, :Email), :find_by, s(:hash, s(:lit, :public_id), s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :public_id)))),
+      user_input: s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :public_id))
   end
 
   def test_before_filter_block

--- a/test/tests/rails4.rb
+++ b/test/tests/rails4.rb
@@ -15,7 +15,7 @@ class Rails4Tests < Minitest::Test
       :controller => 0,
       :model => 3,
       :template => 8,
-      :generic => 91
+      :generic => 92
     }
   end
 
@@ -1606,7 +1606,7 @@ class Rails4Tests < Minitest::Test
       user_input: s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :id))
   end
 
-  def test_unscoped_find_by_with_id!
+  def test_unscoped_find_by_bang_with_id
     assert_warning check_name: "UnscopedFind",
       type: :warning,
       warning_code: 82,
@@ -1631,6 +1631,20 @@ class Rails4Tests < Minitest::Test
       confidence: 2,
       relative_path: "app/controllers/users_controller.rb",
       code: s(:call, s(:const, :Email), :find_by, s(:hash, s(:lit, :public_id), s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :public_id)))),
+      user_input: s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :public_id))
+  end
+
+  def test_unscoped_find_by_bang_with_other_attributes_not_id
+    assert_warning check_name: "UnscopedFind",
+      type: :warning,
+      warning_code: 82,
+      fingerprint: "701d45000d5f2580ead29590dec523e2596ce4c8d8c8f95bc91c8c85c69b1177",
+      warning_type: "Unscoped Find",
+      line: 139,
+      message: /^Unscoped\ call\ to\ `Email\#find_by!`/,
+      confidence: 2,
+      relative_path: "app/controllers/users_controller.rb",
+      code: s(:call, s(:const, :Email), :find_by!, s(:hash, s(:lit, :public_id), s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :public_id)))),
       user_input: s(:call, s(:call, s(:params), :[], s(:lit, :email)), :[], s(:lit, :public_id))
   end
 


### PR DESCRIPTION
Fixes 2 issues described in #1786

> Brakeman has been updated to include find_by but it does not include find_by!.
Brakeman only checks for find_by on id and doesn't look for any other attributes. In our project the attribute we use public_id instead of id as the publicly facing ID of our models. This means we don't get any warnings for unscoped find for most of our models.