### PR TITLE
Add check for unrestricted search using Ransack

### DIFF
--- a/lib/brakeman/checks/check_ransack.rb
+++ b/lib/brakeman/checks/check_ransack.rb
@@ -1,0 +1,42 @@
+require 'brakeman/checks/base_check'
+
+class Brakeman::CheckRansack < Brakeman::BaseCheck
+  Brakeman::Checks.add self
+
+  @description = "Checks for dangerous use of the Ransack library"
+
+  def run_check
+    return unless version_between? "0.0.0", "3.99", tracker.config.gem_version(:ransack)
+    check_ransack_calls
+  end
+
+  def check_ransack_calls
+    tracker.find_call(method: :ransack, nested: true).each do |result|
+      call = result[:call]
+      arg = call.first_arg
+
+      # If an allow list is defined anywhere in the
+      # class or super classes, consider it safe
+      class_name = result[:chain].first
+      next if ransackable_allow_list?(class_name)
+
+      if input = has_immediate_user_input?(arg)
+        confidence = :high
+        message = msg("Unrestricted search using ", msg_code('ransack'), " library called with ", msg_input(input), '. Limit using ', msg_code('ransackable_attributes'), ' and ', msg_code('ransackable_associations'))
+
+        warn :result => result,
+          :warning_type => "Missing Authorization",
+          :warning_code => :ransack_search,
+          :message => message,
+          :user_input => input,
+          :confidence => confidence,
+          :cwe_id => [502]
+      end
+    end
+  end
+
+  def ransackable_allow_list? class_name
+    tracker.find_method(:ransackable_attributes, class_name, :class) and
+      tracker.find_method(:ransackable_associations, class_name, :class)
+  end
+end

--- a/lib/brakeman/checks/check_ransack.rb
+++ b/lib/brakeman/checks/check_ransack.rb
@@ -18,10 +18,13 @@ class Brakeman::CheckRansack < Brakeman::BaseCheck
       # If an allow list is defined anywhere in the
       # class or super classes, consider it safe
       class_name = result[:chain].first
+
       next if ransackable_allow_list?(class_name)
 
       if input = has_immediate_user_input?(arg)
-        confidence = if result[:location][:file].relative.include? 'admin'
+        confidence = if tracker.find_class(class_name).nil?
+                       confidence = :low
+                     elsif result[:location][:file].relative.include? 'admin'
                        confidence = :medium
                      else
                        confidence = :high

--- a/lib/brakeman/checks/check_ransack.rb
+++ b/lib/brakeman/checks/check_ransack.rb
@@ -21,16 +21,22 @@ class Brakeman::CheckRansack < Brakeman::BaseCheck
       next if ransackable_allow_list?(class_name)
 
       if input = has_immediate_user_input?(arg)
-        confidence = :high
-        message = msg("Unrestricted search using ", msg_code('ransack'), " library called with ", msg_input(input), '. Limit using ', msg_code('ransackable_attributes'), ' and ', msg_code('ransackable_associations'))
+        confidence = if result[:location][:file].relative.include? 'admin'
+                       confidence = :medium
+                     else
+                       confidence = :high
+                     end
 
-        warn :result => result,
-          :warning_type => "Missing Authorization",
-          :warning_code => :ransack_search,
-          :message => message,
-          :user_input => input,
-          :confidence => confidence,
-          :cwe_id => [502]
+        message = msg('Unrestricted search using ', msg_code('ransack'), ' library called with ', msg_input(input), '. Limit search by defining ', msg_code('ransackable_attributes'), ' and ', msg_code('ransackable_associations'), ' methods in class or upgrade Ransack to version 4.0.0 or newer')
+
+        warn result: result,
+          warning_type: 'Missing Authorization',
+          warning_code: :ransack_search,
+          message: message,
+          user_input: input,
+          confidence: confidence,
+          cwe_id: [862],
+          link: 'https://positive.security/blog/ransack-data-exfiltration'
       end
     end
   end

