### PR TITLE
Fix parsing issue of yields in ERB templates

### DIFF
--- a/lib/brakeman/parsers/rails3_erubis.rb
+++ b/lib/brakeman/parsers/rails3_erubis.rb
@@ -6,6 +6,7 @@ class Brakeman::Rails3Erubis < ::Erubis::Eruby
 
   def add_preamble(src)
     @newline_pending = 0
+    src << "_this_is_to_make_yields_syntactally_correct {"
     src << "@output_buffer = output_buffer || ActionView::OutputBuffer.new;"
   end
 
@@ -62,7 +63,7 @@ class Brakeman::Rails3Erubis < ::Erubis::Eruby
 
   def add_postamble(src)
     flush_newline_if_pending(src)
-    src << '@output_buffer.to_s'
+    src << '@output_buffer.to_s; }'
   end
 
   def flush_newline_if_pending(src)


### PR DESCRIPTION
Yields with no method/block context is now a syntax error at parse time, so ERB templates need to avoid that to be parsed correctly.

Ruby 3.2.1:
```
$ echo yield | ruby -c
Syntax OK
```

Ruby 3.3.0:
```
$ echo yield | ruby -c
-:1: Invalid yield
yield
-: compile error (SyntaxError)
```