### PR TITLE
Update `terminal-table` version to use latest

### DIFF
--- a/gem_common.rb
+++ b/gem_common.rb
@@ -16,7 +16,7 @@ module Brakeman
 
     def self.extended_dependencies spec
       spec.add_dependency "csv"
-      spec.add_dependency "terminal-table", "~>1.4"
+      spec.add_dependency "terminal-table", "< 4.0"
       spec.add_dependency "highline", "~>3.0"
       spec.add_dependency "erubis", "~>2.6"
       spec.add_dependency "haml", "~>5.1"


### PR DESCRIPTION
Doesn't appear to be any breaking changes in 2.0 or 3.0. Allowing any versions before the next major version.