--- a/lib/brakeman/tracker/collection.rb
+++ b/lib/brakeman/tracker/collection.rb
@@ -5,7 +5,7 @@ module Brakeman
   class Collection
     include Brakeman::Util
 
-    attr_reader :collection, :files, :includes, :name, :options, :parent, :src, :tracker
+    attr_reader :collection, :files, :includes, :name, :options, :parent, :src, :tracker, :class_methods
 
     def initialize name, parent, file_name, src, tracker
       @name = name

--- a/lib/brakeman/tracker/collection.rb
+++ b/lib/brakeman/tracker/collection.rb
@@ -5,7 +5,7 @@ module Brakeman
   class Collection
     include Brakeman::Util
 
-    attr_reader :collection, :files, :includes, :name, :options, :parent, :src, :tracker, :class_methods
+    attr_reader :collection, :files, :includes, :name, :options, :parent, :src, :tracker
 
     def initialize name, parent, file_name, src, tracker
       @name = name

--- a/lib/brakeman/warning_codes.rb
+++ b/lib/brakeman/warning_codes.rb
@@ -130,6 +130,7 @@ module Brakeman::WarningCodes
     :insecure_rsa_padding_mode => 126,
     :missing_rsa_padding_mode => 127,
     :small_rsa_key_size => 128,
+    :ransack_search => 129,
 
     :custom_check => 9090,
   }

--- a/test/apps/rails7/Gemfile
+++ b/test/apps/rails7/Gemfile
@@ -42,6 +42,8 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false
 
+gem 'ransack', '~>3.0.0'
+
 # Use Sass to process CSS
 # gem "sassc-rails", "~> 2.1"
 

--- a/test/apps/rails7/Gemfile.lock
+++ b/test/apps/rails7/Gemfile.lock
@@ -164,6 +164,10 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    ransack (3.0.1)
+      activerecord (>= 6.0.4)
+      activesupport (>= 6.0.4)
+      i18n
     regexp_parser (2.2.0)
     reline (0.2.7)
       io-console (~> 0.5)
@@ -217,6 +221,7 @@ DEPENDENCIES
   jbuilder (~> 2.11)
   puma (~> 5.0)
   rails (~> 7.0.0)
+  ransack (~> 3.0.0)
   selenium-webdriver (>= 4.0.0)
   sprockets-rails (>= 3.4.1)
   sqlite3 (~> 1.4)

--- a/test/apps/rails7/app/controllers/admin_controller.rb
+++ b/test/apps/rails7/app/controllers/admin_controller.rb
@@ -1,0 +1,6 @@
+class AdminController < ApplicationController
+  def search_users
+    # Medium warning because it's probably an admin interface
+    User.ransack(params[:q])
+  end
+end

--- a/test/apps/rails7/app/controllers/users_controller.rb
+++ b/test/apps/rails7/app/controllers/users_controller.rb
@@ -37,6 +37,10 @@ class UsersController < ApplicationController
     redirect_back_or_to params[:x], allow_other_host: false # no warning
   end
 
+  def search
+    User.ransack(params[:q])
+  end
+
   class << self
     def just_here_for_test_coverage_thanks
     end

--- a/test/apps/rails7/app/controllers/users_controller.rb
+++ b/test/apps/rails7/app/controllers/users_controller.rb
@@ -44,6 +44,9 @@ class UsersController < ApplicationController
   def search_books
     # Should not warn - search limited appropriately
     Book.ransack(params[:q])
+
+    # Low confidence because no idea what `some_book` is
+    some_book.things.ransack(params[:q])
   end
 
   class << self

--- a/test/apps/rails7/app/controllers/users_controller.rb
+++ b/test/apps/rails7/app/controllers/users_controller.rb
@@ -41,6 +41,11 @@ class UsersController < ApplicationController
     User.ransack(params[:q])
   end
 
+  def search_books
+    # Should not warn - search limited appropriately
+    Book.ransack(params[:q])
+  end
+
   class << self
     def just_here_for_test_coverage_thanks
     end

