### PR TITLE
Output `originalBaseUriIds` for SARIF report

### DIFF
--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -1,8 +1,10 @@
+require 'uri'
+
 class Brakeman::Report::SARIF < Brakeman::Report::Base
   def generate_report
     sarif_log = {
       :version => '2.1.0',
-      :$schema => 'https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json',
+      :$schema => 'https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json',
       :runs => runs,
     }
     JSON.pretty_generate sarif_log

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -20,8 +20,120 @@ class Brakeman::Report::SARIF < Brakeman::Report::Base
           },
         },
         :results => results,
-      },
+      }.merge(original_uri_base_ids)
     ]
+  end
+
+  # Output base URIs
+  # based on what the user specified for the application path
+  # and whether or not --absolute-paths was set.
+  def original_uri_base_ids
+    if tracker.options[:app_path] == '.'
+      # Probably no app_path was specified, as that's the default
+
+      if absolute_paths?
+        # Set %SRCROOT% to absolute path
+        {
+          originalUriBaseIds: {
+            '%SRCROOT%' => {
+              uri: file_uri(tracker.app_tree.root),
+              description: {
+                text: 'Base path for application'
+              }
+            }
+          }
+        }
+      else
+        # Empty %SRCROOT%
+        # This avoids any paths appearing in the report
+        # that are not part of the application directory.
+        # Seems fine!
+        {
+          originalUriBaseIds: {
+            '%SRCROOT%' => {
+              description: {
+                text: 'Base path for application'
+              }
+            },
+          }
+        }
+
+      end
+    elsif tracker.options[:app_path] != tracker.app_tree.root
+      # Path was specified and it was relative
+
+      if absolute_paths?
+        # Include absolute root and relative application path
+        {
+          originalUriBaseIds: {
+            PROJECTROOT: {
+              uri: file_uri(tracker.app_tree.root),
+              description: {
+                text: 'Base path for all project files'
+              }
+            },
+            '%SRCROOT%' => {
+              # Technically should ensure this doesn't have any '..'
+              # but... TODO
+              uri: File.join(tracker.options[:app_path], '/'),
+              uriBaseId: 'PROJECTROOT',
+              description: {
+                text: 'Base path for application'
+              }
+            }
+          }
+        }
+      else
+        # Just include relative application path.
+        # Not clear this is 100% valid, but there is one example in the spec like this
+        {
+          originalUriBaseIds: {
+            PROJECTROOT: {
+              description: {
+                text: 'Base path for all project files'
+              }
+            },
+            '%SRCROOT%' => {
+              # Technically should ensure this doesn't have any '..'
+              # but... TODO
+              uri: File.join(tracker.options[:app_path], '/'),
+              uriBaseId: 'PROJECTROOT',
+              description: {
+                text: 'Base path for application'
+              }
+            }
+          }
+        }
+      end
+    else
+      # app_path was absolute
+
+      if absolute_paths?
+        # Set %SRCROOT% to absolute path
+        {
+          originalUriBaseIds: {
+            '%SRCROOT%' => {
+              uri: file_uri(tracker.app_tree.root),
+              description: {
+                text: 'Base path for application'
+              }
+            }
+          }
+        }
+      else
+        # Empty %SRCROOT%
+        # Seems fine!
+        {
+          originalUriBaseIds: {
+            '%SRCROOT%' => {
+              description: {
+                text: 'Base path for application'
+              }
+            },
+          }
+        }
+      end
+    end
   end
 
   def rules
@@ -129,5 +241,11 @@ class Brakeman::Report::SARIF < Brakeman::Report::Base
       2 => 'note',     # 2 represents 'weak, or low, confidence', which we infer as 'note'
     })
     @@levels_from_confidence[warning.confidence]
+  end
+
+  # File URI as a string with trailing forward-slash
+  # as required by SARIF standard
+  def file_uri(path)
+    URI::File.build(path: File.join(path, '/')).to_s
   end
 end

--- a/test/tests/sarif_output.rb
+++ b/test/tests/sarif_output.rb
@@ -21,7 +21,7 @@ class SARIFOutputTests < Minitest::Test
 
   def test_log_shape
     assert_equal '2.1.0', @@sarif['version']
-    assert_equal 'https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json', @@sarif['$schema']
+    assert_equal 'https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json', @@sarif['$schema']
   end
 
   def test_runs_shape


### PR DESCRIPTION
Fixes #1889 

This adds `originalBaseUriIds` following [GitHub guidance](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#relative-uri-guidance-for-sarif-producers) and hopefully [the spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790748).

This PR covers six cases, with example output below.

If there is only one URI to specify, it will be `%SRCROOT%`. If there is more than one (a relative and an absolute or empty URI), then `%SRCROOT%` will be relative and it will reference `PROJECTROOT` which will be the absolute (or empty) base URI.
This is because all the results use `%SRCROOT%` as the `uri`.

To best preserve privacy, the base URI does not include an absolute path unless `--absolute-paths` is set.

1. Default (implicit path)

```json
      "originalUriBaseIds": {
        "%SRCROOT%": {
          "description": {
            "text": "Base path for application"
          }
        }
      }
```

2. Relative application path (e.g. `--path some/where/`)

```json
      "originalUriBaseIds": {
        "PROJECTROOT": {
          "description": {
            "text": "Base path for all project files"
          }
        },
        "%SRCROOT%": {
          "uri": "test/apps/rails8/",
          "uriBaseId": "PROJECTROOT",
          "description": {
            "text": "Base path for application"
          }
        }
      }
```

3. Absolute application path (e.g. `--path /some/where`)

```json
      "originalUriBaseIds": {
        "%SRCROOT%": {
          "description": {
            "text": "Base path for application"
          }
        }
      }
```
4. Default (implicit path) with `--absolute-paths`

```json
      "originalUriBaseIds": {
        "%SRCROOT%": {
          "uri": "file:///home/justin/work/brakeman/test/apps/rails8/",
          "description": {
            "text": "Base path for application"
          }
        }
      }
```

5. Relative application path with `--absolute-paths`

```json
      "originalUriBaseIds": {
        "PROJECTROOT": {
          "uri": "file:///home/justin/work/brakeman/test/apps/rails8/",
          "description": {
            "text": "Base path for all project files"
          }
        },
        "%SRCROOT%": {
          "uri": "test/apps/rails8/",
          "uriBaseId": "PROJECTROOT",
          "description": {
            "text": "Base path for application"
          }
        }
      }
```

6. Absolute application path with `--absolute-paths`

```json
      "originalUriBaseIds": {
        "%SRCROOT%": {
          "uri": "file:///home/justin/work/brakeman/test/apps/rails8/",
          "description": {
            "text": "Base path for application"
          }
        }
      }
```

As far as I can tell with the [SARIF validator](https://sarifweb.azurewebsites.net/Validation), these are all valid.