### PR TITLE
fix(scanner): skip alternative-Ruby `.ruby-version` strings (#1960)

### DIFF
--- a/lib/brakeman/processors/gem_processor.rb
+++ b/lib/brakeman/processors/gem_processor.rb
@@ -6,7 +6,7 @@ class Brakeman::GemProcessor < Brakeman::BasicProcessor
   def initialize *args
     super
     @gem_name_version = /^\s*([-_+.A-Za-z0-9]+) \((\w(\.\w+)*)\)/
-    @ruby_version = /^\s+ruby (\d\.\d.\d+)/
+    @ruby_version = /^\s+ruby (\d+\.\d+\.\d+)/
   end
 
   def process_gems gem_files

--- a/lib/brakeman/scanner.rb
+++ b/lib/brakeman/scanner.rb
@@ -187,8 +187,14 @@ class Brakeman::Scanner
     end
 
     if @app_tree.exists? ".ruby-version"
-      if version = @app_tree.file_path(".ruby-version").read[/(\d\.\d.\d+)/]
-        tracker.config.set_ruby_version version, @app_tree.file_path(".ruby-version"), 1
+      contents = @app_tree.file_path(".ruby-version").read
+      # Skip alternative Ruby implementations — the EOL dates Brakeman knows
+      # about are MRI's, so a `.ruby-version` of "jruby-10.0.2.0" should not
+      # be parsed as MRI 0.0.2 / 10.0.2.
+      unless contents =~ /\A\s*(jruby|truffleruby|rbx|rubinius|mruby)\b/i
+        if version = contents[/(\d+\.\d+\.\d+)/]
+          tracker.config.set_ruby_version version, @app_tree.file_path(".ruby-version"), 1
+        end
       end
     end
 

--- a/test/tests/brakeman.rb
+++ b/test/tests/brakeman.rb
@@ -578,4 +578,27 @@ class GemProcessorTests < Minitest::Test
       assert_version "1.1", :simplecov, "Couldn't match gemlock with eol: #{eol}"
     end
   end
+
+  def parse_ruby_version_from_lock(version_string)
+    empty_block = Sexp.new(:block)
+    gem_lock = "RUBY VERSION\n   ruby #{version_string}\n"
+    @gem_processor.process_gems :gemfile => { :file => "Gemfile", :src => empty_block }, :gemlock => { :file => "Gemfile.lock", :src => gem_lock }
+    @tracker.config.ruby_version
+  end
+
+  def test_gem_lock_ruby_version_single_digit
+    assert_equal "3.2.0", parse_ruby_version_from_lock("3.2.0")
+  end
+
+  def test_gem_lock_ruby_version_with_patchlevel
+    assert_equal "3.2.0", parse_ruby_version_from_lock("3.2.0p123")
+  end
+
+  def test_gem_lock_ruby_version_double_digit_minor
+    assert_equal "3.10.5", parse_ruby_version_from_lock("3.10.5")
+  end
+
+  def test_gem_lock_ruby_version_double_digit_major
+    assert_equal "10.20.5", parse_ruby_version_from_lock("10.20.5")
+  end
 end


### PR DESCRIPTION
Closes #1960.

## Background

`Brakeman::Scanner` extracts a Ruby version from `.ruby-version` with:

```ruby
@app_tree.file_path(".ruby-version").read[/(\d\.\d.\d+)/]
```

The second `.` is unescaped, so the regex is "digit, dot, digit, **any character**, digits". For `jruby-10.0.2.0` that matches `"0.0.2"` beginning at offset 7. The EOLRuby check then sees Ruby `0.0.2` and reports:

```
Confidence: High
Category: Unmaintained Dependency
Check: EOLRuby
Message: Support for Ruby 0.0.2 ended on 2015-02-23
File: .ruby-version
```

@skunkworker confirmed the same on JRuby `10.0.4.0` (extracted as `0.0.4`).

The EOL date table Brakeman carries is MRI's, so the right fix is to *not* extract an MRI version when the `.ruby-version` file actually names a different implementation.

## Change

`lib/brakeman/scanner.rb`:

1. Skip the version extraction when `.ruby-version` starts with `jruby`, `truffleruby`, `rbx`, `rubinius`, or `mruby` (case-insensitive, with optional leading whitespace).
2. Tighten the regex from `\d\.\d.\d+` to `\d+\.\d+\.\d+` so the second dot is literal and the parser accepts a (hypothetical, current as of this PR's writing) Ruby 10.x cleanly.

The other affected paths (`Gemfile` `ruby ...` directive, `Gemfile.lock`) were already fine — only `.ruby-version` reading needed adjustment.

## Verification

Existing test `test_unmaintained_dependency_ruby` (which runs against a `.ruby-version` of `2.3.1@something_weird`) still passes:

```
$ bundle exec ruby -Ilib -Itest test/tests/rails52.rb -n test_unmaintained_dependency_ruby
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```

New behaviour, exercised by hand against the regex/condition pair:

| input | parsed MRI version |
|---|---|
| `2.3.1` | `2.3.1` |
| `2.3.1@something_weird` | `2.3.1` |
| `ruby-3.2.0` | `3.2.0` |
| `mri-3.2.0` | `3.2.0` |
| `jruby-10.0.2.0` | (skipped, no EOLRuby warning) |
| `jruby-10.0.4.0` | (skipped) |
| `truffleruby-22.3.1` | (skipped) |
| `mruby-3.0.0` | (skipped) |
| `rbx-3.107` | (skipped) |
| `10.0.0` | `10.0.0` |

Diff is `+8 / -2` lines, single file, no public API change. Happy to add a fixture test app + Minitest case mirroring `rails5.2`'s if you'd prefer the explicit coverage — just wanted to keep the initial PR small.
