### PR TITLE
Add multiple file for ignore options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test/coverage/
 .bundle
 bundle
 *.gem
+test-report.json

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -185,11 +185,11 @@ By default, brakeman opens output in `less` pager. To have brakeman output direc
 
 Brakeman will ignore warnings if configured to do so. By default, it looks for a configuration file in `config/brakeman.ignore`.
 
-To specify a file to use:
+To specify a file or a list of files to use:
 
-    brakeman -i path/to/config.ignore
+    brakeman -i path/to/config.ignore,path/to/config2.ignore,etc
 
-To create and manage this file, use:
+To create and manage this files, use:
 
     brakeman -I
 

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -546,10 +546,10 @@ module Brakeman
 
     app_tree = Brakeman::AppTree.from_options(options)
 
-    if options[:ignore_file]
-      file = options[:ignore_file]
+    if options[:ignore_files]
+      files = options[:ignore_files]
     elsif app_tree.exists? "config/brakeman.ignore"
-      file = app_tree.expand_path("config/brakeman.ignore")
+      files = [app_tree.expand_path("config/brakeman.ignore")]
     elsif not options[:interactive_ignore]
       return
     end
@@ -558,11 +558,14 @@ module Brakeman
 
     if options[:interactive_ignore]
       require 'brakeman/report/ignore/interactive'
-      config = InteractiveIgnorer.new(file, tracker.warnings).start
+      config = InteractiveIgnorer.new(files.first, tracker.warnings).start
     else
-      notify "[Notice] Using '#{file}' to filter warnings"
-      config = IgnoreConfig.new(file, tracker.warnings)
+      notify "[Notice] Using '#{files.join(', ')}' to filter warnings"
+      config = IgnoreConfig.new(files.first, tracker.warnings)
       config.read_from_file
+      files.to_a.slice(1..).each do |f|
+        config.read_from_file(f)
+      end
       config.filter_ignored
     end
 

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -261,8 +261,9 @@ module Brakeman::Options
           options[:html_style] = File.expand_path file
         end
 
-        opts.on "-i IGNOREFILE", "--ignore-config IGNOREFILE", "Use configuration to ignore warnings" do |file|
-          options[:ignore_file] = file
+        opts.on "-i IGNOREFILE1,IGNOREFILE2,etc", "--ignore-config IGNOREFILE1,IGNOREFILE2,etc", Array, "Use configurations to ignore warnings" do |files|
+          options[:ignore_files] ||= Set.new
+          options[:ignore_files].merge files
         end
 
         opts.on "-I", "--interactive-ignore", "Interactively ignore warnings" do

--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -102,7 +102,7 @@ module Brakeman
     def read_from_file file = @file
       if File.exist? file
         begin
-          @already_ignored = JSON.parse(File.read(file), :symbolize_names => true)[:ignored_warnings]
+          @already_ignored += JSON.parse(File.read(file), :symbolize_names => true)[:ignored_warnings]
         rescue => e
           raise e, "\nError[#{e.class}] while reading brakeman ignore file: #{file}\n"
         end

--- a/test/tests/commandline.rb
+++ b/test/tests/commandline.rb
@@ -167,6 +167,25 @@ class CommandlineTests < Minitest::Test
     ignore_file_with_notes.unlink
   end
 
+  def test_ensure_ignore_whit_multiple_files
+    ignore_file_1 = Tempfile.new('brakeman1.ignore')
+    ignore_file_1.write IGNORE_WITH_MISSING_NOTES_JSON
+    ignore_file_1.close
+
+    ignore_file_2 = Tempfile.new('brakeman2.ignore')
+    ignore_file_2.write ANOTHER_IGNORE_JSON
+    ignore_file_2.close
+
+    ignore_files_paths = "#{ignore_file_1.path.to_s},#{ignore_file_2.path.to_s}"
+
+    assert_exit do
+      scan_app '--no-exit-on-warn', '-i', ignore_files_paths
+    end
+
+    ignore_file_1.unlink
+    ignore_file_2.unlink
+  end
+
   IGNORE_WITH_MISSING_NOTES_JSON = <<~JSON.freeze
     {
       "ignored_warnings": [
@@ -243,5 +262,33 @@ class CommandlineTests < Minitest::Test
       "updated": "2019-04-02 12:15:05 -0700",
       "brakeman_version": "4.5.0"
     }
+  JSON
+
+  ANOTHER_IGNORE_JSON = <<~JSON.freeze
+  {
+    "ignored_warnings": [
+      {
+        "warning_type": "Remote Code Execution",
+        "warning_code": 110,
+        "fingerprint": "9ae68e59cfee3e5256c0540dadfeb74e6b72c91997fdb60411063a6e8518144a",
+        "check_name": "CookieSerialization",
+        "message": "Use of unsafe cookie serialization strategy `:hybrid` might lead to remote code execution",
+        "file": "/home/baldarn/Projects/brakeman/test/apps/rails5.2/config/initializers/cookies_serializer.rb",
+        "line": 5,
+        "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+        "code": "Rails.application.config.action_dispatch.cookies_serializer = :hybrid",
+        "render_path": null,
+        "location": null,
+        "user_input": null,
+        "confidence": "Medium",
+        "cwe_id": [
+            565,
+            502
+        ]
+      }
+    ],
+    "updated": "2019-04-02 12:15:05 -0700",
+    "brakeman_version": "4.5.0"
+  }
   JSON
 end

--- a/test/tests/ignore.rb
+++ b/test/tests/ignore.rb
@@ -38,6 +38,20 @@ class IgnoreConfigTests < Minitest::Test
     assert_equal 3, config.ignored_warnings.length
   end
 
+  def test_ignored_warnings_with_multiple_files
+    another_config_json = JSON.parse(ANOTHER_IGNORE_JSON, symbolize_names: true)
+
+    another_config_file = Tempfile.new("brakeman-another.ignore")
+    another_config_file.write ANOTHER_IGNORE_JSON
+    another_config_file.close
+
+    config.read_from_file(another_config_file.path)
+
+    config.filter_ignored
+
+    assert_equal 4, config.ignored_warnings.length
+  end
+
   def test_shown_warnings
     expected = report.warnings.length - config.ignored_warnings.length
 
@@ -234,7 +248,7 @@ class IgnoreConfigTests < Minitest::Test
   end
 end
 
-IGNORE_JSON = <<JSON
+IGNORE_JSON = <<~JSON.freeze
 {
   "ignored_warnings": [
     {
@@ -296,6 +310,34 @@ IGNORE_JSON = <<JSON
       "user_input": "params[:json]",
       "confidence": "High",
       "note": "Here's a note!"
+    }
+  ],
+  "updated": "2019-04-02 12:15:05 -0700",
+  "brakeman_version": "4.5.0"
+}
+JSON
+
+ANOTHER_IGNORE_JSON = <<~JSON.freeze
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 110,
+      "fingerprint": "9ae68e59cfee3e5256c0540dadfeb74e6b72c91997fdb60411063a6e8518144a",
+      "check_name": "CookieSerialization",
+      "message": "Use of unsafe cookie serialization strategy `:hybrid` might lead to remote code execution",
+      "file": "/home/baldarn/Projects/brakeman/test/apps/rails5.2/config/initializers/cookies_serializer.rb",
+      "line": 5,
+      "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+      "code": "Rails.application.config.action_dispatch.cookies_serializer = :hybrid",
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+          565,
+          502
+      ]
     }
   ],
   "updated": "2019-04-02 12:15:05 -0700",

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -242,12 +242,18 @@ class BrakemanOptionsTest < Minitest::Test
     assert_equal local_path, options[:html_style]
   end
 
-  def test_ignore_file_option
+  def test_ignore_files_option
     options = setup_options_from_input("-i", "dont_warn_for_these.rb")
-    assert_equal "dont_warn_for_these.rb", options[:ignore_file]
+    assert_equal Set["dont_warn_for_these.rb"], options[:ignore_files]
 
     options = setup_options_from_input("--ignore-config", "dont_warn_for_these.rb")
-    assert_equal "dont_warn_for_these.rb", options[:ignore_file]
+    assert_equal Set["dont_warn_for_these.rb"], options[:ignore_files]
+
+    options = setup_options_from_input("-i", "dont_warn_for_these.rb,dont_warn_for_these_2.rb")
+    assert_equal Set["dont_warn_for_these.rb", "dont_warn_for_these_2.rb"], options[:ignore_files]
+
+    options = setup_options_from_input("--ignore-config", "dont_warn_for_these.rb,dont_warn_for_these_2.rb")
+    assert_equal Set["dont_warn_for_these.rb", "dont_warn_for_these_2.rb"], options[:ignore_files]
   end
 
   def test_combine_warnings_option


### PR DESCRIPTION
Hi!

I needed the `-i` parameter to accept multiple files, because we are planning to have multiple list of ignore files based on priority to solve.

This pr doesn't change the interface, but instead add the possiblity to pass multiple paths of ignore config to the `-i` parameter

What do you think? Can this be useful?