### PR TITLE
Enable aliases for YAML safe_load of `secrets.yml` file

### DIFF
--- a/lib/brakeman/checks/check_session_settings.rb
+++ b/lib/brakeman/checks/check_session_settings.rb
@@ -118,7 +118,7 @@ class Brakeman::CheckSessionSettings < Brakeman::BaseCheck
       yaml = secrets_file.read
       require 'yaml'
       begin
-        secrets = YAML.safe_load yaml
+        secrets = YAML.safe_load yaml, aliases: true
       rescue Psych::SyntaxError, RuntimeError => e
         Brakeman.notify "[Notice] #{self.class}: Unable to parse `#{secrets_file}`"
         Brakeman.debug "Failed to parse #{secrets_file}: #{e.inspect}"

--- a/test/apps/rails5.2/config/secrets.yml
+++ b/test/apps/rails5.2/config/secrets.yml
@@ -1,0 +1,34 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+test_anchor: &test_anchor
+  abc: 123
+
+development:
+  test_anchor: *test_anchor
+  secret_key_base: 12d3735e1cdb18ef2eca25f9a370028ac096ff273c5a889ed7a49047d5e30c9dc7fe095792a71b60c3f37dd80efaeda44db75e73c9f60813550c875eee7a241f
+
+test:
+  test_anchor: *test_anchor
+  secret_key_base: 446b08c3cdeccdaf9e8b247a2624d45218c5d429e8acde61ddd87aa7b9dd50973e49e6d94378cb4bcf08b7818a90abb044b5c8886f94de6970ade4a496df22f3
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  test_anchor: *test_anchor
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
+<% if Rails.root.join('config/ansible/secrets.yml').exist? %>
+<%= Rails.root.join('config/ansible/secrets.yml').read %>
+<% end %>
+
+


### PR DESCRIPTION
While checking logs for my brakeman run I've noticed this notice:
`Brakeman::CheckSessionSettings: Unable to parse /Users/c/code/rails_app/config/secrets.yml`

After running the `safe_load` without the `begin..rescue` part, I've had this exception:
```
 Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`. (Psych::AliasesNotEnabled)
```

After enabling the `aliases: true`, the YAML loading worked as expected
