### PR TITLE
Add new flag to detect obsolete ignore entries

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -24,6 +24,10 @@ module Brakeman
   #--ensure-ignore-notes is set
   Empty_Ignore_Note_Exit_Code = 8
 
+  # Exit code returned when at least one obsolete ignore entry is present
+  # and `--ensure-no-obsolete-ignore-entries` is set.
+  Obsolete_Ignore_Entries_Exit_Code = 9
+
   @debug = false
   @quiet = false
   @loaded_dependencies = []

--- a/lib/brakeman/commandline.rb
+++ b/lib/brakeman/commandline.rb
@@ -145,6 +145,11 @@ module Brakeman
           quit Brakeman::Errors_Found_Exit_Code
         end
 
+        if tracker.options[:ensure_no_obsolete_ignore_entries] && tracker.unused_fingerprints.any?
+          warn '[Error] Obsolete ignore entries were found, exiting with an error code.'
+          quit Brakeman::Obsolete_Ignore_Entries_Exit_Code
+        end
+
         if ensure_ignore_notes_failed
           quit Brakeman::Empty_Ignore_Note_Exit_Code
         end

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -71,6 +71,10 @@ module Brakeman::Options
           options[:ensure_ignore_notes] = true
         end
 
+        opts.on "--ensure-no-obsolete-ignore-entries", "Fail when an obsolete ignore entry is found" do
+          options[:ensure_no_obsolete_ignore_entries] = true
+        end
+
         opts.on "-3", "--rails3", "Force Rails 3 mode" do
           options[:rails3] = true
         end

--- a/test/tests/commandline.rb
+++ b/test/tests/commandline.rb
@@ -174,6 +174,20 @@ class CommandlineTests < Minitest::Test
     ignore_file_with_notes.unlink
   end
 
+  def test_ensure_no_obsolete_ignore_entries
+    ignore_file_obsolete_entries = Tempfile.new('brakeman.ignore')
+    ignore_file_obsolete_entries.write IGNORE_WITH_OBSOLETE_ENTRIES
+    ignore_file_obsolete_entries.close
+
+    assert_exit Brakeman::Obsolete_Ignore_Entries_Exit_Code do
+      scan_app '--ensure-no-obsolete-ignore-entries',
+               '-i', ignore_file_obsolete_entries.path.to_s,
+               '-t', 'None'
+    end
+
+    ignore_file_obsolete_entries.unlink
+  end
+
   IGNORE_WITH_MISSING_NOTES_JSON = <<~JSON.freeze
     {
       "ignored_warnings": [
@@ -249,4 +263,6 @@ class CommandlineTests < Minitest::Test
       "brakeman_version": "4.5.0"
     }
   JSON
+
+  IGNORE_WITH_OBSOLETE_ENTRIES = IGNORE_WITH_NOTES_JSON
 end


### PR DESCRIPTION
I'd like to propose a new CLI flag `--ensure-no-obsolete-config-entries`. If at least one obsolete (unused) fingerprint is found, brakeman should fail (with exit code 9).

This flag would be mostly useful in e.g. CI environments to ensure code changes are reflected in configuration changes.