--- a/test/apps/rails7/app/models/book.rb
+++ b/test/apps/rails7/app/models/book.rb
@@ -1,4 +1,4 @@
-class Book < Thing 
+class Book < Thing
   def self.ransackable_attributes(auth_object = nil)
     [:author, :title]
   end

--- a/test/apps/rails7/app/models/book.rb
+++ b/test/apps/rails7/app/models/book.rb
@@ -1,0 +1,5 @@
+class Book < Thing 
+  def self.ransackable_attributes(auth_object = nil)
+    [:author, :title]
+  end
+end

--- a/test/apps/rails7/app/models/thing.rb
+++ b/test/apps/rails7/app/models/thing.rb
@@ -1,0 +1,7 @@
+class Thing < ApplicationRecord
+  class << self
+    def ransackable_associations(auth_object = nil)
+      []
+    end
+  end
+end

--- a/test/tests/rails7.rb
+++ b/test/tests/rails7.rb
@@ -16,7 +16,7 @@ class Rails7Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 0,
-      :warning => 23
+      :warning => 25
     }
   end
 
@@ -424,17 +424,28 @@ class Rails7Tests < Minitest::Test
       user_input: s(:call, s(:params), :[], s(:lit, :q))
   end
 
+  def test_missing_authorization_ransack_admin
+    assert_warning check_name: "Ransack",
+      type: :warning,
+      warning_code: 129,
+      fingerprint: "cb03f7424bc739b26e3789e2d9bb6893b4f2f517dbe10d4d3f3f19b4cf845459",
+      warning_type: "Missing Authorization",
+      line: 4,
+      message: /^Unrestricted\ search\ using\ `ransack`\ libr/,
+      confidence: 1,
+      relative_path: "app/controllers/admin_controller.rb",
+      code: s(:call, s(:const, :User), :ransack, s(:call, s(:params), :[], s(:lit, :q))),
+      user_input: s(:call, s(:params), :[], s(:lit, :q))
+  end
+
   def test_missing_authorization_ransack_2
     assert_no_warning check_name: "Ransack",
       type: :warning,
       warning_code: 129,
-      fingerprint: "9786bef019c90a6364baffb97b857fbf9e559bab42bf1c06fc19e01c9c36f438",
       warning_type: "Missing Authorization",
       line: 46,
       message: /^Unrestricted\ search\ using\ `ransack`\ libr/,
       confidence: 0,
-      relative_path: "app/controllers/users_controller.rb",
-      code: s(:call, s(:const, :Book), :ransack, s(:call, s(:params), :[], s(:lit, :q))),
-      user_input: s(:call, s(:params), :[], s(:lit, :q))
+      relative_path: "app/controllers/users_controller.rb"
   end
 end

--- a/test/tests/rails7.rb
+++ b/test/tests/rails7.rb
@@ -16,7 +16,7 @@ class Rails7Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 0,
-      :warning => 25
+      :warning => 26
     }
   end
 
@@ -447,5 +447,19 @@ class Rails7Tests < Minitest::Test
       message: /^Unrestricted\ search\ using\ `ransack`\ libr/,
       confidence: 0,
       relative_path: "app/controllers/users_controller.rb"
+  end
+
+  def test_missing_authorization_ransack_low
+    assert_warning check_name: "Ransack",
+      type: :warning,
+      warning_code: 129,
+      fingerprint: "50e236d8fbc9db0f67e0011941b92b08d0ece176ce4b8caea89d372f007a4873",
+      warning_type: "Missing Authorization",
+      line: 49,
+      message: /^Unrestricted\ search\ using\ `ransack`\ libr/,
+      confidence: 2,
+      relative_path: "app/controllers/users_controller.rb",
+      code: s(:call, s(:call, s(:call, nil, :some_book), :things), :ransack, s(:call, s(:params), :[], s(:lit, :q))),
+      user_input: s(:call, s(:params), :[], s(:lit, :q))
   end
 end

