### PR TITLE
Fix compatibility with `--enable-frozen-string-literal`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run: bundle check || bundle install
       - run:
           command: |
-            bundle exec rake
+            bundle exec rake RUBYOPT='--enable-frozen-string-literal --debug-frozen-string-literal'
             ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/codeclimate.json coverage/.resultset.json
       - store_test_results:
           path: test-results

--- a/gem_common.rb
+++ b/gem_common.rb
@@ -12,7 +12,7 @@ module Brakeman
       spec.add_dependency "parallel", "~>1.20"
       spec.add_dependency "ruby_parser", "~>3.20.2"
       spec.add_dependency "sexp_processor", "~> 4.7"
-      spec.add_dependency "ruby2ruby", "~>2.4.0"
+      spec.add_dependency "ruby2ruby", "~>2.5.1"
       spec.add_dependency "racc"
     end
 
@@ -21,7 +21,7 @@ module Brakeman
       spec.add_dependency "highline", "~>3.0"
       spec.add_dependency "erubis", "~>2.6"
       spec.add_dependency "haml", "~>5.1"
-      spec.add_dependency "slim", ">=1.3.6", "<=4.1"
+      spec.add_dependency "slim", ">=1.3.6", "< 5.3"
       spec.add_dependency "rexml", "~>3.0"
     end
   end

--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -50,7 +50,7 @@ module Brakeman
           "#{Regexp.escape f}\\z"
         end
       end
-      Regexp.new("(?:" << path_regexes.join("|") << ")")
+      Regexp.new("(?:#{path_regexes.join("|")})")
     end
     private_class_method(:regex_for_paths)
 

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -211,7 +211,7 @@ module Brakeman::Options
             if check.start_with? "Check"
               check
             else
-              "Check" << check
+              "Check#{check}"
             end
           end
 
@@ -222,7 +222,7 @@ module Brakeman::Options
         opts.on "-t", "--test Check1,Check2,etc", Array, "Only run the specified checks" do |checks|
           checks.each_with_index do |s, index|
             if s[0,5] != "Check"
-              checks[index] = "Check" << s
+              checks[index] = "Check#{s}"
             end
           end
 
@@ -233,7 +233,7 @@ module Brakeman::Options
         opts.on "-x", "--except Check1,Check2,etc", Array, "Skip the specified checks" do |skip|
           skip.each do |s|
             if s[0,5] != "Check"
-              s = "Check" << s
+              s = "Check#{s}"
             end
 
             options[:skip_checks] ||= Set.new
@@ -263,7 +263,7 @@ module Brakeman::Options
           "Specify output formats. Default is text" do |type|
 
           type = "s" if type == :text
-          options[:output_format] = ("to_" << type.to_s).to_sym
+          options[:output_format] = :"to_#{type}"
         end
 
         opts.on "--css-file CSSFile", "Specify CSS to use for HTML output" do |file|

--- a/lib/brakeman/parsers/erubis_patch.rb
+++ b/lib/brakeman/parsers/erubis_patch.rb
@@ -1,0 +1,11 @@
+module Brakeman::ErubisPatch
+  # Simple patch to make `erubis` compatible with frozen string literals
+  def convert(input)
+    codebuf = +"" # Modified line, the rest is identitical
+    @preamble.nil? ? add_preamble(codebuf) : (@preamble && (codebuf << @preamble))
+    convert_input(codebuf, input)
+    @postamble.nil? ? add_postamble(codebuf) : (@postamble && (codebuf << @postamble))
+    @_proc = nil    # clear cached proc object
+    return codebuf  # or codebuf.join()
+  end
+end

--- a/lib/brakeman/parsers/rails2_erubis.rb
+++ b/lib/brakeman/parsers/rails2_erubis.rb
@@ -1,6 +1,9 @@
 Brakeman.load_brakeman_dependency 'erubis'
 
+require 'brakeman/parsers/erubis_patch'
+
 #Erubis processor which ignores any output which is plain text.
 class Brakeman::ScannerErubis < Erubis::Eruby
   include Erubis::NoTextEnhancer
+  include Brakeman::ErubisPatch
 end

--- a/lib/brakeman/parsers/rails2_xss_plugin_erubis.rb
+++ b/lib/brakeman/parsers/rails2_xss_plugin_erubis.rb
@@ -1,7 +1,11 @@
 Brakeman.load_brakeman_dependency 'erubis'
 
