### PR TITLE
Add `--show-ignored` flag

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -201,6 +201,10 @@ Brakeman will raise warnings on models that use `attr_protected`. To suppress th
 
     brakeman --ignore-protected
 
+To show all ignored warnings without affecting the exit code (i.e. - Will return `0` if the application shows no warnings when simply running `brakeman`):
+
+    brakeman --show-ignored
+
 Brakeman will assume that unknown methods involving untrusted data are dangerous. For example, this would cause a warning (Rails 2):
 
     <%= some_method(:option => params[:input]) %>

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ To create and manage this file, use:
 
     brakeman -I
 
+If you want to temporarily see the warnings you ignored without affecting the exit code, use:
+
+    brakeman --show-ignored
+
 # Warning information
 
 See [warning\_types](docs/warning_types) for more information on the warnings reported by this tool.

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -65,6 +65,7 @@ module Brakeman
   #  * :report_routes - show found routes on controllers (default: false)
   #  * :run_checks - array of checks to run (run all if not specified)
   #  * :safe_methods - array of methods to consider safe
+  #  * :show_ignored - Display warnings that are usually ignored
   #  * :sql_safe_methods - array of sql sanitization methods to consider safe
   #  * :skip_libs - do not process lib/ directory (default: false)
   #  * :skip_vendor - do not process vendor/ directory (default: true)
@@ -198,6 +199,7 @@ module Brakeman
       :relative_path => false,
       :report_progress => true,
       :safe_methods => Set.new,
+      :show_ignored => false,
       :sql_safe_methods => Set.new,
       :skip_checks => Set.new,
       :skip_vendor => true,

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -295,6 +295,10 @@ module Brakeman::Options
           options[:interactive_ignore] = true
         end
 
+        opts.on "--show-ignored", "Show files that are usually ignored by the ignore configuration file" do
+          options[:show_ignored] = true
+        end
+
         opts.on "-l", "--[no-]combine-locations", "Combine warning locations (Default)" do |combine|
           options[:combine_locations] = combine
         end

--- a/lib/brakeman/report/report_text.rb
+++ b/lib/brakeman/report/report_text.rb
@@ -103,7 +103,7 @@ class Brakeman::Report::Text < Brakeman::Report::Base
   end
 
   def generate_show_ignored_overview
-    double_space("Ignored File Overview", ignored_warnings.map {|w| output_warning w})
+    double_space("Ignored Warnings", ignored_warnings.map {|w| output_warning w})
   end
 
   def generate_errors

--- a/lib/brakeman/report/report_text.rb
+++ b/lib/brakeman/report/report_text.rb
@@ -9,6 +9,7 @@ class Brakeman::Report::Text < Brakeman::Report::Base
     unless summary_option == :no_summary
       add_chunk generate_header
       add_chunk generate_overview
+      add_chunk generate_show_ignored_overview if tracker.options[:show_ignored] && ignored_warnings.any?
       add_chunk generate_warning_overview
     end
 
@@ -99,6 +100,10 @@ class Brakeman::Report::Text < Brakeman::Report::Base
 
       double_space "Warnings", warnings
     end
+  end
+
+  def generate_show_ignored_overview
+    double_space("Ignored File Overview", ignored_warnings.map {|w| output_warning w})
   end
 
   def generate_errors

--- a/lib/brakeman/report/report_text.rb
+++ b/lib/brakeman/report/report_text.rb
@@ -9,7 +9,6 @@ class Brakeman::Report::Text < Brakeman::Report::Base
     unless summary_option == :no_summary
       add_chunk generate_header
       add_chunk generate_overview
-      add_chunk generate_show_ignored_overview if tracker.options[:show_ignored] && ignored_warnings.any?
       add_chunk generate_warning_overview
     end
 
@@ -22,6 +21,9 @@ class Brakeman::Report::Text < Brakeman::Report::Base
     add_chunk generate_obsolete
     add_chunk generate_errors
     add_chunk generate_warnings
+    add_chunk generate_show_ignored_overview if tracker.options[:show_ignored] && ignored_warnings.any?
+
+    @output_string
   end
 
   def add_chunk chunk, out = @output_string

--- a/test/tests/commandline.rb
+++ b/test/tests/commandline.rb
@@ -135,6 +135,13 @@ class CommandlineTests < Minitest::Test
     end
   end
 
+  # Assert default when using `--show-ignored` flag.
+  def test_show_ignored_warnings
+    assert_exit Brakeman::Warnings_Found_Exit_Code do
+      scan_app "--show-ignored"
+    end
+  end
+
   def test_compare_deactivates_ensure_ignore_notes
     opts, = Brakeman::Commandline.parse_options [
       '--ensure-ignore-notes',

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -25,6 +25,7 @@ class BrakemanOptionsTest < Minitest::Test
     :absolute_paths         => "--absolute-paths",
     :list_checks            => "-k",
     :list_optional_checks   => "--optional-checks",
+    :show_ignored           => "--show-ignored",
     :show_version           => "-v",
     :show_help              => "-h",
     :force_scan             => "--force-scan",
@@ -250,6 +251,11 @@ class BrakemanOptionsTest < Minitest::Test
 
     options = setup_options_from_input("--ignore-config", "dont_warn_for_these.rb")
     assert_equal "dont_warn_for_these.rb", options[:ignore_file]
+  end
+
+  def test_show_ignored_option
+    options = setup_options_from_input("--show-ignored")
+    assert options[:show_ignored]
   end
 
   def test_combine_warnings_option


### PR DESCRIPTION
Closes #1767.

After scaffolding a `Foo` model with a couple of vulnerabilities on a new application, running `brakeman --show-ignored` displays the following:

```
> brakeman --show-ignored
...

== Overview ==

Controllers: 2
Models: 2
Templates: 8
Errors: 0
Security Warnings: 0
Ignored Warnings: 2

== Ignored File Overview ==

Confidence: High
Category: SQL Injection
Check: SQL
Message: Possible SQL injection
Code: Foo.where(("bar = " + params[:bar]))
File: app/controllers/foos_controller.rb
Line: 24

Confidence: High
Category: SQL Injection
Check: SQL
Message: Possible SQL injection
Code: Foo.where(("bar = " + params[:bar]))
File: app/controllers/foos_controller.rb
Line: 40

== Warning Types ==


No warnings found

> echo $?
0
```

This ensures the exit code is unaffected by adding the flag (you can see in the test I added that the exit code returned is `3` which is the default in the command line test).

I wanted to check the output and not just the exit code in the command line test, but I had some trouble finding the right way to do it.

Either way, Looking back at [this comment](https://github.com/presidentbeef/brakeman/issues/1767#issuecomment-1482352588), if we do want to affect the exit code or take another approach, I'd be glad to look over the logic again.