### PR TITLE
Only load from `cgi` what is required

### DIFF
--- a/lib/brakeman/messages.rb
+++ b/lib/brakeman/messages.rb
@@ -86,7 +86,7 @@ class Brakeman::Messages::Message
   end
 
   def to_html
-    require 'cgi'
+    require 'cgi/escape'
 
     output = @parts.map(&:to_html).join
 

--- a/lib/brakeman/report/report_html.rb
+++ b/lib/brakeman/report/report_html.rb
@@ -1,4 +1,4 @@
-require 'cgi'
+require 'cgi/escape'
 require 'brakeman/report/report_table.rb'
 
 class Brakeman::Report::HTML < Brakeman::Report::Table


### PR DESCRIPTION
In Ruby 3.5 most of the `cgi` gem will be removed. Only the various escape/unescape methods will be retained by default.

https://bugs.ruby-lang.org/issues/21258