### PR TITLE
Fix name of obsolete ignore entries option in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 * Improve ignored warnings layout in HTML report (Sebastien Savater)
 * Update JUnit report for CircleCI (Philippe Bernery)
 * Only load escape functionality from cgi library (Earlopain)
-* Add `--ensure-no-obsolete-config-entries` option (viralpraxis)
+* Add `--ensure-no-obsolete-ignore-entries` option (viralpraxis)
 
 # 7.0.2 - 2025-04-04
 


### PR DESCRIPTION
Follow-up to #1921