### PR TITLE
Clean-up and update JUnit report to make it compatible with CircleCI

### DIFF
--- a/lib/brakeman/report/report_junit.rb
+++ b/lib/brakeman/report/report_junit.rb
@@ -9,48 +9,6 @@ class Brakeman::Report::JUnit < Brakeman::Report::Base
     doc.add REXML::XMLDecl.new '1.0', 'UTF-8'
 
     test_suites = REXML::Element.new 'testsuites'
-    test_suites.add_attribute 'xmlns:brakeman', 'https://brakemanscanner.org/'
-    properties = test_suites.add_element 'brakeman:properties', { 'xml:id' => 'scan_info' }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'app_path', 'brakeman:value' => tracker.app_path }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'rails_version', 'brakeman:value' => rails_version }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'security_warnings', 'brakeman:value' => all_warnings.length }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'start_time', 'brakeman:value' => tracker.start_time.iso8601 }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'end_time', 'brakeman:value' => tracker.end_time.iso8601 }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'duration', 'brakeman:value' => tracker.duration }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'checks_performed', 'brakeman:value' => checks.checks_run.join(',') }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'number_of_controllers', 'brakeman:value' => tracker.controllers.length }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'number_of_models', 'brakeman:value' => tracker.models.length - 1 }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'ruby_version', 'brakeman:value' => number_of_templates(@tracker) }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'number_of_templates', 'brakeman:value' => RUBY_VERSION }
-    properties.add_element 'brakeman:property', { 'brakeman:name' => 'brakeman_version', 'brakeman:value' => Brakeman::Version }
-
-    errors = test_suites.add_element 'brakeman:errors'
-    tracker.errors.each { |e|
-      error = errors.add_element 'brakeman:error'
-      error.add_attribute 'brakeman:message', e[:error]
-      e[:backtrace].each { |b|
-        backtrace = error.add_element 'brakeman:backtrace'
-        backtrace.add_text b
-      }
-    }
-
-    obsolete = test_suites.add_element 'brakeman:obsolete'
-    tracker.unused_fingerprints.each { |fingerprint|
-      obsolete.add_element 'brakeman:warning', { 'brakeman:fingerprint' => fingerprint }
-    }
-
-    ignored = test_suites.add_element 'brakeman:ignored'
-    ignored_warnings.each { |w|
-      warning = ignored.add_element 'brakeman:warning'
-      warning.add_attribute 'brakeman:message', w.message
-      warning.add_attribute 'brakeman:category', w.warning_type
-      warning.add_attribute 'brakeman:file', warning_file(w)
-      warning.add_attribute 'brakeman:line', w.line
-      warning.add_attribute 'brakeman:fingerprint', w.fingerprint
-      warning.add_attribute 'brakeman:confidence', w.confidence_name 
-      warning.add_attribute 'brakeman:code', w.format_code
-      warning.add_text w.to_s
-    }
 
     hostname = `hostname`.strip
     i = 0
@@ -66,7 +24,7 @@ class Brakeman::Report::JUnit < Brakeman::Report::Base
         test_suite = test_suites.add_element 'testsuite'
         test_suite.add_attribute 'id', i
         test_suite.add_attribute 'package', 'brakeman'
-        test_suite.add_attribute 'name', file.relative
+        test_suite.add_attribute 'file', file.relative
         test_suite.add_attribute 'timestamp', tracker.start_time.strftime('%FT%T')
         test_suite.add_attribute 'hostname', hostname == '' ? 'localhost' : hostname
         test_suite.add_attribute 'tests', checks.checks_run.length
@@ -78,18 +36,14 @@ class Brakeman::Report::JUnit < Brakeman::Report::Base
 
         warnings.each { |warning|
           test_case = test_suite.add_element 'testcase'
-          test_case.add_attribute 'name', 'run_check'
-          test_case.add_attribute 'classname', warning.check
+          test_case.add_attribute 'name', warning.check
+          test_case.add_attribute 'file', file.relative
+          test_case.add_attribute 'line', warning.line
           test_case.add_attribute 'time', '0'
 
           failure = test_case.add_element 'failure'
           failure.add_attribute 'message', warning.message
           failure.add_attribute 'type', warning.warning_type
-          failure.add_attribute 'brakeman:fingerprint', warning.fingerprint
-          failure.add_attribute 'brakeman:file', warning_file(warning)
-          failure.add_attribute 'brakeman:line', warning.line
-          failure.add_attribute 'brakeman:confidence', warning.confidence_name 
-          failure.add_attribute 'brakeman:code', warning.format_code
           failure.add_text warning.to_s
         }
 

--- a/lib/brakeman/report/report_junit.rb
+++ b/lib/brakeman/report/report_junit.rb
@@ -32,8 +32,6 @@ class Brakeman::Report::JUnit < Brakeman::Report::Base
         test_suite.add_attribute 'errors', '0'
         test_suite.add_attribute 'time', '0'
 
-        test_suite.add_element 'properties'
-
         warnings.each { |warning|
           test_case = test_suite.add_element 'testcase'
           test_case.add_attribute 'name', warning.check
@@ -46,9 +44,6 @@ class Brakeman::Report::JUnit < Brakeman::Report::Base
           failure.add_attribute 'type', warning.warning_type
           failure.add_text warning.to_s
         }
-
-        test_suite.add_element 'system-out'
-        test_suite.add_element 'system-err'
       }
 
     doc.add test_suites

