### PR TITLE
Fix issue #1832 ViewComponent with_content

### DIFF
--- a/lib/brakeman/checks/check_render.rb
+++ b/lib/brakeman/checks/check_render.rb
@@ -101,6 +101,11 @@ class Brakeman::CheckRender < Brakeman::BaseCheck
   def renderable? exp
     return false unless call?(exp) and constant?(exp.target)
 
+    if exp.method == :with_content
+      exp = exp.target
+    end
+
+    return false unless constant?(exp.target)
     target_class_name = class_name(exp.target)
     known_renderable_class?(target_class_name) or tracker.find_method(:render_in, target_class_name)
   end

--- a/test/apps/rails6/app/controllers/groups_controller.rb
+++ b/test/apps/rails6/app/controllers/groups_controller.rb
@@ -90,4 +90,9 @@ class GroupsController < ApplicationController
   def render_view_component_contrib
     render(TestViewComponentContrib.new(params.require('name')))
   end
+
+  # Test ViewComponent with with_content chain (issue #1832)
+  def render_view_component_with_content
+    render(TestViewComponent.new(params.require('name')).with_content("string"))
+  end
 end

--- a/test/tests/github_output.rb
+++ b/test/tests/github_output.rb
@@ -6,7 +6,7 @@ class TestGithubOutput < Minitest::Test
   end
 
   def test_report_format
-    assert_equal 43, @@report.lines.count, "Did you add vulnerabilities to the Rails 6 app? Update this test please!"
+    assert_equal 44, @@report.lines.count, "Did you add or remove vulnerabilities in the Rails 6 app? Update this test please!"
     @@report.lines.each do |line|
       assert line.start_with?('::'), 'Every line must start with `::`'
       assert_equal 2, line.scan('::').count, 'Every line must have exactly 2 `::`'

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,7 +13,7 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 37
+      :generic => 38
     }
   end
 
@@ -680,6 +680,15 @@ class Rails6Tests < Minitest::Test
       :confidence => 2,
       :relative_path => "app/controllers/groups_controller.rb",
       :code => s(:render, :action, s(:call, s(:const, :TestViewComponentContrib), :new, s(:call, s(:params), :require, s(:str, "name"))), s(:hash)),
+      :user_input => s(:call, s(:params), :require, s(:str, "name"))
+  end
+
+  def test_dynamic_render_path_view_component_with_content
+    assert_warning :type => :warning,
+      :warning_code => 15,
+      :warning_type => "Dynamic Render Path",
+      :relative_path => "app/controllers/groups_controller.rb",
+      :code => s(:render, :action, s(:call, s(:call, s(:const, :TestViewComponent), :new, s(:call, s(:params), :require, s(:str, "name"))), :with_content, s(:str, "string")), s(:hash)),
       :user_input => s(:call, s(:params), :require, s(:str, "name"))
   end
 


### PR DESCRIPTION
Addresses the report in issue https://github.com/presidentbeef/brakeman/issues/1832

When rendering a ViewComponent via the with_content method a Dynamic Render Path warning will be raised. However, using the block version, the warning is not raised. Example using the [basic implementation for a view component](https://viewcomponent.org/guide/getting-started.html#implementation):

```
<!-- No error raised -->
<%= render ExampleComponent.new(title: "my title") %>

<!-- Error raised -->
<%= render ExampleComponent.new(title: "my title").with_content("string") %>

<!-- No error raised -->
<%= render ExampleComponent.new(title: "my title") do %>
  string
<% end %>

<!-- No error raised -->
<%= render ExampleComponent.new(title: "my title") do %>
  <%= "string" %>
<% end %>
```
My (@gavingmiller) debugging has lead me to the [renderable? method](https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_render.rb#L102), and it appears like it's missing logic to detect the with_content usage of this pattern.
