### PR TITLE
Always warn about deserializing with Marshal

### DIFF
--- a/lib/brakeman/checks/check_deserialize.rb
+++ b/lib/brakeman/checks/check_deserialize.rb
@@ -76,10 +76,13 @@ class Brakeman::CheckDeserialize < Brakeman::BaseCheck
       confidence = :high
     elsif input = include_user_input?(arg)
       confidence = :medium
+    elsif target == :Marshal
+      confidence = :low
+      message = msg("Use of ", msg_code("#{target}.#{method}"), " may be dangerous")
     end
 
     if confidence
-      message = msg(msg_code("#{target}.#{method}"), " called with ", msg_input(input))
+      message ||= msg(msg_code("#{target}.#{method}"), " called with ", msg_input(input))
 
       warn :result => result,
         :warning_type => "Remote Code Execution",

--- a/test/apps/rails8/app/controllers/application_controller.rb
+++ b/test/apps/rails8/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  def deserialize_it
+    Marshal.load(something) # Always warns
+  end
 end

--- a/test/tests/rails8.rb
+++ b/test/tests/rails8.rb
@@ -16,7 +16,7 @@ class Rails8Tests < Minitest::Test
       controller: 0,
       model:      0,
       template:   0,
-      warning:    2
+      warning:    3
     }
   end
 
@@ -45,6 +45,20 @@ class Rails8Tests < Minitest::Test
       confidence: 2,
       relative_path: "lib/evals.rb",
       code: s(:call, nil, :instance_eval, s(:dstr, "interpolated ", s(:evstr, s(:call, nil, :string)), s(:str, " - warning"))),
+      user_input: nil
+  end
+
+  def test_plain_marshal_load_weak_warning
+    assert_warning check_name: "Deserialize",
+      type: :warning,
+      warning_code: 25,
+      fingerprint: "458ac9bba693eae0b1d311627d59101dceac803c578bd1da7d808cb333c75068",
+      warning_type: "Remote Code Execution",
+      line: 6,
+      message: /^Use\ of\ `Marshal\.load`\ may\ be\ dangerous/,
+      confidence: 2,
+      relative_path: "app/controllers/application_controller.rb",
+      code: s(:call, s(:const, :Marshal), :load, s(:call, nil, :something)),
       user_input: nil
   end
 end


### PR DESCRIPTION
A little bit noisy, but people probably want to know about uses of `Marshal.load` in their applications.

Low confidence, so easily ignored with `--confidence-level 2`.