### PR TITLE
Improve ignored warnings layout

### DIFF
--- a/lib/brakeman/report/templates/header.html.erb
+++ b/lib/brakeman/report/templates/header.html.erb
@@ -9,10 +9,15 @@
     function toggle(context) {
       var elem = document.getElementById(context);
 
-      if (elem.style.display != "block")
+      if (elem.style.display != "block") {
         elem.style.display = "block";
-      else
+
+        elem.querySelectorAll("table").forEach(function(table) {
+          $(table).DataTable().columns.adjust();
+        });
+      } else {
         elem.style.display = "none";
+      }
 
       elem.parentNode.scrollIntoView();
     }

--- a/lib/brakeman/report/templates/ignored_warnings.html.erb
+++ b/lib/brakeman/report/templates/ignored_warnings.html.erb
@@ -1,6 +1,6 @@
 <div onClick="toggle('ignored_table');">  <h2><%= warnings.length %> Ignored Warnings (click to see them)</h2 ></div>
-<div>
-  <table style="display:none" id="ignored_table">
+<div style="display:none; width:100%" id="ignored_table">
+  <table>
     <thead>
       <tr>
         <th>Confidence</th>
@@ -8,7 +8,7 @@
         <th>Warning Type</th>
         <th>CWE ID</th>
         <th>Message</th>
-        <th>Note</th>
+        <th width="auto">Note</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
A minor update on HTML output to improve reading of ignored warning notes :

Before : 
![Capture d’écran 2025-06-04 à 10 43 19](https://github.com/user-attachments/assets/9fdea089-7fda-4128-a92e-78a9701c9cde)



After:
![Capture d’écran 2025-06-04 à 10 39 56](https://github.com/user-attachments/assets/0b468db3-9a17-4062-8059-68308b6d3845)
