### PR TITLE
Add remediation advice for command injection warnings

### DIFF
--- a/docs/warning_types/command_injection/index.markdown
+++ b/docs/warning_types/command_injection/index.markdown
@@ -10,4 +10,8 @@ There are many ways to run commands in Ruby:
 
 Brakeman will warn on any method like these that uses user input or unsafely interpolates variables.
 
+You can use [`shellescape`](https://apidock.com/ruby/Shellwords/shellescape) to render a variable safe:
+
+    `ls #{params[:file].shellescape}`
+
 See [the Ruby Security Guide](http://guides.rubyonrails.org/security.html#command-line-injection) for details.


### PR DESCRIPTION
Spent far to long pursuing other resolutions (none of which worked, not really) when the answer was `shellescape` all along.