### PR TITLE
Fix RenderInline false positive for partial local named text

### DIFF
--- a/lib/brakeman/processors/base_processor.rb
+++ b/lib/brakeman/processors/base_processor.rb
@@ -227,6 +227,11 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
     end
 
     #Look for render :action, ... or render "action", ...
+    #When the type is determined by a leading positional argument, a key in the
+    #options hash that happens to match a render type name (e.g. `text:`) is a
+    #local passed to the partial/action, not a render type directive.
+    type_from_positional = false
+
     if string? first_arg or symbol? first_arg
       if @current_template and @tracker.options[:rails3]
         type = :partial
@@ -235,15 +240,18 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
         type = :action
         value = first_arg
       end
+      type_from_positional = true
     elsif first_arg.is_a? Symbol or first_arg.is_a? String
       type = :action
       value = Sexp.new(:lit, first_arg.to_sym).line(call.line)
+      type_from_positional = true
     elsif first_arg.nil?
       type = :default
     elsif not hash? first_arg
       # Maybe do partial if in view?
       type = :action
       value = first_arg
+      type_from_positional = true
     end
 
     types_in_hash = Set[:action, :file, :inline, :js, :json, :nothing, :partial, :template, :text, :update, :xml]
@@ -259,10 +267,10 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
     #For example, render :file => "blah"
     if hash? last_arg
       hash_iterate(last_arg) do |key, val|
-        if symbol? key and types_in_hash.include? key.value
+        if symbol? key and types_in_hash.include? key.value and not type_from_positional
           type = key.value
           value = val
-        else  
+        else
           rest << key << val
         end
       end

--- a/lib/brakeman/processors/base_processor.rb
+++ b/lib/brakeman/processors/base_processor.rb
@@ -227,11 +227,6 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
     end
 
     #Look for render :action, ... or render "action", ...
-    #When the type is determined by a leading positional argument, a key in the
-    #options hash that happens to match a render type name (e.g. `text:`) is a
-    #local passed to the partial/action, not a render type directive.
-    type_from_positional = false
-
     if string? first_arg or symbol? first_arg
       if @current_template and @tracker.options[:rails3]
         type = :partial
@@ -240,18 +235,15 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
         type = :action
         value = first_arg
       end
-      type_from_positional = true
     elsif first_arg.is_a? Symbol or first_arg.is_a? String
       type = :action
       value = Sexp.new(:lit, first_arg.to_sym).line(call.line)
-      type_from_positional = true
     elsif first_arg.nil?
       type = :default
     elsif not hash? first_arg
       # Maybe do partial if in view?
       type = :action
       value = first_arg
-      type_from_positional = true
     end
 
     types_in_hash = Set[:action, :file, :inline, :js, :json, :nothing, :partial, :template, :text, :update, :xml]
@@ -266,12 +258,19 @@ class Brakeman::BaseProcessor < Brakeman::SexpProcessor
     #Look for "type" of render in options hash
     #For example, render :file => "blah"
     if hash? last_arg
-      hash_iterate(last_arg) do |key, val|
-        if symbol? key and types_in_hash.include? key.value and not type_from_positional
-          type = key.value
-          value = val
-        else
-          rest << key << val
+      if type
+        #The render type was already determined by a positional argument, so a
+        #key in the options hash that happens to match a render type name (e.g.
+        #`text:`) is a local passed to the partial/action, not a type directive.
+        rest = last_arg
+      else
+        hash_iterate(last_arg) do |key, val|
+          if symbol? key and types_in_hash.include? key.value
+            type = key.value
+            value = val
+          else
+            rest << key << val
+          end
         end
       end
     end

--- a/test/apps/rails5/app/views/widget/show.html.erb
+++ b/test/apps/rails5/app/views/widget/show.html.erb
@@ -2,3 +2,5 @@
 
 <%= link_to("Thing", "#{ENV['SOME_URL']}#{params[:x]}") %>
 <%= link_to("Email!", "mailto:#{params[:x]}") %>
+
+<%= render("shared/inventory_record", text: params[:comment]) %>

--- a/test/tests/rails5.rb
+++ b/test/tests/rails5.rb
@@ -416,6 +416,20 @@ class Rails5Tests < Minitest::Test
       :user_input => s(:call, s(:call, s(:call, nil, :request), :cookies), :[], s(:str, "value"))
   end
 
+  def test_render_inline_partial_local_named_text
+    # render("partial", text: ...) passes `text` as a local to the partial.
+    # It must not be treated as `render text:` (inline rendering).
+    assert_no_warning :type => :template,
+      :warning_code => 84,
+      :warning_type => "Cross-Site Scripting",
+      :line => 6,
+      :message => /^Unescaped\ parameter\ value\ rendered\ inline/,
+      :confidence => 0,
+      :relative_path => "app/views/widget/show.html.erb",
+      :code => s(:render, :text, s(:call, s(:params), :[], s(:lit, :comment)), s(:hash)),
+      :user_input => s(:call, s(:params), :[], s(:lit, :comment))
+  end
+
   def test_warning_in_helper_method
     assert_warning :type => :warning,
       :warning_code => 13,


### PR DESCRIPTION
Fixes #1915

## Problem

Rendering a partial with a local whose name happens to match a Rails render type (most commonly `text`) produces a false positive `RenderInline` / Cross-Site Scripting warning:

```erb
<%= render("shared/inventory_record", text: params[:comment]) %>
```

reports:

```
Confidence: High
Category: Cross-Site Scripting
Check: RenderInline
Message: Unescaped parameter value rendered inline
```

Renaming the local to anything that is not a render type name (for example `comment:`) makes the warning disappear, which confirms it is a parsing issue rather than a real finding.

## Root cause

`Brakeman::BaseProcessor#find_render_type` first sets the render type from the leading positional argument (a string/symbol partial or action name). It then iterates the options hash and, for any key whose name is in the render-type set (`:text`, `:inline`, `:action`, ...), overrides the type and value with that key.

When the type was already established by a positional partial name, a hash key like `text:` is just a local passed to the partial, not a `render text:` directive. The override reclassified the partial render as a `:text` render and pointed its value at the user input, so `RenderInline` flagged it.

## Fix

Track whether the render type was determined by a leading positional argument. Only treat a matching options-hash key as a render-type directive when the type was not already set positionally. In the partial case the key is now retained as a local, matching Rails behavior.

## Verification

Before (on `main`), against a minimal app:

```
RenderInline | Cross-Site Scripting | line 1 | Unescaped parameter value rendered inline
TOTAL: 1
```

After:

```
TOTAL: 0
```

True positives are unaffected. `render(text: params[:x])` and `render(inline: params[:y])` (no positional argument) still report inline XSS.

A regression test was added in `test/tests/rails5.rb` (`test_render_inline_partial_local_named_text`) with a fixture line in `test/apps/rails5/app/views/widget/show.html.erb`. The test uses `assert_no_warning` and fails on the unpatched parser, passes with the fix. The full suite count is unchanged aside from the one added test (pre-existing environmental failures on Ruby 4.0 are present on `main` as well).
