### PR TITLE
Fix HAML crash on .raw calls

### DIFF
--- a/lib/brakeman/processors/haml_template_processor.rb
+++ b/lib/brakeman/processors/haml_template_processor.rb
@@ -186,6 +186,8 @@ class Brakeman::HamlTemplateProcessor < Brakeman::TemplateProcessor
 
   def raw? exp
     call? exp and
-      exp.method == :raw
+      exp.target.nil? and
+      exp.method == :raw and
+      exp.first_arg
   end
 end

--- a/test/apps/rails8/app/controllers/users_controller.rb
+++ b/test/apps/rails8/app/controllers/users_controller.rb
@@ -79,6 +79,10 @@ class UsersController < ApplicationController
      not_ar_model.count("something - #{params[:x]}")
   end
 
+  def chained_raw
+    @users = User.all
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_user

--- a/test/apps/rails8/app/views/users/chained_raw.html.haml
+++ b/test/apps/rails8/app/views/users/chained_raw.html.haml
@@ -1,0 +1,2 @@
+- @users.each do |user|
+  %span= user.profile.raw


### PR DESCRIPTION
I tried fixing https://github.com/presidentbeef/brakeman/issues/1972.
Seems like calls like `login.user_agent.raw` were being wrongly identified as calls to Rails' `raw()` view helper.
Let me know what you think!