### PR TITLE
Fix argument error to logger.cleanup

### DIFF
--- a/lib/brakeman/logger.rb
+++ b/lib/brakeman/logger.rb
@@ -57,7 +57,7 @@ module Brakeman
       def spin; end
 
       # Called on exit
-      def cleanup(newline); end
+      def cleanup(newline = true); end
 
       def show_timing? = @show_timing
 


### PR DESCRIPTION
I chose to update the definition to match the Base and Console logger instead of updating the call site.

Fixes: https://github.com/presidentbeef/brakeman/issues/2003