### PR TITLE
Remove command injection false positives for splatted args

### DIFF
--- a/lib/brakeman/checks/check_execute.rb
+++ b/lib/brakeman/checks/check_execute.rb
@@ -55,6 +55,13 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
     first_arg = call.first_arg
     failure = nil
 
+    # All spawn-family methods optionally accept an env hash as the first
+    # argument. Strip it so first_arg always points to the command name.
+    if hash?(first_arg)
+      args.delete_at(1)
+      first_arg = args[1]
+    end
+
     case call.method
     when :popen
       # Normally, if we're in a `popen` call, we only are worried about shell
@@ -99,14 +106,17 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
 
         break if failure
       end
-    when :system, :exec
-      # Normally, if we're in a `system` or `exec` call, we only are worried
-      # about shell injection when there's a single argument, because comma-
-      # separated arguments are always escaped by Ruby. However, an exception is
-      # when the first two arguments are something like "bash -c" because then
-      # the third argument is effectively the command being run and might be
-      # a malicious executable if it comes (partially or fully) from user input.
-      if dash_c_shell_command?(first_arg, call.second_arg)
+    when :system, :exec, :spawn, :capture2, :capture2e, :capture3,
+         :popen2, :popen2e, :popen3
+      # Comma-separated arguments are passed directly to execve without a
+      # shell, so only the first argument (the command name) needs checking.
+      # Exception: `bash -c <script>` — the script is the injection vector.
+      #
+      # All of these methods accept an optional trailing options hash
+      # (e.g. stdin_data:, chdir:); strip it before checking.
+      args.pop if hash?(args.last) && args.length > 2
+
+      if dash_c_shell_command?(first_arg, args[2])
         failure = include_user_input?(args[3]) ||
                   dangerous_interp?(args[3]) ||
                   dangerous_string_building?(args[3])
@@ -114,21 +124,6 @@ class Brakeman::CheckExecute < Brakeman::BaseCheck
         failure = include_user_input?(first_arg) ||
                   dangerous_interp?(first_arg) ||
                   dangerous_string_building?(first_arg)
-      end
-    when :capture2, :capture2e, :capture3
-      # Open3 capture methods can take a :stdin_data argument which is used as the
-      # the input to the called command so it is not succeptable to command injection.
-      # As such if the last argument is a hash (and therefore execution options) it
-      # should be ignored
-
-      args.pop if hash?(args.last) && args.length > 2
-
-      args.each_sexp do |arg|
-        failure = include_user_input?(arg) ||
-          dangerous_interp?(arg) ||
-          dangerous_string_building?(arg)
-
-        break if failure
       end
     else
       failure = include_user_input?(args) ||

--- a/test/apps/rails5.2/lib/shell.rb
+++ b/test/apps/rails5.2/lib/shell.rb
@@ -146,4 +146,24 @@ class ShellStuff
       system("something -out #{tempfile.path}")
     end
   end
+
+  def capture_array_safe
+    Open3.capture2("true", params[:user_input])
+    Open3.capture2e("true", params[:user_input])
+    Open3.capture3("true", params[:user_input])
+  end
+
+  def popen2_array_safe
+    Open3.popen2("true", params[:user_input])
+    Open3.popen2e("true", params[:user_input])
+    Open3.popen3("true", params[:user_input])
+  end
+
+  def spawn_array_safe
+    spawn("true", params[:user_input])
+  end
+
+  def spawn_env_hash_safe
+    spawn({"LOG" => "1"}, "true", params[:user_input])
+  end
 end

--- a/test/tests/rails52.rb
+++ b/test/tests/rails52.rb
@@ -642,6 +642,91 @@ class Rails52Tests < Minitest::Test
       user_input: nil
   end
 
