### PR TITLE
Better help and error message for --ensure-latest

### DIFF
--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -63,9 +63,9 @@ module Brakeman::Options
           options[:exit_on_error] = exit_on_error
         end
 
-        opts.on "--ensure-latest [DAYS]", Integer, "Fail when Brakeman is outdated. Optionally set minimum age in days." do |days|
+        opts.on "--ensure-latest [DAYS]", Integer, "Fail when Brakeman is outdated. Optionally set minimum age in days (1-15)." do |days|
           if days and not (1..15).include? days
-            raise OptionParser::InvalidArgument
+            raise OptionParser::InvalidArgument, "Minimum age must be 1-15 days."
           end
 
           options[:ensure_latest] = days || true

--- a/test/tests/options.rb
+++ b/test/tests/options.rb
@@ -91,9 +91,11 @@ class BrakemanOptionsTest < Minitest::Test
     options = setup_options_from_input("--ensure-latest", "10")
     assert_equal 10, options[:ensure_latest]
 
-    assert_raises OptionParser::InvalidArgument do
+    err = assert_raises OptionParser::InvalidArgument do
       setup_options_from_input("--ensure-latest", "16")
     end
+
+    assert_match /1-15 days/, err.message
 
     assert_raises OptionParser::InvalidArgument do
       setup_options_from_input("--ensure-latest", "0")


### PR DESCRIPTION
```
> brakeman --ensure-latest 16
invalid argument: --ensure-latest Minimum age must be 1-15 days.
Please see `brakeman --help` for valid options
```

```
--ensure-latest [DAYS]       Fail when Brakeman is outdated. Optionally set minimum age in days (1-15).
```

Fixes #2036