### PR TITLE
Docs: Add 'sarif' to list of output format options

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -107,7 +107,7 @@ To specify an output file for the results:
 
     brakeman -o output_file
 
-The output format is determined by the file extension or by using the `-f` option. Current options are: `text`, `html`, `tabs`, `json`, `junit`, `markdown`, `csv`, `codeclimate`, `github` and `sonar`.
+The output format is determined by the file extension or by using the `-f` option. Current options are: `text`, `html`, `tabs`, `json`, `junit`, `markdown`, `csv`, `codeclimate`, `github`, `sarif` and `sonar`.
 
 Multiple output files can be specified:
 


### PR DESCRIPTION
Changelog entry for SARIF support: https://brakemanscanner.org/blog/2020/09/28/brakeman-4-dot-10-dot-0-released