### PR TITLE
New end-of-support dates for Rails

### DIFF
--- a/lib/brakeman/checks/check_eol_rails.rb
+++ b/lib/brakeman/checks/check_eol_rails.rb
@@ -11,6 +11,8 @@ class Brakeman::CheckEOLRails < Brakeman::EOLCheck
     check_eol_version :rails, RAILS_EOL_DATES
   end
 
+  # https://rubyonrails.org/maintenance
+  # https://endoflife.date/rails
   RAILS_EOL_DATES = {
     ['2.0.0', '2.3.99'] => Date.new(2013, 6, 25),
     ['3.0.0', '3.2.99'] => Date.new(2016, 6, 30),
@@ -19,5 +21,9 @@ class Brakeman::CheckEOLRails < Brakeman::EOLCheck
     ['5.1.0', '5.1.99'] => Date.new(2019, 8, 25),
     ['5.2.0', '5.2.99'] => Date.new(2022, 6, 1),
     ['6.0.0', '6.0.99'] => Date.new(2023, 6, 1),
+    ['6.1.0', '6.1.99'] => Date.new(2024, 10, 1),
+    ['7.0.0', '7.0.99'] => Date.new(2025, 4, 1),
+    ['7.1.0', '7.1.99'] => Date.new(2025, 10, 1),
+    ['7.2.0', '7.2.99'] => Date.new(2026, 8, 9),
   }
 end


### PR DESCRIPTION
From https://rubyonrails.org/maintenance

> List of currently supported releases
> 7.2.x - Supported until August 9, 2026
> 7.1.x - Supported until October 1, 2025
> 7.0.x - Supported until April 1, 2025
> 6.1.x - Supported until October 1, 2024