### PR TITLE
Fix singleton method prefixes

### DIFF
--- a/lib/brakeman/tracker/collection.rb
+++ b/lib/brakeman/tracker/collection.rb
@@ -55,11 +55,21 @@ module Brakeman
       if src.node_type == :defs
         @class_methods[name] = meth_info
 
-        # TODO fix this weirdness
-        name = :"#{src[1]}.#{name}"
+        name = :"#{method_definition_receiver(src[1])}.#{name}"
       end
 
       @methods[visibility][name] = meth_info
+    end
+
+    def method_definition_receiver(receiver)
+      return receiver if receiver.is_a?(Symbol)
+
+      case receiver.sexp_type
+      when :self
+        "self"
+      else
+        receiver[1].to_s
+      end
     end
 
     def each_method

--- a/test/apps/rails8/lib/evals.rb
+++ b/test/apps/rails8/lib/evals.rb
@@ -26,4 +26,23 @@ class Evals
       METHODS
     end
   end
+
+  class << self
+    def defs_eval(string)
+      eval("foo #{string}")
+    end
+  end
+
+  def Object.object_defs_eval(string)
+    eval("foo #{string}")
+  end
+
+  def @ivar.ivar_def_eval(string)
+    eval("foo #{string}")
+  end
+
+  lvar = Object.new
+  def lvar.lvar_def_eval(string)
+    eval("foo #{string}")
+  end
 end

--- a/test/tests/rails8.rb
+++ b/test/tests/rails8.rb
@@ -16,7 +16,7 @@ class Rails8Tests < Minitest::Test
       controller: 0,
       model:      0,
       template:   2,
-      warning:    5
+      warning:    9
     }
   end
 
@@ -59,6 +59,66 @@ class Rails8Tests < Minitest::Test
       confidence: 2,
       relative_path: "lib/evals.rb",
       code: s(:call, nil, :eval, s(:dstr, "interpolate ", s(:evstr, s(:lvar, :something)))),
+      user_input: nil
+  end
+
+  def test_dangerous_eval_4
+    assert_warning check_name: "Evaluation",
+      type: :warning,
+      warning_code: 13,
+      fingerprint: "3f08e08ea36320517ee869bd7f6f6f150efe38f6e02667f5907e9964881b46be",
+      warning_type: "Dangerous Eval",
+      line: 32,
+      message: /^Dynamic\ string\ evaluated\ as\ code/,
+      confidence: 2,
+      method: :"self.defs_eval",
+      relative_path: "lib/evals.rb",
+      code: s(:call, nil, :eval, s(:dstr, "foo ", s(:evstr, s(:lvar, :string)))),
+      user_input: nil
+  end
+
+  def test_dangerous_eval_5
+    assert_warning check_name: "Evaluation",
+      type: :warning,
+      warning_code: 13,
+      fingerprint: "a4284b65b029c04b9e786bf70d7a1bb88a9e7d35a4c0258b0e0e7f8011524994",
+      warning_type: "Dangerous Eval",
+      line: 37,
+      message: /^Dynamic\ string\ evaluated\ as\ code/,
+      confidence: 2,
+      method: :"Object.object_defs_eval",
+      relative_path: "lib/evals.rb",
+      code: s(:call, nil, :eval, s(:dstr, "foo ", s(:evstr, s(:lvar, :string)))),
+      user_input: nil
+  end
+
+  def test_dangerous_eval_6
+    assert_warning check_name: "Evaluation",
+      type: :warning,
+      warning_code: 13,
+      fingerprint: "bcd52e91053d1e52c90c9a30992e255bb5602e6f06740b9473e1c4b0b6110430",
+      warning_type: "Dangerous Eval",
+      line: 41,
+      message: /^Dynamic\ string\ evaluated\ as\ code/,
+      confidence: 2,
+      method: :"@ivar.ivar_def_eval",
+      relative_path: "lib/evals.rb",
+      code: s(:call, nil, :eval, s(:dstr, "foo ", s(:evstr, s(:lvar, :string)))),
+      user_input: nil
+  end
+
+  def test_dangerous_eval_7
+    assert_warning check_name: "Evaluation",
+      type: :warning,
+      warning_code: 13,
+      fingerprint: "a261e54367af8c1621ab2612ca8b7d0c67f67edb46295aeb3a68ca90035b29f6",
+      warning_type: "Dangerous Eval",
+      line: 46,
+      message: /^Dynamic\ string\ evaluated\ as\ code/,
+      confidence: 2,
+      method: :"lvar.lvar_def_eval",
+      relative_path: "lib/evals.rb",
+      code: s(:call, nil, :eval, s(:dstr, "foo ", s(:evstr, s(:lvar, :string)))),
       user_input: nil
   end
 


### PR DESCRIPTION
In case of something like

```ruby
class A
  class << self
    def foo = ??
  end
end
```

the prefixed name of the `foo` method is `s(:self).foo`, not `self.foo`.

Looks like ideally it should be `A.foo` (?), but this patch does not address that.

Here's how it looks in the report,

before:

```
"location": {
  "type": "method",
  "class": "SomeModule::SomeClass",
  "method": "s(:self).some_singleton_method"
}
```

after:

```
"location": {
  "type": "method",
  "class": "SomeModule::SomeClass",
  "method": "self.some_singleton_method"
}
```