### PR TITLE
Fix array/hash unknown index handling

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -97,6 +97,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
   end
 
   def process_bracket_call exp
+    # TODO: What is even happening in this method?
     r = replace(exp)
 
     if r != exp
@@ -127,7 +128,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
         return r
       end
     else
-      t = nil
+      t = exp.target # put it back?
     end
 
     if hash? t
@@ -242,6 +243,7 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
         exp = math_op(method, target, first_arg, exp)
       end
     when :[]
+      # TODO: This might never be used because of process_bracket_call above
       if array? target
         exp = process_array_access(target, exp.args, exp)
       elsif hash? target

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -138,6 +138,13 @@ class AliasProcessorTests < Minitest::Test
     RUBY
   end
 
+  def test_array_index_unknown_literal
+    assert_alias ':BRAKEMAN_SAFE_LITERAL', <<-RUBY
+    x = [1, 2, 3][y]
+    x
+    RUBY
+  end
+
   def test_array_append
     assert_alias '[1, 2, 3]', <<-RUBY
       x = [1]


### PR DESCRIPTION
E.g. `[1,2,3][x]` should be treated as returning a safe (although unknown) literal.