### PR TITLE
Add FilePath#to_path for Ruby 3.5 compatibility

### DIFF
--- a/lib/brakeman/file_path.rb
+++ b/lib/brakeman/file_path.rb
@@ -68,6 +68,10 @@ module Brakeman
       self.absolute
     end
 
+    # Required for Pathname compatibility.
+    # Ruby 3.5+ requires Pathname#initialize to receive a String or an object with to_path method.
+    alias to_path to_str
+
     # Returns a string with the absolute path.
     def to_s
       self.to_str


### PR DESCRIPTION
Thank you for maintaining this library!                                                                                                                                                                                                                                                                                                                                                 I encountered this issue while testing Brakeman with Ruby 3.5.0-dev.
This is my first PR to Brakeman. Please let me know if there's anything else needed or any additional changes required.

  ## Summary

  Adds `FilePath#to_path` method to fix compatibility issues with Ruby 3.5+.

  ## Problem

  Ruby 3.5 introduces stricter type checking in `Pathname#initialize`. Previously, Ruby used the `StringValue()` macro which would fall back to calling `to_str` for implicit
  conversion, allowing `FilePath` objects to work seamlessly with `Pathname.new()`.

  In Ruby 3.5, this implicit conversion was removed. `Pathname#initialize` now requires arguments to be either:
  - A `String`, or
  - An object with a `to_path` method that returns a `String`

  Without this change, all tests fail with `TypeError` when running on Ruby 3.5:

```bash
  TypeError: TypeError
      lib/brakeman/app_tree.rb:260:in 'Pathname#initialize'
```

  ## Solution

  Added `to_path` as an alias to `to_str` in the `FilePath` class. This provides explicit conversion for `Pathname` while maintaining backward compatibility with older Ruby versions.

  ## Reference

  Ruby commit introducing the change: https://github.com/ruby/ruby/commit/a931da6df4bcb8b979d715e1e18fd84328fb417d
