### PR TITLE
Ensure exact match when rejecting global excludes with `EXCLUDED_PATHS`

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -203,13 +203,13 @@ module Brakeman
 
     EXCLUDED_PATHS = %w[
       /generators/
-      lib/tasks/
-      lib/templates/
-      db/
-      spec/
-      test/
-      tmp/
-      log/
+      /lib/tasks/
+      /lib/templates/
+      /db/
+      /spec/
+      /test/
+      /tmp/
+      /log/
     ]
 
     def reject_global_excludes(paths)
@@ -220,6 +220,7 @@ module Brakeman
           true
         else
           EXCLUDED_PATHS.any? do |excluded|
+            relative_path = "/#{relative_path}" unless relative_path.match(/^\//)
             relative_path.include? excluded
           end
         end


### PR DESCRIPTION
Closes #1830.

We can scaffold a simple, namespaced model to test the new changes.
```
# Rails Version: 7.1.4.2
# Ruby Version: 3.3.1

> rails new brakeman_test
> cd brakeman_test
> bundle add brakeman --git "https://github.com/gazayas/brakeman.git" --branch "fixes/update-excluded-paths-strings"
> rails g scaffold Catalog::Order title:string
> rails db:migrate
```

```erb
<%# Add command injection to `app/views/catalog/orders/_order.html.erb` %>
<%= `#{x}` %>
```

Due to the problem in #1830 The current version of brakeman (6.2.2) won't report any warnings:
```
== Overview ==

Controllers: 1
Models: 1
Templates: 2
Errors: 0
Security Warnings: 0

== Warning Types ==


No warnings found
```

However, with the changes in this PR we get the following output.
```
== Overview ==

Controllers: 2
Models: 2
Templates: 8
Errors: 0
Security Warnings: 1

== Warning Types ==

Command Injection: 1

== Warnings ==

Confidence: Medium
Category: Command Injection
Check: Execute
Message: Possible command injection
Code: `#{x}`
File: app/views/catalog/orders/_order.html.erb
Line: 9
```

## Experimenting with Regular Expressions
Since the value of `relative_path` often times does not start with a leading `/`, I chose to add one at the beginning when it doesn't exist. That way we can be sure we're getting an exact match for the directories we need to exclude.

I primarily was thinking about scanning for exact matches with a Regular Expression instead of adding the leading `/`:
```ruby
# Since we would get only directories with the following,
# it seemed like a good idea at first...
File.dirname(relative_path).split("/")
#=> ["app", "views", "catalog", "orders"]
```

However, since we have nested directories like `lib/tasks/` and `lib/templates/` in `EXCLUDED_PATHS`, I experimented with some regular expressions to extract those two by themselves. I ultimately refrained from this because I felt it made the code more convoluted/hard to read, so I left things simple and just went with the leading `/` in `EXCLUDED_PATHS`. I hope this helps!