### PR TITLE
Avoid duplicate warnings about Ransack

### DIFF
--- a/lib/brakeman/checks/check_ransack.rb
+++ b/lib/brakeman/checks/check_ransack.rb
@@ -12,6 +12,8 @@ class Brakeman::CheckRansack < Brakeman::BaseCheck
 
   def check_ransack_calls
     tracker.find_call(method: :ransack, nested: true).each do |result|
+      next unless original? result
+
       call = result[:call]
       arg = call.first_arg
 


### PR DESCRIPTION
One day I'll just make this the default, since I always forget it.