### PR TITLE
Use `puts` for `$stderr` output in command line

### DIFF
--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -406,7 +406,7 @@ class Brakeman::Scanner
 
   def report_progress(current, total, type = "files")
     return unless @options[:report_progress]
-    $stderr.print " #{current}/#{total} #{type} processed\r"
+    $stderr.puts " #{current}/#{total} #{type} processed\r"
   end
 
   def index_call_sites

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -39,7 +39,7 @@ class Brakeman::Scanner
   end
 
   def process_step description
-    Brakeman.notify "#{description}...".ljust(40)
+    Brakeman.notify "#{description}..."
 
     if @show_timing
       start_t = Time.now


### PR DESCRIPTION
`print` was being used here so the stderr output was being overwritten, sometimes resulting in jumbled strings:

```
> rails new brakeman_test
> cd brakeman_test
> bundle add brakeman
> rails g scaffold Foo bar:string
> rails db:migrate
> bundle exec brakeman --debug
...

Processing foos/_foossed
(foos/_foo) Duration: 0.000641864 seconds
Processing foos/_formsed
(foos/_form) Duration: 0.000724829 seconds
Processing foos/editssed
Rendering foos/_form (["Template:foos/edit"])
(foos/edit) Duration: 0.002030275 seconds
Processing foos/indexsed
Rendering foos/foo (["Template:foos/index"])
[Notice] No such template: foos/foo
(foos/index) Duration: 0.000331022 seconds
Processing foos/newessed
Rendering foos/_form (["Template:foos/new"])
(foos/new) Duration: 0.00073369 seconds
Processing foos/showssed

...
```


This fix ensures the lines are displayed properly. Also, in #1629 and #1801 white space was added to account for stderr being overwritten, so I decided to remove the padding there.

```
> bundle exec brakeman --debug
...

Processing foos/_foo
(foos/_foo) Duration: 0.000826535 seconds
 1/8 templates processed
Processing foos/_form
(foos/_form) Duration: 0.001395142 seconds
 2/8 templates processed
Processing foos/edit
Rendering foos/_form (["Template:foos/edit"])
(foos/edit) Duration: 0.002028311 seconds
 3/8 templates processed
Processing foos/index
Rendering foos/foo (["Template:foos/index"])
[Notice] No such template: foos/foo
(foos/index) Duration: 0.000345746 seconds
 4/8 templates processed
Processing foos/new
Rendering foos/_form (["Template:foos/new"])
(foos/new) Duration: 0.000594765 seconds
 5/8 templates processed
...
```