### PR TITLE
Fix SQL injection false positive on Faraday connection.delete

### DIFF
--- a/lib/brakeman/checks/check_sql.rb
+++ b/lib/brakeman/checks/check_sql.rb
@@ -723,14 +723,62 @@ class Brakeman::CheckSQL < Brakeman::BaseCheck
     target = call.target
 
     if call? target and target.method == :connection
-      target = target.target
-      klass = class_name(target)
+      inner = target.target
+      klass = class_name(inner)
 
-      target.nil? or
-      target == SELF_CLASS or
-      node_type? target, :self or
-      klass == :"ActiveRecord::Base" or
-      active_record_models.include? klass
+      # `connection` with no explicit receiver is ambiguous: inside an
+      # ActiveRecord model it is the AR connection, but it is also a very
+      # common name for a Faraday/HTTP client (see issue #1750). When the
+      # receiver is implicit, only treat the call as a SQL connection call if
+      # the argument does not clearly look like an HTTP URL/path. Calls with an
+      # explicit AR receiver (`self`, `ActiveRecord::Base`, a model) are left
+      # untouched so real SQL injection is still reported.
+      if inner.nil?
+        not http_url_argument?(call.first_arg)
+      else
+        inner == SELF_CLASS or
+        node_type? inner, :self or
+        klass == :"ActiveRecord::Base" or
+        active_record_models.include? klass
+      end
+    end
+  end
+
+  SQL_LEADING_KEYWORD = /\A\s*(?:SELECT|INSERT|UPDATE|DELETE|REPLACE|WITH|MERGE|UPSERT|CALL|EXEC|TRUNCATE|DESCRIBE|SHOW|ALTER|CREATE|DROP|GRANT|REVOKE|PRAGMA|BEGIN|COMMIT|ROLLBACK|SET|EXPLAIN)\b/i
+
+  # An HTTP-style URL or path argument, e.g. Faraday's
+  # `connection.delete("api/sessions/#{id}")`. Used to avoid flagging non-SQL
+  # connection calls. Deliberately conservative: anything that opens with a SQL
+  # keyword, or that is not slash-delimited path-like text, is NOT treated as a
+  # URL so genuine SQL strings keep being analyzed.
+  def http_url_argument? arg
+    leading = leading_static_string arg
+    return false if leading.nil? or leading.empty?
+
+    # Never mistake SQL for a URL.
+    return false if leading =~ SQL_LEADING_KEYWORD
+
+    # Absolute URLs or scheme-relative URLs.
+    return true if leading =~ %r{\A\s*https?://}i
+    return true if leading =~ %r{\A\s*//[^\s]}
+
+    # Relative path: one or more slash-separated segments made of URL-ish
+    # characters, no SQL whitespace structure. e.g. "api/sessions/", "/v1/users/".
+    leading =~ %r{\A/?[A-Za-z0-9_.~%:@!$&'()*+,;=-]+(?:/[A-Za-z0-9_.~%:@!$&'()*+,;=-]*)+\z}
+  end
+
+  # Returns the leading literal portion of a string/dstr argument, or nil if the
+  # argument does not begin with a static string.
+  def leading_static_string arg
+    return nil unless sexp? arg
+
+    case arg.node_type
+    when :str, :string
+      arg.value.is_a?(String) ? arg.value : nil
+    when :dstr
+      arg[1].is_a?(String) ? arg[1] : nil
+    else
+      nil
     end
   end
 

--- a/test/apps/rails6/app/models/stream_client.rb
+++ b/test/apps/rails6/app/models/stream_client.rb
@@ -1,0 +1,16 @@
+# Plain HTTP client (not ActiveRecord). `connection` here is a Faraday
+# connection, so `connection.delete(url)` is an HTTP request, not SQL.
+# Regression coverage for issue #1750 (SQL injection false positive).
+class StreamClient
+  def connection
+    @connection ||= Faraday.new(connection_options)
+  end
+
+  def unpublish_stream(session_id:, stream_id:)
+    connection.delete("api/sessions/#{session_id}/stream/#{stream_id}")
+  end
+
+  def fetch_session(session_id)
+    connection.get("/v1/sessions/#{session_id}")
+  end
+end

--- a/test/apps/rails6/app/models/user.rb
+++ b/test/apps/rails6/app/models/user.rb
@@ -21,6 +21,11 @@ class User < ApplicationRecord
     SQL
   end
 
+  def delete_old_records(period)
+    # Bare `connection.delete` with a SQL string must still warn (no FN).
+    connection.delete("DELETE FROM users WHERE updated_at < '#{period}'")
+  end
+
   def recent_stuff
     where("date > #{Date.today - 1}")
   end

--- a/test/tests/github_output.rb
+++ b/test/tests/github_output.rb
@@ -6,7 +6,7 @@ class TestGithubOutput < Minitest::Test
   end
 
   def test_report_format
-    assert_equal 43, @@report.lines.count, "Did you add or remove vulnerabilities in the Rails 6 app? Update this test please!"
+    assert_equal 44, @@report.lines.count, "Did you add or remove vulnerabilities in the Rails 6 app? Update this test please!"
     @@report.lines.each do |line|
       assert line.start_with?('::'), 'Every line must start with `::`'
       assert_equal 2, line.scan('::').count, 'Every line must have exactly 2 `::`'

--- a/test/tests/rails6.rb
+++ b/test/tests/rails6.rb
@@ -13,8 +13,31 @@ class Rails6Tests < Minitest::Test
       :controller => 0,
       :model => 0,
       :template => 4,
-      :generic => 37
+      :generic => 38
     }
