### PR TITLE
Handle racc as default gem in Ruby 3.3.0

### DIFF
--- a/brakeman.gemspec
+++ b/brakeman.gemspec
@@ -30,8 +30,13 @@ Gem::Specification.new do |s|
 
     s.files += Dir['bundle/ruby/*/gems/**/*'].reject do |path|
       # Skip unnecessary files in dependencies
-      path =~ /^bundle\/ruby\/\d\.\d\.\d\/gems\/[^\/]+\/(Rakefile|benchmark|bin|doc|example|man|site|spec|test)/
+      path =~ /^bundle\/ruby\/\d\.\d\.\d\/gems\/[^\/]+\/(Rakefile|benchmark|bin|doc|example|man|site|spec|test)/ or
+        path.include? '/gems/racc'
     end
+
+    # racc is not only a built-in gem, but also has native code which we cannot
+    # bundle with Brakeman, so leaving it as a regular dependency
+    s.add_dependency "racc"
   else
     Brakeman::GemDependencies.dev_dependencies(s) unless ENV['BM_PACKAGE']
     Brakeman::GemDependencies.base_dependencies(s)

--- a/build.rb
+++ b/build.rb
@@ -13,7 +13,7 @@ File.open "bundle/load.rb", "w" do |f|
   f.puts "path = File.expand_path('../..', __FILE__)"
 
   Dir["bundle/ruby/**/lib"].each do |dir|
-    f.puts %Q[$:.unshift "\#{path}/#{dir}"]
+    f.puts %Q[$:.unshift "\#{path}/#{dir}"] unless dir.include? 'racc'
   end
 end
 

--- a/gem_common.rb
+++ b/gem_common.rb
@@ -13,6 +13,7 @@ module Brakeman
       spec.add_dependency "sexp_processor", "~> 4.7"
       spec.add_dependency "ruby2ruby", "~>2.4.0"
       spec.add_dependency "safe_yaml", ">= 1.0"
+      spec.add_dependency "racc"
     end
 
     def self.extended_dependencies spec


### PR DESCRIPTION
As noted [here](https://github.com/seattlerb/ruby_parser/pull/341)

but also Brakeman needs to avoid bundling `racc` as a dependency, since it includes a C extension and bundling the compiled extension is not going to work.