### PR TITLE
Add option to show duration of steps

### DIFF
--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -244,6 +244,10 @@ module Brakeman::Options
           options[:debug] = true
         end
 
+        opts.on "--timing", "Measure time for scan steps" do
+          options[:show_timing] = true
+        end
+
         opts.on "-f",
           "--format TYPE",
           [:pdf, :text, :html, :csv, :tabs, :json, :markdown, :codeclimate, :cc, :plain, :table, :junit, :sarif, :sonar, :github],

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -267,6 +267,20 @@ class ConfigTests < Minitest::Test
     end
   end
 
+  def test_timing_output
+    options = {
+      :app_path => "#{TEST_PATH}/apps/rails4",
+      :show_timing => true,
+      :quiet => false,
+      :run_checks => []
+    }
+
+    assert_output nil, /Duration/ do
+      Brakeman.run options
+    end
+
+  end
+
   def output_format_tester options, expected_options
     output_formats = Brakeman.get_output_formats(options)
 

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -30,6 +30,7 @@ class BrakemanOptionsTest < Minitest::Test
     :ensure_latest          => "--ensure-latest",
     :allow_check_paths_in_config => "--allow-check-paths-in-config",
     :pager                  => "--pager",
+    :show_timing                 => "--timing",
   }
 
   ALT_OPTION_INPUTS = {


### PR DESCRIPTION
To help with debugging, etc. use `--timing` to output duration for different steps, e.g.:

```
Processing gems...                      
(Processing gems) Duration: 0.020700368 seconds
Processing configuration...             
[Notice] Escaping HTML by default
(Processing configuration) Duration: 0.097705767 seconds
Parsing files...                        
(Parsing files) Duration: 22.476206476 seconds
Detecting file types...                 
(Detecting file types) Duration: 2.04680957 seconds
```

Also makes the code a little nicer, in my opinion.