### PR TITLE
Allow model paths for classifying files to be configured

### DIFF
--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -52,6 +52,7 @@ module Brakeman
   #  * :interprocedural - limited interprocedural processing of method calls (default: false)
   #  * :message_limit - limit length of messages
   #  * :min_confidence - minimum confidence (0-2, 0 is highest)
+  #  * :model_paths - array of paths for files to be considered as models (default: app/models/**/*)
   #  * :output_files - files for output
   #  * :output_formats - formats for output (:to_s, :to_tabs, :to_csv, :to_html)
   #  * :parallel_checks - run checks in parallel (default: true)
@@ -208,6 +209,7 @@ module Brakeman
       :index_libs => true,
       :message_limit => 100,
       :min_confidence => 2,
+      :model_paths => Set['app/models/**/*'],
       :output_color => true,
       :pager => true,
       :parallel_checks => true,

--- a/lib/brakeman/processors/lib/file_type_detector.rb
+++ b/lib/brakeman/processors/lib/file_type_detector.rb
@@ -1,6 +1,7 @@
 module Brakeman
   class FileTypeDetector < BaseProcessor
-    def initialize
+    def initialize(model_paths)
+      @model_paths = model_paths
       super(nil)
       reset
     end
@@ -38,7 +39,7 @@ module Brakeman
 
     def guess_from_path path
       case
-      when path.include?('app/models')
+      when @model_paths.any? { |model_path| File.fnmatch?(model_path, path, File::FNM_PATHNAME) }
         :model
       when path.include?('app/controllers')
         :controller

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -164,7 +164,7 @@ class Brakeman::Scanner
   end
 
   def detect_file_types(astfiles)
-    detector = Brakeman::FileTypeDetector.new
+    detector = Brakeman::FileTypeDetector.new(@options.fetch(:model_paths))
 
     astfiles.each do |file|
       if file.is_a? Brakeman::TemplateParser::TemplateFile


### PR DESCRIPTION
I have some situations where models are not located in standard directories and also use subclasses of `ApplicationRecord` so these files do not get classified as models. Would it be possible to allow the expected model path to be configurable?

This PR shows how I imagine it would work in a backwards compatible way while also allowing the configuration to take advantage of pattern matching.

### Example Usage

```yaml
# brakeman.yml
---
:model_paths:
- app/models/**/*
- lib/packages/*/models/**/*.rb
```