### PR TITLE
fix: avoid detecting 'ViewComponentContrib::Base' as dynamic render paths

### DIFF
--- a/lib/brakeman/checks/check_render.rb
+++ b/lib/brakeman/checks/check_render.rb
@@ -108,6 +108,11 @@ class Brakeman::CheckRender < Brakeman::BaseCheck
   def known_renderable_class? class_name
     klass = tracker.find_class(class_name)
     return false if klass.nil?
-    klass.ancestor?(:"ViewComponent::Base") || klass.ancestor?(:"Phlex::HTML")
+    knowns = [
+      :"ViewComponent::Base",
+      :"ViewComponentContrib::Base",
+      :"Phlex::HTML"
+    ]
+    knowns.any? { |k| klass.ancestor? k }
   end
 end

--- a/test/apps/rails6/app/components/test_view_component_contrib.rb
+++ b/test/apps/rails6/app/components/test_view_component_contrib.rb
@@ -1,0 +1,5 @@
+class TestViewComponentContrib < ViewComponentContrib::Base
+  def initialize(prop)
+    @prop = prop
+  end
+end

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -84,4 +84,8 @@ class GroupsController < ApplicationController
   def render_phlex_component
     render(TestPhlexComponent.new(params.require('name')))
   end
+
+  def render_view_component_contrib
+    render(TestViewComponentContrib.new(params.require('name')))
+  end
 end

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -643,6 +643,18 @@ class Rails6Tests < Minitest::Test
       :user_input => s(:call, s(:params), :require, s(:str, "name"))
   end
 
+  def test_dynamic_render_view_component_contrib
+    assert_no_warning :type => :warning,
+      :warning_code => 15,
+      :warning_type => "Dynamic Render Path",
+      :line => 88,
+      :message => /^Render\ path\ contains\ parameter\ value/,
+      :confidence => 2,
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:render, :action, s(:call, s(:const, :TestViewComponentContrib), :new, s(:call, s(:params), :require, s(:str, "name"))), s(:hash)),
+      :user_input => s(:call, s(:params), :require, s(:str, "name"))
+  end
+
   def test_dynamic_render_path_dir_glob_filter
     assert_no_warning :type => :warning,
       :warning_code => 15,


### PR DESCRIPTION
# Description 📖
This pull request adds support for [view_component-contrib gem](https://github.com/palkan/view_component-contrib).
`view_component-contrib` is a support library for [ViewComponent](https://github.com/github/view_component), which defines ViewComponent using the `class SomeComponent < ViewComponentContrib::Base` instead of `class SomeComponent < ViewComponent::Base`.
(`ViewComponentContrib::Base` is a class that extends `ViewComponent::Base` (see: https://github.com/palkan/view_component-contrib/blob/master/lib/ view_component_contrib/base.rb))

This PR prevents brakeman from detecting a Component using ViewCompontontrib as an occurrence of Dynamic Render Paths.

# Background 📜

This problem is similar to what used to happen in the past for view_components:

https://github.com/presidentbeef/brakeman/issues/1529
https://github.com/presidentbeef/brakeman/pull/1578
https://github.com/presidentbeef/brakeman/pull/1805