### PR TITLE
Fix error on directory with `rb` extension

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -190,7 +190,12 @@ module Brakeman
       paths = select_only_files(paths)
       paths = reject_skipped_files(paths)
       paths = convert_to_file_paths(paths)
-      reject_global_excludes(paths)
+      paths = reject_global_excludes(paths)
+      reject_directories(paths)
+    end
+
+    def reject_directories(paths)
+      paths.reject { |path| File.directory?(path) }
     end
 
     def select_only_files(paths)

--- a/test/tests/app_tree.rb
+++ b/test/tests/app_tree.rb
@@ -6,7 +6,7 @@ class AppTreeTests < Minitest::Test
   def temp_dir_and_file_from_path(relative_path)
     Dir.mktmpdir do |dir|
       file = File.join(dir, relative_path)
-      FileUtils.mkdir_p(file)
+      FileUtils.mkdir_p(File.dirname(file))
       FileUtils.touch(file)
       yield dir, file
     end
@@ -21,7 +21,7 @@ class AppTreeTests < Minitest::Test
       FileUtils.mkdir_p(target_dir)
 
       file = File.join(sibling_dir, relative_path)
-      FileUtils.mkdir_p(file)
+      FileUtils.mkdir_p(File.dirname(file))
       FileUtils.touch(file)
 
       symlink = File.join(target_dir, "symlink")
@@ -39,7 +39,7 @@ class AppTreeTests < Minitest::Test
       FileUtils.mkdir_p(target_dir)
 
       file = File.join(sibling_dir, relative_path)
-      FileUtils.mkdir_p(file)
+      FileUtils.mkdir_p(File.dirname(file))
       FileUtils.touch(file)
 
       symlink = File.join(target_dir, "symlink")
@@ -122,6 +122,15 @@ class AppTreeTests < Minitest::Test
     temp_dir_and_file_from_path("gem123/lib/test.rb") do |dir, file|
       at = Brakeman::AppTree.new(dir, :additional_libs_path => ["gems/gem123/lib"])
       assert_equal [file], at.ruby_file_paths.collect(&:absolute)
+    end
+  end
+
+  def test_ruby_file_paths_directory_with_rb_extension
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "test.rb"))
+
+      at = Brakeman::AppTree.new(dir)
+      assert_equal [], at.ruby_file_paths.collect(&:absolute)
     end
   end
 end


### PR DESCRIPTION
Currently if application has a directory with `rb` extension (e.g. `app/test.rb`), brakeman fails with the following backtrace:

```
lib/brakeman/file_path.rb:45:in `read': Is a directory @ io_fread - app/test.rb (Errno::EISDIR)
	from lib/brakeman/file_path.rb:45:in `read'
	from lib/brakeman/file_parser.rb:49:in `block in parse_files'
	from bundle/ruby/3.1.0/gems/parallel-1.26.3/lib/parallel.rb:650:in `call_with_index'
	from bundle/ruby/3.1.0/gems/parallel-1.26.3/lib/parallel.rb:620:in `process_incoming_jobs'
	from bundle/ruby/3.1.0/gems/parallel-1.26.3/lib/parallel.rb:600:in `block in worker'
	from bundle/ruby/3.1.0/gems/parallel-1.26.3/lib/parallel.rb:591:in `fork'
	from bundle/ruby/3.1.0/gems/parallel-1.26.3/lib/parallel.rb:591:in `worker'
	from bundle/ruby/3.1.0/gems/parallel-1.26.3/lib/parallel.rb:582:in `block in create_workers'
	from bundle/ruby/3.1.0/gems/parallel-1.26.3/lib/parallel.rb:581:in `each'
	from bundle/ruby/3.1.0/gems/parallel-1.26.3/lib/parallel.rb:581:in `each_with_index'
	from bundle/ruby/3.1.0/gems/parallel-1.26.3/lib/parallel.rb:581:in `create_workers'
	from bundle/ruby/3.1.0/gems/parallel-1.26.3/lib/parallel.rb:520:in `work_in_processes'
	from bundle/ruby/3.1.0/gems/parallel-1.26.3/lib/parallel.rb:291:in `map'
	from lib/brakeman/file_parser.rb:47:in `parse_files'

  (snip)
```

Also, for some reason `AppTree` tests used directories instead of files. This was fixed as well.