### PR TITLE
Resolve index_by(&:itself) on literal arrays to hash literals

### DIFF
--- a/lib/brakeman/processors/alias_processor.rb
+++ b/lib/brakeman/processors/alias_processor.rb
@@ -347,6 +347,13 @@ class Brakeman::AliasProcessor < Brakeman::SexpProcessor
           exp = safe_literal(exp.line)
         end
       end
+    when :index_by
+      # Convert %w[a b].index_by(&:itself) to {"a" => "a", "b" => "b"}
+      if array? target and all_literals? target and
+          node_type? first_arg, :block_pass and first_arg[1] == s(:lit, :itself)
+        hash_body = target.each_sexp.flat_map { |e| [e, e.deep_clone] }
+        exp = s(:hash, *hash_body).line(exp.line)
+      end
     end
 
     exp

--- a/lib/brakeman/tracker/constants.rb
+++ b/lib/brakeman/tracker/constants.rb
@@ -105,6 +105,15 @@ module Brakeman
         value = value.target
       end
 
+      # Convert %w[...].index_by(&:itself) to a hash literal
+      if call? value and value.method == :index_by and
+          array? value.target and all_literals? value.target and
+          node_type? value.first_arg, :block_pass and
+          value.first_arg[1] == s(:lit, :itself)
+        hash_body = value.target.each_sexp.flat_map { |e| [e, e.deep_clone] }
+        value = s(:hash, *hash_body).line(value.line)
+      end
+
       base_name = Constants.get_constant_base_name(name)
       @constants[base_name] ||= []
       @constants[base_name] << Constant.new(name, value, context)

--- a/test/tests/alias_processor.rb
+++ b/test/tests/alias_processor.rb
@@ -1513,4 +1513,26 @@ class AliasProcessorTests < Minitest::Test
     # Does not raise because the error is caught and handled by the Tracker
     assert Brakeman::AliasProcessor.new(BrakemanTester.new_tracker).process s(:block, s(:attrasgn, s(:call, nil, :x), :"[]!", s(:lit, 1), s(:lit, 2)))
   end
+
+  def test_index_by_itself
+    assert_alias '{"a" => "a", "b" => "b"}', <<-RUBY
+      x = %w[a b].index_by(&:itself)
+      x
+    RUBY
+  end
+
+  def test_index_by_itself_with_freeze
+    assert_alias '{"a" => "a", "b" => "b"}', <<-RUBY
+      x = %w[a b].index_by(&:itself).freeze
+      x
+    RUBY
+  end
+
+  def test_index_by_without_itself
+    # Should not convert if not &:itself
+    assert_alias '%w[a b].index_by(&:to_s)', <<-RUBY
+      x = %w[a b].index_by(&:to_s)
+      x
+    RUBY
+  end
 end

--- a/test/tests/constants.rb
+++ b/test/tests/constants.rb
@@ -278,4 +278,32 @@ class ConstantTests < Minitest::Test
     end
     INPUT
   end
+
+  def test_constants_index_by_itself
+    # index_by(&:itself) on an array of literals should be converted to a hash
+    value = s(:call,
+      s(:array, s(:str, "a").line(1), s(:str, "b").line(1)).line(1),
+      :index_by,
+      s(:block_pass, s(:lit, :itself).line(1)).line(1)).line(1)
+    @constants.add :LOOKUP, value
+
+    result = @constants.get_simple_value(s(:const, :LOOKUP))
+    assert_equal :hash, result.node_type
+    assert_equal ["a", "a", "b", "b"], result.each_sexp.map(&:value)
+  end
+
+  def test_constants_index_by_itself_with_freeze
+    # .index_by(&:itself).freeze — freeze is stripped first, then index_by
+    value = s(:call,
+      s(:call,
+        s(:array, s(:str, "x").line(1), s(:str, "y").line(1)).line(1),
+        :index_by,
+        s(:block_pass, s(:lit, :itself).line(1)).line(1)).line(1),
+      :freeze).line(1)
+    @constants.add :FROZEN_LOOKUP, value
+
+    result = @constants.get_simple_value(s(:const, :FROZEN_LOOKUP))
+    assert_equal :hash, result.node_type
+    assert_equal ["x", "x", "y", "y"], result.each_sexp.map(&:value)
+  end
 end


### PR DESCRIPTION
Fixes #2018

## Problem

When a constant is defined as `%w[a b c].index_by(&:itself).freeze`, Brakeman doesn't know what `index_by` does, so the constant's value remains an unresolved `:call` sexp. This means lookups like `LOOKUP[params[:id]]` propagate taint from `params[:id]` through the hash access, even though the return value can only be one of the hash's constant values.

## Solution

Teach Brakeman to convert `array.index_by(&:itself)` into a hash literal (`{"a" => "a", "b" => "b", ...}`) when the array contains all literal values. This is done in two places:

1. **`AliasProcessor#process_call_target`** — handles inline usage within method bodies
2. **`Constants#add`** — handles class-level constant definitions (after `.freeze` is already stripped)

Once the constant resolves to a hash literal, Brakeman's existing logic correctly untaints hash lookups with tainted keys, eliminating false positive File Access, Path Traversal, Cross-Site Scripting, and Dynamic Render Path warnings.

## Scope

Only converts `index_by(&:itself)` — not arbitrary blocks like `index_by(&:to_s)` or `index_by { |x| x.name }`. The conversion requires all array elements to be literals.

## Tests

- 3 alias processor tests: `index_by(&:itself)`, with `.freeze`, and non-`:itself` block pass (no conversion)
- 2 constants tests: direct and with `.freeze` wrapping

## Real-world validation

Tested against a Rails app that defines:
```ruby
TEMPLATE_IDS = %w[layout message_available ...].index_by(&:itself).freeze
```
and uses `TEMPLATE_IDS[params[:id]]` in file paths. Before: 14 false positive warnings. After: 0.