--- a/test/tests/junit_output.rb
+++ b/test/tests/junit_output.rb
@@ -6,31 +6,6 @@ class JUnitOutputTests < Minitest::Test
     @@document ||= REXML::Document.new(Brakeman.run("#{TEST_PATH}/apps/rails3.2").report.to_junit)
   end
 
-  def test_for_ignored_warnings
-    assert @@document.get_elements('/testsuites/brakeman:ignored/brakeman:warning').length == 0
-
-    document = REXML::Document.new(Brakeman.run("#{TEST_PATH}/apps/rails4").report.to_junit)
-    ignored_warnings = document.get_elements('/testsuites/brakeman:ignored/brakeman:warning')
-    assert_equal 1, ignored_warnings.length
-  end
-
-  def test_for_errors
-    assert @@document.get_elements('/testsuites/brakeman:errors/brakeman:error').length == 0
-
-    tracker = Brakeman.run("#{TEST_PATH}/apps/rails3.2")
-    tracker.error Exception.new "some message"
-    document = REXML::Document.new(tracker.report.to_junit)
-    elements = document.get_elements('/testsuites/brakeman:errors/brakeman:error')
-    assert_equal elements.map { |e| e.attribute('brakeman:message').to_s }, ["some message"]
-  end
-
-  def test_for_obsolete
-    document = REXML::Document.new(Brakeman.run("#{TEST_PATH}/apps/rails4").report.to_junit)
-    obsolete = document.get_elements('/testsuites/brakeman:obsolete/brakeman:warning')
-      .map { |e| e.attribute('brakeman:fingerprint').to_s }
-    assert_equal ["abcdef01234567890ba28050e7faf1d54f218dfa9435c3f65f47cb378c18cf98"], obsolete
-  end
-
   def test_paths
     elements = @@document.get_elements('/testsuites/testsuite/testcase/failure')
     assert elements.all? { |e| not e.attribute('brakeman:file').to_s.start_with? "/" }

--- a/test/tests/junit_output.rb
+++ b/test/tests/junit_output.rb
@@ -2,12 +2,69 @@ require_relative '../test'
 require 'rexml/document'
 
 class JUnitOutputTests < Minitest::Test
+  NO_LINE_REPORT_CHECKS = %w[
+    Brakeman::CheckDefaultRoutes
+    Brakeman::CheckModelAttrAccessible
+  ]
+
   def setup
     @@document ||= REXML::Document.new(Brakeman.run("#{TEST_PATH}/apps/rails3.2").report.to_junit)
   end
 
-  def test_paths
-    elements = @@document.get_elements('/testsuites/testsuite/testcase/failure')
-    assert elements.all? { |e| not e.attribute('brakeman:file').to_s.start_with? "/" }
+  def test_document_structure
+    assert_equal "testsuites", @@document.root.name
+    assert @@document.root.elements.count > 0, "No test suites found"
+
+    @@document.root.elements.each do |testsuite|
+      assert_equal "testsuite", testsuite.name
+      assert testsuite.elements.count > 0, "No elements in test suite"
+
+      # Check testcase elements
+      testsuite.elements.each("testcase") do |testcase|
+        assert_equal "testcase", testcase.name
+        assert testcase.elements["failure"], "Missing failure element in testcase"
+      end
+    end
+  end
+
+  def test_testsuite_attributes
+    @@document.root.elements.each do |testsuite|
+      # Required attributes for testsuite
+      assert testsuite.attributes["id"], "Missing id attribute"
+      assert_equal "brakeman", testsuite.attributes["package"]
+      assert testsuite.attributes["file"], "Missing file attribute"
+      assert testsuite.attributes["timestamp"], "Missing timestamp attribute"
+      assert testsuite.attributes["hostname"], "Missing hostname attribute"
+      assert testsuite.attributes["tests"], "Missing tests attribute"
+      assert testsuite.attributes["failures"], "Missing failures attribute"
+      assert testsuite.attributes["errors"], "Missing errors attribute"
+      assert testsuite.attributes["time"], "Missing time attribute"
+    end
+  end
+
+  def test_testcase_attributes
+    @@document.root.elements.each do |testsuite|
+      testsuite.elements.each("testcase") do |testcase|
+        # Required attributes for testcase
+        assert testcase.attributes["name"], "Missing name attribute"
+        assert testcase.attributes["file"], "Missing file attribute"
+        assert testcase.attributes["line"], "Missing line attribute: #{testcase.attributes}" unless NO_LINE_REPORT_CHECKS.include?(testcase.attributes["name"])
+        assert testcase.attributes["time"], "Missing time attribute"
+      end
+    end
+  end
+
+  def test_failure_attributes
+    @@document.root.elements.each do |testsuite|
+      testsuite.elements.each("testcase") do |testcase|
+        failure = testcase.elements["failure"]
+        assert failure, "Missing failure element"
+
+        # Required attributes for failure
+        assert failure.attributes["message"], "Missing message attribute"
+        assert failure.attributes["type"], "Missing type attribute"
+        assert failure.text.strip.length > 0, "Failure text is empty"
+      end
+    end
   end
 end


### PR DESCRIPTION
The report was adding custom XML tags and attributes to add more info in the output, however this is not supported by some Continuous Integration services like CircleCI.

This PR removes those custom attributes, but also changes the XML format slightly: `file` and `line` attributes are used to report code which breaks, which should create more elegant and convenient reports on CI tools.

This PR also removes some XML tags that was added to the report without content.

It has been tested on CircleCI which currently shows the report like this:
