### PR TITLE
README.md: `require: false` to bundler instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Using Bundler:
 
 ```ruby
 group :development do
-  gem 'brakeman'
+  gem 'brakeman', require: false
 end
 ```
 


### PR DESCRIPTION
No reason to load the code.
Not loading the code is faster.

Brakeman is always executed using `bundle exec brakeman` or using its binstub, which will still work with `require: false`