### PR TITLE
Relax Prism version requirement

### DIFF
--- a/gem_common.rb
+++ b/gem_common.rb
@@ -22,7 +22,7 @@ module Brakeman
       spec.add_dependency "haml", "~>5.1"
       spec.add_dependency "slim", ">=1.3.6", "< 5.3"
       spec.add_dependency "rexml", "~>3.0"
-      spec.add_dependency "prism", "~>1.3"
+      spec.add_dependency "prism", "~>1.0"
     end
   end
 end


### PR DESCRIPTION
While 1.3.0+ is recommended, earlier versions work.