### PR TITLE
Add `dom_id` and `dom_class` to ignore methods for `CrossSiteScripting`

### DIFF
--- a/lib/brakeman/checks/check_cross_site_scripting.rb
+++ b/lib/brakeman/checks/check_cross_site_scripting.rb
@@ -289,13 +289,13 @@ class Brakeman::CheckCrossSiteScripting < Brakeman::BaseCheck
   end
 
   def setup
-    @ignore_methods = Set[:==, :!=, :button_to, :check_box, :content_tag, :escapeHTML, :escape_once,
-                           :field_field, :fields_for, :form_for, :h, :hidden_field,
-                           :hidden_field, :hidden_field_tag, :image_tag, :label,
-                           :link_to, :mail_to, :radio_button, :select,
-                           :submit_tag, :text_area, :text_field,
-                           :text_field_tag, :url_encode, :u, :url_for,
-                           :will_paginate].merge tracker.options[:safe_methods]
+    @ignore_methods = Set[
+      :==, :!=, :button_to, :check_box, :content_tag, :dom_class, :dom_id,
+      :escapeHTML, :escape_once, :field_field, :fields_for, :form_for, :h,
+      :hidden_field, :hidden_field, :hidden_field_tag, :image_tag, :label,
+      :link_to, :mail_to, :radio_button, :select, :submit_tag, :text_area,
+      :text_field, :text_field_tag, :url_encode, :u, :url_for, :will_paginate
+    ].merge tracker.options[:safe_methods]
 
     @models = tracker.models.keys
     @inspect_arguments = tracker.options[:check_arguments]


### PR DESCRIPTION
Described/requested in https://github.com/presidentbeef/brakeman/issues/1952#issuecomment-3092654010

Because I'm not 100% sure how to reliably trigger these warnings (see note in linked issue), I'm not sure where to add coverage for this. Specifically in this case, the `_user` partial in the test suite DOES call `dom_id`, but does not trigger a warning ... I'm assuming because whatever combination of params/setup from the controller does not cause it to happen. Would love guidance on that if it's needed in this case.