+require 'brakeman/parsers/erubis_patch'
+
 #This is from the rails_xss plugin for Rails 2
 class Brakeman::Rails2XSSPluginErubis < ::Erubis::Eruby
+  include Brakeman::ErubisPatch
+
   def add_preamble(src)
     #src << "@output_buffer = ActiveSupport::SafeBuffer.new;"
   end

--- a/lib/brakeman/parsers/rails3_erubis.rb
+++ b/lib/brakeman/parsers/rails3_erubis.rb
@@ -1,8 +1,11 @@
 Brakeman.load_brakeman_dependency 'erubis'
 
+require 'brakeman/parsers/erubis_patch'
+
 # This is from Rails 5 version of the Erubis handler
 # https://github.com/rails/rails/blob/ec608107801b1e505db03ba76bae4a326a5804ca/actionview/lib/action_view/template/handlers/erb.rb#L7-L73
 class Brakeman::Rails3Erubis < ::Erubis::Eruby
+  include Brakeman::ErubisPatch
 
   def add_preamble(src)
     @newline_pending = 0

--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -373,7 +373,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
     result << join_item(array.last, nil)
 
     # Combine the strings at the beginning because that's what RubyParser does
-    combined_first = ""
+    combined_first = +""
     result.each do |e|
       if string? e
         combined_first << e.value

--- a/lib/brakeman/report/report_markdown.rb
+++ b/lib/brakeman/report/report_markdown.rb
@@ -27,7 +27,7 @@ class Brakeman::Report::Markdown < Brakeman::Report::Table
   end
 
   def generate_report
-    out = "# BRAKEMAN REPORT\n\n" <<
+    out = +"# BRAKEMAN REPORT\n\n" <<
     generate_metadata.to_s << "\n\n" <<
     generate_checks.to_s << "\n\n" <<
     "### SUMMARY\n\n" <<

--- a/lib/brakeman/report/report_table.rb
+++ b/lib/brakeman/report/report_table.rb
@@ -8,7 +8,7 @@ class Brakeman::Report::Table < Brakeman::Report::Base
 
   def generate_report
     summary_option = tracker.options[:summary_only]
-    out = ""
+    out = +""
 
     unless summary_option == :no_summary
       out << text_header <<
@@ -166,7 +166,7 @@ class Brakeman::Report::Table < Brakeman::Report::Base
 
     template_rows = template_rows.sort_by{|name, value| name.to_s}
 
-    output = ''
+    output = +''
     template_rows.each do |template|
       output << template.first.to_s << "\n\n"
       table = @table.new(:headings => ['Output']) do |t|

--- a/lib/brakeman/report/report_tabs.rb
+++ b/lib/brakeman/report/report_tabs.rb
@@ -9,7 +9,6 @@ class Brakeman::Report::Tabs < Brakeman::Report::Table
 
       self.send(meth).map do |w|
         line = w.line || 0
-        w.warning_type.gsub!(/[^\w\s]/, ' ')
         "#{(w.file.absolute)}\t#{line}\t#{w.warning_type}\t#{category}\t#{w.format_message}\t#{w.confidence_name}"
       end.join "\n"
 

--- a/lib/brakeman/report/report_text.rb
+++ b/lib/brakeman/report/report_text.rb
@@ -4,7 +4,7 @@ class Brakeman::Report::Text < Brakeman::Report::Base
   def generate_report
     HighLine.use_color = !!tracker.options[:output_color]
     summary_option = tracker.options[:summary_only]
-    @output_string = "\n"
+    @output_string = +"\n"
 
     unless summary_option == :no_summary
       add_chunk generate_header

--- a/lib/brakeman/warning.rb
+++ b/lib/brakeman/warning.rb
@@ -317,7 +317,7 @@ class Brakeman::Warning
 
   def format_ruby code, strip
     formatted = Brakeman::OutputProcessor.new.format(code)
-    formatted.gsub!(/(\t|\r|\n)+/, " ") if strip
+    formatted = formatted.gsub(/(\t|\r|\n)+/, " ") if strip
     formatted
   end
 end


### PR DESCRIPTION
Since Ruby 2.3, Ruby can be started with this options, and it's expected to become the default in Ruby 4.0 (no release date yet).

This commit fixes the callsites that assume string literal are mutable.

Note however that a large part of the test suite is still failing, because of two dependencies:

  - ruby2ruby: https://github.com/seattlerb/ruby2ruby/pull/58
  - erubis: (this one is abandoned so can hardly be fixed).