### PR TITLE
Ignore attribute builder in Haml 6

### DIFF
--- a/lib/brakeman/processors/haml_template_processor.rb
+++ b/lib/brakeman/processors/haml_template_processor.rb
@@ -166,7 +166,7 @@ class Brakeman::HamlTemplateProcessor < Brakeman::TemplateProcessor
   def haml_attribute_builder? exp
     call? exp and
       exp.target == ATTRIBUTE_BUILDER and
-      exp.method == :build
+      (exp.method == :build or exp.method == :build_id)
   end
 
   def fix_textareas? exp

--- a/test/apps/rails8/app/views/users/dom_id.haml
+++ b/test/apps/rails8/app/views/users/dom_id.haml
@@ -1,0 +1,1 @@
+.test-list__item{ id: dom_id(User.first) }

--- a/test/tests/rails8.rb
+++ b/test/tests/rails8.rb
@@ -115,4 +115,18 @@ class Rails8Tests < Minitest::Test
       code: s(:call, s(:call, s(:const, :Thing), :new), :name),
       user_input: nil
   end
+
+  def test_cross_site_scripting_haml6_attribute_builder
+    assert_no_warning check_name: "CrossSiteScripting",
+      type: :template,
+      warning_code: 2,
+      fingerprint: "26ce9d920c75d29438b84cd3a45efdf4a7235d883d133937445c31c627bbc791",
+      warning_type: "Cross-Site Scripting",
+      line: 1,
+      message: /^Unescaped\ model\ attribute/,
+      confidence: 2,
+      relative_path: "app/views/users/dom_id.haml",
+      code: s(:call, s(:colon2, s(:colon3, :Haml), :AttributeBuilder), :build_id, s(:true), s(:call, nil, :dom_id, s(:call, s(:const, :User), :first))),
+      user_input: s(:call, s(:const, :User), :first)
+  end
 end


### PR DESCRIPTION
Fixes #1952