### PR TITLE
Update required Ruby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Outside of Rails root (note that the output file is relative to path/to/rails/ap
 
 Brakeman should work with any version of Rails from 2.3.x to 8.x.
 
-Brakeman can analyze code written with Ruby 2.0 syntax and newer, but requires at least Ruby 3.0.0 to run.
+Brakeman can analyze code written with Ruby 2.0 syntax and newer, but requires at least Ruby 3.2.0 to run.
 
 # Basic Options
 


### PR DESCRIPTION
It should now require version 3.2.0 or higher.

ref: https://github.com/presidentbeef/brakeman/blob/901a45de9481ea531ed574a84678c406de7f61eb/brakeman.gemspec#L15