### PR TITLE
Make following symbolic links for dirs optional

### DIFF
--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -223,6 +223,10 @@ module Brakeman::Options
           options[:engine_paths].merge paths
         end
 
+        opts.on '--[no-]follow-symlinks', 'Follow symbolic links for directions' do |follow_symlinks|
+          options[:follow_symlinks] = follow_symlinks
+        end
+
         opts.on "-E", "--enable Check1,Check2,etc", Array, "Enable the specified checks" do |checks|
           checks.map! do |check|
             if check.start_with? "Check"

--- a/test/tests/app_tree.rb
+++ b/test/tests/app_tree.rb
@@ -50,15 +50,22 @@ class AppTreeTests < Minitest::Test
 
   def test_directory_absolute_symlink_support
     temp_dir_absolute_symlink_and_file_from_path("test.rb") do |dir, file|
-      at = Brakeman::AppTree.new(dir)
+      at = Brakeman::AppTree.new(dir, follow_symlinks: true)
       assert_equal [file], at.ruby_file_paths.collect(&:absolute)
     end
   end
 
   def test_directory_relative_symlink_support
     temp_dir_relative_symlink_and_file_from_path("test.rb") do |dir, file|
-      at = Brakeman::AppTree.new(dir)
+      at = Brakeman::AppTree.new(dir, follow_symlinks: true)
       assert_equal [file], at.ruby_file_paths.collect(&:absolute)
+    end
+  end
+
+  def test_directory_relative_disabled_symlink_support
+    temp_dir_relative_symlink_and_file_from_path("test.rb") do |dir, file|
+      at = Brakeman::AppTree.new(dir, follow_symlinks: false)
+      assert_empty at.ruby_file_paths.collect(&:absolute)
     end
   end
 

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -390,6 +390,14 @@ class BrakemanOptionsTest < Minitest::Test
     end
   end
 
+  def test_follow_symlinks
+    options = setup_options_from_input("--follow-symlinks")
+    assert options[:follow_symlinks]
+
+    options = setup_options_from_input("--no-follow-symlinks")
+    refute options[:follow_symlinks]
+  end
+
   private
 
   def setup_options_from_input(*args)


### PR DESCRIPTION
Following symbolically linked directories was added in [Brakeman 6.2.1](https://brakemanscanner.org/blog/2024/08/22/brakeman-6-dot-2-released). Unfortunately, since the implementation globs every file (actually more than Brakeman normally) and checks each one to see if it's linked directory, it's pretty slow (sometimes adding double the overhead). Since having symbolic links is the minority scenario, Brakeman 7.0 will revert back to the old behavior.

Re-enable with `--follow-symlinks`.