### PR TITLE
Consider Tempfile.create.path as safe input

### DIFF
--- a/lib/brakeman/checks/base_check.rb
+++ b/lib/brakeman/checks/base_check.rb
@@ -151,10 +151,13 @@ class Brakeman::BaseCheck < Brakeman::SexpProcessor
     method[-1] == "?"
   end
 
-  TEMP_FILE_PATH = s(:call, s(:call, s(:const, :Tempfile), :new), :path).freeze
+  TEMP_FILE_PATH = [
+    s(:call, s(:call, s(:const, :Tempfile), :new), :path).freeze,
+    s(:call, s(:call, s(:const, :Tempfile), :create), :path).freeze
+  ].freeze
 
   def temp_file_path? exp
-    exp == TEMP_FILE_PATH
+    TEMP_FILE_PATH.include? exp
   end
 
   #Report a warning

--- a/test/apps/rails5.2/lib/shell.rb
+++ b/test/apps/rails5.2/lib/shell.rb
@@ -136,4 +136,10 @@ class ShellStuff
     Open3.capture2e("cat", stdin_data: "User.z = #{u.z}")
     Open3.capture3("cat", stdin_data: "User.z = #{u.z}")
   end
+
+  def tempfile_create
+    # should not warn
+    tempfile = Tempfile.create
+    `something -out #{tempfile.path}`
+  end
 end


### PR DESCRIPTION
This PR adds extends the base check to consider `Tempfile.create.path` to be a safe input. This was already the case for `Tempfile.new`. According to ruby docs `Tempfile.create` is the recommended usage: https://docs.ruby-lang.org/en/3.4/Tempfile.html