+  end
+
+  # Issue #1750: a bare `connection.delete` whose argument is an HTTP URL/path
+  # (Faraday/HTTP client) must NOT be reported as SQL injection.
+  def test_no_sql_injection_faraday_connection_delete
+    assert_no_warning :type => :warning,
+      :warning_type => "SQL Injection",
+      :relative_path => "app/models/stream_client.rb"
+  end
+
+  # Issue #1750 guard: a bare `connection.delete` whose argument IS a SQL string
+  # with interpolation must still warn (no false negative from the FP fix).
+  def test_sql_injection_bare_connection_delete
+    assert_warning :type => :warning,
+      :warning_code => 0,
+      :fingerprint => "fa62370154c764324f5a80d8d7e26491bf2ae96b29d157d3ee5320774c48c143",
+      :warning_type => "SQL Injection",
+      :line => 26,
+      :message => /^Possible\ SQL\ injection/,
+      :confidence => 1,
+      :relative_path => "app/models/user.rb",
+      :code => s(:call, s(:call, nil, :connection), :delete, s(:dstr, "DELETE FROM users WHERE updated_at < '", s(:evstr, s(:lvar, :period)), s(:str, "'"))),
+      :user_input => s(:lvar, :period)
   end
 
   def test_sql_injection_delete_by


### PR DESCRIPTION
Fixes #1750.

## Problem

A bare `connection.delete("...")` with no explicit receiver is reported as SQL injection even when `connection` is a Faraday/HTTP client rather than an ActiveRecord connection:

```ruby
def connection
  @connection ||= Faraday.new(connection_options)
end

def unpublish_stream(session_id:, stream_id:)
  connection.delete("api/sessions/#{session_id}/stream/#{stream_id}")
end
```

`:delete` is in `@connection_calls` and `:connection` is in `@expected_targets`, so `find_call` picks this up. In `connect_call?` the implicit-receiver branch (`target.nil?`) returned true unconditionally, so Brakeman treated the Faraday HTTP path as a SQL string.

## Fix

The change is scoped to the ambiguous case only: a `connection` call with an implicit receiver. In that case the call is now treated as a SQL connection call only if the argument does not clearly look like an HTTP URL or path.

`http_url_argument?` is deliberately conservative:

- A leading static string that begins with a SQL keyword (`SELECT`, `INSERT`, `UPDATE`, `DELETE`, etc.) is never treated as a URL.
- It only returns true for `http(s)://` / scheme-relative URLs, or slash-delimited path-like text with no SQL whitespace structure (for example `api/sessions/`, `/v1/users/`).

Calls with an explicit ActiveRecord receiver (`self.connection`, `ActiveRecord::Base.connection`, `SomeModel.connection`) are left completely unchanged, so existing detection there is untouched.

This means real SQL injection is still reported, including the bare implicit-receiver form, for example `connection.delete("DELETE FROM users WHERE updated_at < '#{period}'")` continues to warn because the string starts with a SQL keyword.

## Tests

Added a Faraday client app (`test/apps/rails6/app/models/stream_client.rb`) and two assertions in `test/tests/rails6.rb`:

- `test_no_sql_injection_faraday_connection_delete` asserts no SQL warning for the HTTP path case (the false positive).
- `test_sql_injection_bare_connection_delete` asserts that a bare `connection.delete` with a SQL string still warns (guards against a false negative). A matching true-positive case was added to `test/apps/rails6/app/models/user.rb`.

I confirmed the false-positive test fails when the fix is reverted, so it exercises the change. The rails3, rails31, rails32, rails4, rails5, rails6, rails7, and rails8 app test suites all pass with no count changes other than the one intended new warning.

Note: I understand Brakeman requires copyright assignment for contributions; happy to complete that.
