### PR TITLE
Check for unsafe SQL when two arguments are passed to AR methods

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -192,7 +192,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
                       when :last, :first, :all
                         check_find_arguments call.first_arg
                       when :average, :count, :maximum, :minimum, :sum
-                        if call.length >= 5 # more than one argument was passed
+                        if call.arglist.length > 1
                           unsafe_sql?(call.first_arg) or check_find_arguments(call.last_arg)
                         else
                           check_find_arguments call.last_arg

--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -192,7 +192,7 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
                       when :last, :first, :all
                         check_find_arguments call.first_arg
                       when :average, :count, :maximum, :minimum, :sum
-                        if call.length > 5
+                        if call.length >= 5 # more than one argument was passed
                           unsafe_sql?(call.first_arg) or check_find_arguments(call.last_arg)
                         else
                           check_find_arguments call.last_arg


### PR DESCRIPTION
I think this conditional is meant to

1. Always check the first and last arguments.
2. Avoid checking the argument twice when there's only one argument.

The structure of `call` appears to be:

* 0: the symbol `:call`
* 1: the receiver of the method call
* 2: the method being called
* 3: the first argument
* 4: the second argument
* 5: the third argument (and so on)

So `call.length > 5` will be true only if there are at least 3 arguments.

Before this change, the behavior was

```ruby
User.count("#{params[:input]}") # triggers warning
User.count("#{params[:input]}", :foo) # doesn't trigger warning
User.count("#{params[:input]}", :foo, :bar) # triggers warning
```

After this change, the two-argument version will trigger the warning.

Another option would be to use `if call.arglist.length > 1`. This is more explicit, but it involves an additional method call, and I don't know what the performance implications of that are.