### PR TITLE
fix: avoid detecting phlex components as dynamic render paths

### DIFF
--- a/lib/brakeman/checks/check_render.rb
+++ b/lib/brakeman/checks/check_render.rb
@@ -108,6 +108,6 @@ class Brakeman::CheckRender < Brakeman::BaseCheck
   def known_renderable_class? class_name
     klass = tracker.find_class(class_name)
     return false if klass.nil?
-    klass.ancestor? :"ViewComponent::Base"
+    klass.ancestor?(:"ViewComponent::Base") || klass.ancestor?(:"Phlex::HTML")
   end
 end

--- a/test/apps/rails6/app/components/text_phlex_component.rb
+++ b/test/apps/rails6/app/components/text_phlex_component.rb
@@ -1,0 +1,6 @@
+class TestPhlexComponent < Phlex::HTML
+    def initialize(prop)
+      @prop = prop
+    end
+  end
+  

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -80,4 +80,8 @@ class GroupsController < ApplicationController
       redirect_to root_path, notice: 'Invalid status'
     end
   end
+
+  def render_phlex_component
+    render(TestPhlexComponent.new(params.require('name')))
+  end
 end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -634,7 +634,6 @@ class Rails6Tests < Minitest::Test
   def test_dynamic_render_path_phlex_component
     assert_no_warning :type => :warning,
       :warning_code => 15,
-      :fingerprint => "7e8ad12b494ba3e8617fb6a8d27aa10a4f944498c6236d07c31e6063b3c83fc5",
       :warning_type => "Dynamic Render Path",
       :line => 85,
       :message => /^Render\ path\ contains\ parameter\ value/,

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -631,6 +631,19 @@ class Rails6Tests < Minitest::Test
       :user_input => s(:call, s(:params), :require, s(:str, "name"))
   end
 
+  def test_dynamic_render_path_phlex_component
+    assert_no_warning :type => :warning,
+      :warning_code => 15,
+      :fingerprint => "7e8ad12b494ba3e8617fb6a8d27aa10a4f944498c6236d07c31e6063b3c83fc5",
+      :warning_type => "Dynamic Render Path",
+      :line => 85,
+      :message => /^Render\ path\ contains\ parameter\ value/,
+      :confidence => 2,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:render, :action, s(:call, s(:const, :TestPhlexComponent), :new, s(:call, s(:params), :require, s(:str, "name"))), s(:hash)),
+      :user_input => s(:call, s(:params), :require, s(:str, "name"))
+  end
+
   def test_dynamic_render_path_dir_glob_filter
     assert_no_warning :type => :warning,
       :warning_code => 15,


### PR DESCRIPTION
### Description 📖 

This pull request adds support for [`phlex`](https://github.com/phlex-ruby/phlex), preventing brakeman from detecting usages of Phlex components as occurrences of Dynamic Render Paths.

### Background 📜 

This problem is similar to what used to happen in the past for `view_components`:
- #1529
- #1578