### PR TITLE
Unpin `simplecov-html` version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           command: |
             bundle exec rake RUBYOPT='--enable-frozen-string-literal --debug-frozen-string-literal'
-            ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/codeclimate.json coverage/.resultset.json
+            ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/codeclimate.json coverage/coverage.json
       - store_test_results:
           path: test-results
       - persist_to_workspace:

--- a/gem_common.rb
+++ b/gem_common.rb
@@ -5,7 +5,6 @@ module Brakeman
       spec.add_development_dependency "minitest"
       spec.add_development_dependency "minitest-ci"
       spec.add_development_dependency "simplecov"
-      spec.add_development_dependency "simplecov-html", "=0.10.2"
     end
 
     def self.base_dependencies spec


### PR DESCRIPTION
For Ruby 3.4 support and because we're not supporting Ruby 2.3(!!) now.