### PR TITLE
Update LICENSE contact details

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -37,7 +37,7 @@ Example of uses that are not Commercial Uses, and are subject to the terms of th
 * Using the Software to analyze Licensee's software.
 * Any non-commercial use of the Software.
 
-To purchase a license to the Software for Commercial Use, or if Licensee is unsure whether it needs to purchase a Commercial Use license, contact Synopsys at \[sig-sales-ww@synopsys.com\].
+To purchase a license to the Software for Commercial Use, or if Licensee is unsure whether it needs to purchase a Commercial Use license, contact the maintainer at `justin at presidentbeef dot com`.
 Synopsys may grant commercial licenses at no monetary cost at its own discretion if the commercial usage is deemed by Synopsys to significantly benefit the development of the Software.
 
 ## 3. License Grant


### PR DESCRIPTION
Provide an up-to-date contact email address to enquire about commercial licenses as per
https://github.com/presidentbeef/brakeman/issues/1706.

I rececently ran `bundle license` in a rails application to determine whether we needed to license any of the gems we were using in a project that was transitioning from open- to closed-source. 

`bundle license` told me that Brakeman uses the `Brakeman Public Use License` and searching for this brought me to https://github.com/presidentbeef/brakeman/blob/main/LICENSE.md. 

It wasn't clear to me reading this whether I was allowed to use Brakeman. Some additional searching led me to two other issues: 
- https://github.com/presidentbeef/brakeman/issues/1706
- https://github.com/rails/rails/issues/51195

I've updated the contact email address as per the first issue. 

I think the existing text does make it clear that using Brakeman to scan for vulnerabilities in closed source code is permitted without purchasing a commercial license, and although I think that could be more explicit I haven't changed it in this PR. 