+  def test_capture_multi_arg_safe
+    # Multi-arg form of capture2/2e/3 passes each argument directly to execve
+    # (no shell), so only the command name is a danger — not the extra args.
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :warning_type => "Command Injection",
+      :line => 151,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 0,
+      :relative_path => "lib/shell.rb",
+      :code => s(:call, s(:const, :Open3), :capture2, s(:str, "true"), s(:call, s(:params), :[], s(:lit, :user_input))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :user_input))
+
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :warning_type => "Command Injection",
+      :line => 152,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 0,
+      :relative_path => "lib/shell.rb",
+      :code => s(:call, s(:const, :Open3), :capture2e, s(:str, "true"), s(:call, s(:params), :[], s(:lit, :user_input))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :user_input))
+
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :warning_type => "Command Injection",
+      :line => 153,
+      :message => /^Possible\ command\ injection/,
+      :confidence => 0,
+      :relative_path => "lib/shell.rb",
+      :code => s(:call, s(:const, :Open3), :capture3, s(:str, "true"), s(:call, s(:params), :[], s(:lit, :user_input))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :user_input))
+  end
+
+  def test_popen2_multi_arg_safe
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :warning_type => "Command Injection",
+      :line => 157,
+      :message => /^Possible\ command\ injection/,
+      :relative_path => "lib/shell.rb",
+      :code => s(:call, s(:const, :Open3), :popen2, s(:str, "true"), s(:call, s(:params), :[], s(:lit, :user_input))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :user_input))
+
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :warning_type => "Command Injection",
+      :line => 158,
+      :message => /^Possible\ command\ injection/,
+      :relative_path => "lib/shell.rb",
+      :code => s(:call, s(:const, :Open3), :popen2e, s(:str, "true"), s(:call, s(:params), :[], s(:lit, :user_input))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :user_input))
+
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :warning_type => "Command Injection",
+      :line => 159,
+      :message => /^Possible\ command\ injection/,
+      :relative_path => "lib/shell.rb",
+      :code => s(:call, s(:const, :Open3), :popen3, s(:str, "true"), s(:call, s(:params), :[], s(:lit, :user_input))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :user_input))
+  end
+
+  def test_spawn_multi_arg_safe
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :warning_type => "Command Injection",
+      :line => 163,
+      :message => /^Possible\ command\ injection/,
+      :relative_path => "lib/shell.rb",
+      :code => s(:call, nil, :spawn, s(:str, "true"), s(:call, s(:params), :[], s(:lit, :user_input))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :user_input))
+  end
+
+  def test_spawn_env_hash_safe
+    assert_no_warning :type => :warning,
+      :warning_code => 14,
+      :warning_type => "Command Injection",
+      :line => 167,
+      :message => /^Possible\ command\ injection/,
+      :relative_path => "lib/shell.rb",
+      :code => s(:call, nil, :spawn, s(:hash, s(:str, "LOG"), s(:str, "1")), s(:str, "true"), s(:call, s(:params), :[], s(:lit, :user_input))),
+      :user_input => s(:call, s(:params), :[], s(:lit, :user_input))
+  end
+
   def test_command_injection_ignored_in_stdin
     assert_no_warning :type => :warning,
       :warning_code => 14,


### PR DESCRIPTION
This commit expands `check_execute.rb` to no longer warn about splatted args being passed to a variety of additional methods (such as `capture3` and `popen3`), mirroring how the check already treated `system` and `exec`.

This commit also expands that check to correctly handle when environment variables are passed to some of these methods via a hash as the first argument.

Fixes #2017

---

Note: #2017 was already marked as fixed, but the actual issue reported by @marocchino was not actually addressed in [the fix](https://github.com/presidentbeef/brakeman/commit/169a7d4a800ca13188e74e871fb8ade3ab349470):

> Brakeman treats dynamic string segments passed into Open3.capture3 as if they might be executed by a shell. Here, Open3.capture3 is called with multiple separate string arguments. In Ruby, that form uses spawn-style execution: the program is invoked with a discrete argv list and no shell is spawned by default. The interpolated value is therefore passed as a single argument to git (the refspec origin/), not parsed as shell syntax. Characters that would be dangerous in a shell string (spaces, ;, |, `, $(), etc.) do not gain shell metacharacter meaning in this API shape; they are only part of the ref string git receives.

> So the finding conflates “string built with interpolation” with “user input concatenated into a shell command line.” The latter is command injection; the former, in multi-argument Open3.capture3, is argument passing to git only. Any abuse is limited to what git diff does with a malformed ref name, not arbitrary command execution via the shell.