### PR TITLE
Fix `TemplateAliasProcessor#template_name` arity

### DIFF
--- a/lib/brakeman/processors/lib/render_helper.rb
+++ b/lib/brakeman/processors/lib/render_helper.rb
@@ -19,7 +19,9 @@ module Brakeman::RenderHelper
       end
     when :default
       begin
-        process_template template_name, exp[3], nil, exp.line
+        # exp[2] is either the action name (from controller) or :default when no explicit arg
+        name_arg = (exp[2].nil? || exp[2] == :default) ? nil : exp[2]
+        process_template template_name(name_arg), exp[3], nil, exp.line
       rescue ArgumentError
         Brakeman.debug "Problem processing render: #{exp}"
       end

--- a/lib/brakeman/processors/template_alias_processor.rb
+++ b/lib/brakeman/processors/template_alias_processor.rb
@@ -66,7 +66,7 @@ class Brakeman::TemplateAliasProcessor < Brakeman::AliasProcessor
   end
 
   #Determine template name
-  def template_name name
+  def template_name name = nil
     if !name.to_s.include?('/') && @template.name.to_s.include?('/')
       name = "#{@template.name.to_s.match(/^(.*\/).*$/)[1]}#{name}"
     end

--- a/lib/brakeman/processors/template_alias_processor.rb
+++ b/lib/brakeman/processors/template_alias_processor.rb
@@ -66,7 +66,7 @@ class Brakeman::TemplateAliasProcessor < Brakeman::AliasProcessor
   end
 
   #Determine template name
-  def template_name name = nil
+  def template_name name
     if !name.to_s.include?('/') && @template.name.to_s.include?('/')
       name = "#{@template.name.to_s.match(/^(.*\/).*$/)[1]}#{name}"
     end


### PR DESCRIPTION
```shell
<snip>/gems/brakeman-8.0.2/lib/brakeman/processors/lib/render_helper.rb:26 - wrong number of arguments (given 0, expected 1)
```