--- a/test/tests/rails7.rb
+++ b/test/tests/rails7.rb
@@ -26,7 +26,7 @@ class Rails7Tests < Minitest::Test
       warning_code: 123,
       fingerprint: "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
       warning_type: "Unmaintained Dependency",
-      line: 230,
+      line: 235,
       message: /^Support\ for\ Ruby\ 2\.7\.0\ ends\ on\ 2023\-03\-3/,
       confidence: 2,
       relative_path: "Gemfile.lock",
@@ -408,5 +408,33 @@ class Rails7Tests < Minitest::Test
       relative_path: "app/controllers/users_controller.rb",
       code: s(:call, nil, :redirect_back_or_to, s(:call, s(:params), :[], s(:lit, :x))),
       user_input: s(:call, s(:params), :[], s(:lit, :x))
+  end
+
+  def test_missing_authorization_ransack
+    assert_warning check_name: "Ransack",
+      type: :warning,
+      warning_code: 129,
+      fingerprint: "ae28bfeb8423952ffae97149292175b2d10c36c4904ee198ab7b2eda4e05c3e0",
+      warning_type: "Missing Authorization",
+      line: 41,
+      message: /^Unrestricted\ search\ using\ `ransack`\ libr/,
+      confidence: 0,
+      relative_path: "app/controllers/users_controller.rb",
+      code: s(:call, s(:const, :User), :ransack, s(:call, s(:params), :[], s(:lit, :q))),
+      user_input: s(:call, s(:params), :[], s(:lit, :q))
+  end
+
+  def test_missing_authorization_ransack_2
+    assert_no_warning check_name: "Ransack",
+      type: :warning,
+      warning_code: 129,
+      fingerprint: "9786bef019c90a6364baffb97b857fbf9e559bab42bf1c06fc19e01c9c36f438",
+      warning_type: "Missing Authorization",
+      line: 46,
+      message: /^Unrestricted\ search\ using\ `ransack`\ libr/,
+      confidence: 0,
+      relative_path: "app/controllers/users_controller.rb",
+      code: s(:call, s(:const, :Book), :ransack, s(:call, s(:params), :[], s(:lit, :q))),
+      user_input: s(:call, s(:params), :[], s(:lit, :q))
   end
 end


### PR DESCRIPTION
As reported [here](https://positive.security/blog/ransack-data-exfiltration), the [Ransack](https://github.com/activerecord-hackery/ransack) library allows unrestricted searching of all attributes of a model and attributes of associated models.

Typical use of Ransack looks like:

```ruby
Thing.ransack(params[:q])
```

The query is often something like

```ruby
?q[name_cont]=some_name
```

Which is something like

```ruby
Thing.ransack(name_cont: "some_name")
```

And will search the `name` column on `Thing` for rows `cont`aining `"some_name"`. There are actually [several search predicates](https://activerecord-hackery.github.io/ransack/getting-started/using-predicates/) like `start`, `end`, `eq`, etc.

Prior to Ransack 4.0.0, by default all columns _and_ columns on associated models were searchable. Searches can be used to uncover sensitive values in the database, such as secret tokens or keys.

To limit which columns and associations are searchable, define class methods `ransackable_attributes` and `ransackable_associations` methods on the models [as described here](https://activerecord-hackery.github.io/ransack/going-further/other-notes/#authorization-allowlistingdenylisting). Even better, either upgrade Ransack to 4.0.0+ or define those methods on `ApplicationRecord` (or whichever class is the root of the model hierarchy) to force allow-listing:

```ruby
class ApplicationRecord < ActiveRecord::Base
  class << self
    def ransackable_attributes(auth_object = nil)
      []
    end

    def ransackable_associations(auth_object = nil)
      []
    end
  end
end
```

The Brakeman warning will be:

* **High** if no allow-listing methods are found in the class hierarchy of the model on which `ransack` is called
* **Medium** if the use happens to be in a file with `admin` in the path
* **Low** if the call to `ransack` is not on something Brakeman can figure out is a class