### PR TITLE
Fix duplicate test method name

### DIFF
--- a/test/tests/rails8.rb
+++ b/test/tests/rails8.rb
@@ -48,7 +48,7 @@ class Rails8Tests < Minitest::Test
       user_input: nil
   end
 
-  def test_dangerous_eval_2
+  def test_dangerous_eval_3
     assert_warning check_name: "Evaluation",
       type: :warning,
       warning_code: 13,


### PR DESCRIPTION
Just something I noticed.

> /home/user/code/brakeman/test/tests/rails8.rb:51: warning: method redefined; discarding old test_dangerous_eval_2
> /home/user/code/brakeman/test/tests/rails8.rb:37: warning: previous definition of test_dangerous_eval_2 was here