### PR TITLE
Add option to exclude "updated" in brakeman.ignore

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -193,6 +193,10 @@ To create and manage this file, use:
 
     brakeman -I
 
+To exclude the "updated" entry in brakeman.ignore, use:
+
+    brakeman --exclude-updated-in-ignore-file
+
 To ignore possible XSS from model attributes:
 
     brakeman --ignore-model-output

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -47,6 +47,7 @@ module Brakeman
   #  * :github_repo - github repo to use for file links (user/repo[/path][@ref])
   #  * :highlight_user_input - highlight user input in reported warnings (default: true)
   #  * :html_style - path to CSS file
+  #  * :exclude_updated_in_ignore_file - exclude the "updated" entry in brakeman.ignore (default: false)
   #  * :ignore_model_output - consider models safe (default: false)
   #  * :index_libs - add libraries to call index (default: true)
   #  * :interprocedural - limited interprocedural processing of method calls (default: false)
@@ -557,7 +558,11 @@ module Brakeman
 
     if options[:interactive_ignore]
       require 'brakeman/report/ignore/interactive'
-      config = InteractiveIgnorer.new(file, tracker.warnings).start
+      config = InteractiveIgnorer.new(
+        file,
+        tracker.warnings,
+        exclude_updated: options[:exclude_updated_in_ignore_file]
+      ).start
     else
       notify "[Notice] Using '#{file}' to filter warnings"
       config = IgnoreConfig.new(file, tracker.warnings)

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -265,6 +265,10 @@ module Brakeman::Options
           options[:ignore_file] = file
         end
 
+        opts.on "--exclude-updated-in-ignore-file", "Exclude the 'updated' timestamp in brakeman.ignore" do
+          options[:exclude_updated_in_ignore_file] = true
+        end
+
         opts.on "-I", "--interactive-ignore", "Interactively ignore warnings" do
           options[:interactive_ignore] = true
         end

--- a/lib/brakeman/report/ignore/config.rb
+++ b/lib/brakeman/report/ignore/config.rb
@@ -6,7 +6,7 @@ module Brakeman
     attr_reader :shown_warnings, :ignored_warnings
     attr_accessor :file
 
-    def initialize file, new_warnings
+    def initialize file, new_warnings, exclude_updated: false
       @file = file
       @new_warnings = new_warnings
       @already_ignored = []
@@ -15,6 +15,7 @@ module Brakeman
       @notes = {}
       @shown_warnings = @ignored_warnings = nil
       @changed = false
+      @exclude_updated = exclude_updated
     end
 
     # Populate ignored_warnings and shown_warnings based on ignore
@@ -133,6 +134,10 @@ module Brakeman
         :updated => Time.now.to_s,
         :brakeman_version => Brakeman::Version
       }
+
+      if @exclude_updated
+        output.delete(:updated)
+      end
 
       File.open file, "w" do |f|
         f.puts JSON.pretty_generate(output)

--- a/lib/brakeman/report/ignore/interactive.rb
+++ b/lib/brakeman/report/ignore/interactive.rb
@@ -2,8 +2,9 @@ Brakeman.load_brakeman_dependency 'highline'
 
 module Brakeman
   class InteractiveIgnorer
-    def initialize file, warnings
-      @ignore_config = Brakeman::IgnoreConfig.new(file, warnings)
+    def initialize file, warnings, exclude_updated: false
+      @exclude_updated = exclude_updated
+      @ignore_config = Brakeman::IgnoreConfig.new(file, warnings, exclude_updated: @exclude_updated)
       @new_warnings = warnings
       @skip_ignored = false
       @skip_rest = false
@@ -185,7 +186,7 @@ q - Quit, do not update ignored warnings
     end
 
     def reset_config
-      @ignore_config = Brakeman::IgnoreConfig.new(@ignore_config.file, @new_warnings)
+      @ignore_config = Brakeman::IgnoreConfig.new(@ignore_config.file, @new_warnings, @exclude_updated)
     end
 
     def process_warnings

--- a/test/tests/ignore.rb
+++ b/test/tests/ignore.rb
@@ -159,6 +159,13 @@ class IgnoreConfigTests < Minitest::Test
     refute_includes new_config.ignored_warnings, first_ignored
   end
 
+  def test_exclude_updated
+    config = Brakeman::IgnoreConfig.new(@config_file.path, report.warnings, exclude_updated: true)
+    config.save_to_file(report.warnings)
+    ignore_hash = JSON.parse(File.read(config.file), symbolize_names: true)
+    assert !ignore_hash.include?(:updated)
+  end
+
   def test_read_from_nonexistent_file
     make_config("/tmp/not_a_real_file_brakeman.ignore")
   end

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -250,6 +250,11 @@ class BrakemanOptionsTest < Minitest::Test
     assert_equal "dont_warn_for_these.rb", options[:ignore_file]
   end
 
+  def test_exclude_updated_in_ignore_file_option
+    options = setup_options_from_input("--exclude-updated-in-ignore-file")
+    assert options[:exclude_updated_in_ignore_file]
+  end
+
   def test_combine_warnings_option
     options = setup_options_from_input("--combine-locations")
     assert options[:combine_locations]


### PR DESCRIPTION
The "updated" entry in brakeman.ignore is prone to merge conflicts, so I'm adding an option that allows users to omit it.