### PR TITLE
Faster file globbing for templates

### DIFF
--- a/lib/brakeman/app_tree.rb
+++ b/lib/brakeman/app_tree.rb
@@ -120,7 +120,7 @@ module Brakeman
 
     def template_paths
       @template_paths ||= find_paths(".", "*.{#{VIEW_EXTENSIONS}}") +
-        find_paths("**", "*.{erb,haml,slim}").reject { |path| File.basename(path).count(".") > 1 }
+        find_paths(".", "*.{erb,haml,slim}").reject { |path| File.basename(path).count(".") > 1 }
     end
 
     def layout_exists?(name)


### PR DESCRIPTION
Use root directories dot pattern for templates so we take advantage of faster file globbing.

Moving ahead with this tweak to @mhenrixon's suggestion in #1979